### PR TITLE
feat: enable "tap-to-click" for touchpad

### DIFF
--- a/etc/dconf/db/local.d/01-ublue
+++ b/etc/dconf/db/local.d/01-ublue
@@ -28,6 +28,9 @@ button-layout=":minimize,maximize,close"
 num-workspaces='4'
 title-bar-font="Ubuntu Bold 12"
 
+[org/gnome/desktop/peripherals/touchpad]
+tap-to-click=true
+
 [org/gnome/shell/extensions/dash-to-dock]
 dock-fixed=true
 force-straight-corner=false


### PR DESCRIPTION
For some reason Fedora/GNOME doesn't enable "tap-to-click" for touchpad.    
Ubuntu has it enabled by default.    
Check it with a command:   
`gsettings get org.gnome.desktop.peripherals.touchpad tap-to-click`