### PR TITLE
fix: revert "feat(wolfi): add uutils"

### DIFF
--- a/toolboxes/packages.wolfi
+++ b/toolboxes/packages.wolfi
@@ -4,6 +4,4 @@ curl
 git
 posix-libc-utils
 su-exec
-sudo-rs
-uutils
 vim


### PR DESCRIPTION
Reverts ublue-os/bluefin#316

This conflicts with `procps`, which doesn't get installed until you create a distrobox, causing a fatal error.