### PR TITLE
fix(dx): register fedora distrobox shortcut

### DIFF
--- a/dx/etc/dconf/db/local.d/01-ublue-dx
+++ b/dx/etc/dconf/db/local.d/01-ublue-dx
@@ -7,3 +7,7 @@ monospace-font-name="UbuntuMono Nerd Font 18"
 binding='<Control><Alt>f'
 command='flatpak run com.raggesilver.BlackBox --command "distrobox enter fedora"'
 name='blackbox fedora'
+
+[org/gnome/settings-daemon/plugins/media-keys]
+custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/']
+home=['<Super>e']


### PR DESCRIPTION
I forgot to actually register the Fedora Distrobox keyboard shortcut in dconf after adding it, so the shortcut did nothing.

This PR registers the keybinding.

Since the Fedora shortcut is only in the dx image, I copied the entire `org/gnome/settings-daemon/plugins/media-keys` over to the dx file.