### PR TITLE
feat(dx): open fedora userspace on shortcut

### DIFF
--- a/dx/etc/dconf/db/local.d/01-ublue-dx
+++ b/dx/etc/dconf/db/local.d/01-ublue-dx
@@ -2,3 +2,8 @@
 font-name="Ubuntu Nerd Font 12"
 document-font-name="Ubuntu Nerd Font 12"
 monospace-font-name="UbuntuMono Nerd Font 18"
+
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2]
+binding='<Control><Alt>f'
+command='flatpak run com.raggesilver.BlackBox --command "distrobox enter fedora"'
+name='blackbox fedora'

--- a/dx/etc/distrobox/distrobox.ini
+++ b/dx/etc/distrobox/distrobox.ini
@@ -5,3 +5,11 @@ nvidia=false
 pull=true
 root=false
 replace=true
+
+[fedora]
+image=fedora:latest
+init=false
+nvidia=false
+pull=true
+root=false
+replace=true

--- a/dx/etc/distrobox/distrobox.ini
+++ b/dx/etc/distrobox/distrobox.ini
@@ -7,7 +7,7 @@ root=false
 replace=true
 
 [fedora]
-image=registry.fedoraproject.org/fedora-toolbox:38
+image=registry.fedoraproject.org/fedora-toolbox:latest
 init=false
 nvidia=false
 pull=true

--- a/dx/etc/distrobox/distrobox.ini
+++ b/dx/etc/distrobox/distrobox.ini
@@ -7,7 +7,7 @@ root=false
 replace=true
 
 [fedora]
-image=fedora:latest
+image=registry.fedoraproject.org/fedora-toolbox:38
 init=false
 nvidia=false
 pull=true

--- a/etc/dconf/db/local.d/01-ublue
+++ b/etc/dconf/db/local.d/01-ublue
@@ -66,6 +66,8 @@ sort-directories-first=true
 
 [com/raggesilver/BlackBox]
 command-as-login-shell=true
+use-custom-command=true
+custom-shell-command='distrobox enter ubuntu'
 theme-dark="Yaru"
 style-preference=2
 font="Ubuntu Mono 16"

--- a/etc/dconf/db/local.d/01-ublue
+++ b/etc/dconf/db/local.d/01-ublue
@@ -57,11 +57,6 @@ binding='<Control><Alt>t'
 command='gnome-terminal'
 name='gnome-terminal'
 
-[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1]
-binding='<Control><Alt>u'
-command='flatpak run com.raggesilver.BlackBox'
-name='blackbox'
-
 [org/gnome/settings-daemon/plugins/media-keys]
 custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/']
 home=['<Super>e']
@@ -71,10 +66,13 @@ sort-directories-first=true
 
 [com/raggesilver/BlackBox]
 command-as-login-shell=true
-use-custom-command=true
-custom-shell-command='distrobox enter ubuntu'
 theme-dark="Yaru"
 style-preference=2
 font="Ubuntu Mono 16"
 window-width=975
 window-height=650
+
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1]
+binding='<Control><Alt>u'
+command='flatpak run com.raggesilver.BlackBox --command "distrobox enter ubuntu"'
+name='blackbox ubuntu'

--- a/etc/dconf/db/local.d/01-ublue
+++ b/etc/dconf/db/local.d/01-ublue
@@ -57,6 +57,11 @@ binding='<Control><Alt>t'
 command='gnome-terminal'
 name='gnome-terminal'
 
+[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1]
+binding='<Control><Alt>u'
+command='flatpak run com.raggesilver.BlackBox --command "distrobox enter ubuntu"'
+name='blackbox ubuntu'
+
 [org/gnome/settings-daemon/plugins/media-keys]
 custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/']
 home=['<Super>e']
@@ -73,8 +78,3 @@ style-preference=2
 font="Ubuntu Mono 16"
 window-width=975
 window-height=650
-
-[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1]
-binding='<Control><Alt>u'
-command='flatpak run com.raggesilver.BlackBox --command "distrobox enter ubuntu"'
-name='blackbox ubuntu'

--- a/etc/distrobox/distrobox.ini
+++ b/etc/distrobox/distrobox.ini
@@ -5,3 +5,11 @@ nvidia=false
 pull=true
 root=false
 replace=true
+
+[fedora]
+image=fedora:latest
+init=false
+nvidia=false
+pull=true
+root=false
+replace=true


### PR DESCRIPTION
Closes #265 

### NOTE: THIS IS UNTESTED!
The only thing it could break is the existing Ubuntu distrobox shortcut, but the `flatpak run` command works locally, so I don't see how it could fail.

This PR creates a new custom keybinding to open up a Fedora distrobox with BlackBox using <kbd>CTRL</kbd> + <kbd>ALT</kbd> + <kbd>F</kbd>.  
It also refactors the existing Ubuntu keybinding to call distrobox directly, rather than opening the BlackBox app and hoping the initial command remains the same.