### PR TITLE
fix: add back gnome-software-ostree

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -21,8 +21,7 @@
         "exclude": {
             "all": [
                 "firefox",
-                "firefox-langpacks",
-                "gnome-software-rpm-ostree"
+                "firefox-langpacks"
             ]
         }
     },


### PR DESCRIPTION
Looks like we need this.