### PR TITLE
Enable "tap-to-click" for GDM

### DIFF
--- a/etc/dconf/db/gdm.d/01-ublue
+++ b/etc/dconf/db/gdm.d/01-ublue
@@ -1,0 +1,2 @@
+[org/gnome/desktop/peripherals/touchpad]
+tap-to-click=true

--- a/etc/dconf/profile/gdm
+++ b/etc/dconf/profile/gdm
@@ -1,0 +1,3 @@
+user-db:user
+system-db:gdm
+file-db:/usr/share/gdm/greeter-dconf-defaults


### PR DESCRIPTION
This complements commit 8c0d9ae
Based on:
- https://help.gnome.org/admin/system-admin-guide/3.38/login.html.en#appearance
- GDM Settings