### PR TITLE
fix: Create gnome settings background entry

### DIFF
--- a/usr/share/gnome-background-properties/ublue-lagoon.xml
+++ b/usr/share/gnome-background-properties/ublue-lagoon.xml
@@ -3,7 +3,7 @@
 <wallpapers>
     <wallpaper>
         <name>uBlue Lagoon</name>
-        <filename>/usr/share/backgrounds/lagoon.png</filename>
+        <filename>/usr/share/backgrounds/lagoon.jpg</filename>
         <options>zoom</options>
         <shade_type>solid</shade_type>
         <pcolor>#000000</pcolor>

--- a/usr/share/gnome-background-properties/ublue-lagoon.xml
+++ b/usr/share/gnome-background-properties/ublue-lagoon.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE wallpapers SYSTEM "gnome-wp-list.dtd">
+<wallpapers>
+    <wallpaper>
+        <name>uBlue Lagoon</name>
+        <filename>/usr/share/backgrounds/lagoon.png</filename>
+        <options>zoom</options>
+        <shade_type>solid</shade_type>
+        <pcolor>#000000</pcolor>
+        <scolor>#ffffff</scolor>
+    </wallpaper>
+</wallpapers>


### PR DESCRIPTION
If a user changes their background off of the default Lagoon, there's no way to change it back to lagoon without one of these entries.

I've tested this on my personal image (2nd screenshot), so porting the changes over to this repo.

Before:
<img width="405" alt="image" src="https://user-images.githubusercontent.com/46304672/230952769-42aacb5c-f154-4533-838d-6863a0d23329.png">

After (hopefully):
<img width="405" alt="image" src="https://user-images.githubusercontent.com/46304672/230970043-b5a6364e-6b61-4c7d-a380-4d7ac5f76540.png">
