### PR TITLE
fix: inconsistent dir naming in PR #152

### DIFF
--- a/usr/bin/ublue-nix-install
+++ b/usr/bin/ublue-nix-install
@@ -95,14 +95,12 @@ echo "experimental-features = nix-command flakes" | sudo tee -a /etc/nix/nix.con
 
 sleep 1
 
-# nb stands for nix backup
-
 echo "Installing nix backup"
 
 sudo mkdir /opt/nixbackup
-sudo cp -R /nix /opt/nb
+sudo cp -R /nix /opt/nixbackup
 
-sudo tee /opt/nb/reset-nix <<EOF
+sudo tee /opt/nixbackup/reset-nix <<EOF
 #!/bin/bash
 sudo echo "Resetting nix..."
 sudo rm -rf /nix/*


### PR DESCRIPTION
You discussed to change the initially proposed dir name from /opt/nb to /opt/nixbackup ... code got committed using both, in an inconsistent manner.