### PR TITLE
Switch windows (not applications) with Alt+Tab

### DIFF
--- a/etc/dconf/db/local.d/01-ublue
+++ b/etc/dconf/db/local.d/01-ublue
@@ -29,6 +29,12 @@ button-layout=":minimize,maximize,close"
 num-workspaces='4'
 title-bar-font="Ubuntu Bold 12"
 
+[org/gnome/desktop/wm/keybindings]
+switch-applications = ['<Super>Tab']
+switch-applications-backward = ['<Shift><Super>Tab']
+switch-windows = ['<Alt>Tab']
+switch-windows-backward = ['<Shift><Alt>Tab']
+
 [org/gnome/desktop/peripherals/touchpad]
 tap-to-click=true
 


### PR DESCRIPTION
GNOME has separate shortcuts for switching windows and applications.
Application switcher by default shows grouped windows from all workspaces.
Windows switcher doesn't group windows and by default shows only windows with small previews only from the current workspace.
Originally GNOME doesn't bind shortcuts to "switch-windows" so "switch-applications" are used for both Super+Tab and Alt+Tab
When user binds Alt+Tab to "switch-windows" , "switch-applications" gets unbind for some reason.
So Ubuntu settings bind both.