### PR TITLE
feat: use Ubuntu Nerd Font for DX images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,6 +30,7 @@ RUN /tmp/build.sh && \
     systemctl enable rpm-ostree-countme.service && \
     systemctl enable tailscaled.service && \
     fc-cache -f /usr/share/fonts/ubuntu && \
+    fc-cache -f /usr/share/fonts/inter && \
     rm -f /etc/yum.repos.d/tailscale.repo && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/user.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/system.conf && \
@@ -66,7 +67,7 @@ RUN wget https://terra.fyralabs.com/terra.repo -O /etc/yum.repos.d/terra.repo
 RUN rpm-ostree install code
 RUN rpm-ostree install lxd lxc
 RUN rpm-ostree install iotop dbus-x11 podman-compose podman-docker podman-plugins podman-tui
-RUN rpm-ostree install adobe-source-code-pro-fonts cascadiacode-nerd-fonts google-droid-sans-mono-fonts google-go-mono-fonts ibm-plex-mono-fonts jetbrains-mono-fonts-all mozilla-fira-mono-fonts powerline-fonts ubuntumono-nerd-fonts
+RUN rpm-ostree install adobe-source-code-pro-fonts cascadiacode-nerd-fonts google-droid-sans-mono-fonts google-go-mono-fonts ibm-plex-mono-fonts jetbrains-mono-fonts-all mozilla-fira-mono-fonts powerline-fonts ubuntumono-nerd-fonts ubuntu-nerd-fonts
 RUN rpm-ostree install qemu qemu-user-static qemu-user-binfmt virt-manager libvirt qemu qemu-user-static qemu-user-binfmt edk2-ovmf
 RUN rpm-ostree install cockpit cockpit-system cockpit-networkmanager cockpit-selinux cockpit-storaged cockpit-podman cockpit-machines cockpit-pcp
 RUN rpm-ostree install cargo nodejs-npm p7zip p7zip-plugins powertop rust

--- a/dx/etc/dconf/db/local.d/01-ublue-dx
+++ b/dx/etc/dconf/db/local.d/01-ublue-dx
@@ -1,0 +1,4 @@
+[org/gnome/desktop/interface]
+font-name="Ubuntu Nerd Font 12"
+document-font-name="Ubuntu Nerd Font 12"
+monospace-font-name="UbuntuMono Nerd Font 18"


### PR DESCRIPTION
Today, UbuntuMono Nerd Font is installed but not the standard Ubuntu font. This adds the Nerd Font version to the DX image and sets it as the default for the desktop