### PR TITLE
fix: Update Super-E shortcut isn't working

### DIFF
--- a/etc/dconf/db/local.d/01-ublue
+++ b/etc/dconf/db/local.d/01-ublue
@@ -52,6 +52,7 @@ download-updates-notify=false
 
 [org/gnome/settings-daemon/plugins/media-keys]
 custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/']
+home=['<Super>e']
 
 [com/raggesilver/BlackBox]
 command-as-login-shell=true


### PR DESCRIPTION
This pull request is in reference to #4.
I have tested and updated the shortcut defaults to make Super + E open the home folder after a clean rebase.