### PR TITLE
fix: copy toolbox-packages file during build

### DIFF
--- a/Containerfile.toolbox
+++ b/Containerfile.toolbox
@@ -6,11 +6,13 @@ LABEL com.github.containers.toolbox="true" \
       summary="A cloud-native terminal experience" \
       maintainer="jorge.castro@gmail.com"
 
+COPY toolbox-packages /toolbox-packages
+
 RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
     apt-get update && \
     yes | /usr/local/sbin/unminimize && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        $(cat extra-packages | xargs) && \
+        $(cat toolbox-packages) && \
     rm -rd /var/lib/apt/lists/*
 
 RUN rm /toolbox-packages

--- a/Containerfile.toolbox
+++ b/Containerfile.toolbox
@@ -12,7 +12,7 @@ RUN sed -Ei '/apt-get (update|upgrade)/s/^/#/' /usr/local/sbin/unminimize && \
     apt-get update && \
     yes | /usr/local/sbin/unminimize && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install \
-        $(cat toolbox-packages) && \
+        $(cat /toolbox-packages) && \
     rm -rd /var/lib/apt/lists/*
 
 RUN rm /toolbox-packages


### PR DESCRIPTION
Fixes comment https://github.com/ublue-os/bluefin/pull/198#pullrequestreview-1407080950

The Containerfile is trying to install packages from a non-existent `extra-packages` file, so this PR changes to `toolbox-packages`