### PR TITLE
feat(toolbox): add distrobox.ini for ubuntu image

### DIFF
--- a/etc/distrobox/distrobox.ini
+++ b/etc/distrobox/distrobox.ini
@@ -1,0 +1,7 @@
+[ubuntu]
+image=ghcr.io/ublue-os/ubuntu-toolbox:latest
+init=false
+nvidia=false
+pull=true
+root=false
+replace=true


### PR DESCRIPTION
New feature in distrobox, this will let us declare toolboxes. This feature is unreleased so we're just prepping for it.