### PR TITLE
feat: import vscode profile for container development

### DIFF
--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -18,6 +18,8 @@ cockpit:
   sudo podman container runlabel INSTALL quay.io/cockpit/ws
   sudo systemctl enable cockpit.service
 
+code-profile:
+  xdg-open https://vscode.dev/profile/github/c761b7738e9a7b02286d6d94cb2d1ecd
 
 distrobox-universal:
   echo 'Creating Universal Development distrobox ...'


### PR DESCRIPTION
Adds a just command `code-profile` that imports the bluefin-dx vs-code profile that enables dev container development.