### PR TITLE
feat(ubuntu): add libvte and bc since distrobox needs it

### DIFF
--- a/toolboxes/packages.ubuntu
+++ b/toolboxes/packages.ubuntu
@@ -1,3 +1,4 @@
+bc
 btop
 dbus-x11
 direnv
@@ -5,11 +6,11 @@ ffmpeg
 fzf
 libegl1-mesa
 libgl1-mesa-glx
+libvte-common
 make
 ncdu
 neofetch
 neovim
-npm
 plocate
 progress
 python-is-python3


### PR DESCRIPTION
This should help with launch time. And drop npm for size.