### PR TITLE
fix: Apply custom background to dark mode

### DIFF
--- a/etc/dconf/db/local.d/01-ublue
+++ b/etc/dconf/db/local.d/01-ublue
@@ -4,6 +4,7 @@ enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'dash-to-dock@mi
 
 [org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/lagoon.jpg'
+picture-uri-dark='file:///usr/share/backgrounds/lagoon.jpg'
 picture-options='stretched'
 primary-color='000000'
 secondary-color='FFFFFF'


### PR DESCRIPTION
When you switch your global theme to dark mode, the desktop background is reset to the default GNOME background.

Since we already have this nice, dark background already used for light mode, we might as well make it the default for dark mode too.