### PR TITLE
fix: update toolbox-packages

### DIFF
--- a/toolbox-packages
+++ b/toolbox-packages
@@ -3,7 +3,6 @@ dbus-x11
 direnv
 ffmpeg
 fzf
-just
 make
 ncdu
 neofetch
@@ -14,4 +13,3 @@ python-is-python3
 python3
 ripgrep
 speedtest-cli
-vimdiff


### PR DESCRIPTION
just and vimdiff aren't in ubuntu