### PR TITLE
chore(ci): use different naming convention

### DIFF
--- a/.github/workflows/build-toolbox.yml
+++ b/.github/workflows/build-toolbox.yml
@@ -9,8 +9,8 @@ on:
   merge_group:    
   workflow_dispatch:
 env:
-    IMAGE_NAME: ubuntu
-    IMAGE_TAGS: toolbox
+    IMAGE_NAME: ubuntu-toolnox
+    IMAGE_TAGS: latest
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:


### PR DESCRIPTION
This would end up being ublue-os/ubuntu-toolbox, which reads nicer