### PR TITLE
feat: replace GNOME Games with Lutris

### DIFF
--- a/etc/yafti.yml
+++ b/etc/yafti.yml
@@ -71,8 +71,8 @@ screens:
           packages:
           - Bottles: com.usebottles.bottles
           - Discord: com.discordapp.Discord
-          - Games: org.gnome.Games
           - Heroic Games Launcher: com.heroicgameslauncher.hgl
+          - Lutris: net.lutris.Lutris
           - MangoHUD: org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
           - Steam: com.valvesoftware.Steam
           - Gamescope for Steam: com.valvesoftware.Steam.Utility.gamescope


### PR DESCRIPTION
GNOME Games is EOL and unmaintained, and Lutris should cover most of the same use cases and more.