### PR TITLE
fix: remove podman-compose from image

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10,7 +10,6 @@
                 "libgda",
                 "libgda-sqlite",
                 "libratbag-ratbagd",
-                "podman-compose",
                 "python3-pip",
                 "tailscale",
                 "wireguard-tools",


### PR DESCRIPTION
It's included in main already, no need to have it here.