### PR TITLE
chore: add artifact hub information

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,8 @@
+repositoryID: d93848a7-1ba3-446f-a556-8cba07a42167
+owners: # (optional, used to claim repository ownership)
+  - name: Jorge Castro
+    email: jorge.castro@gmail.com
+#ignore: # (optional, packages that should not be indexed by Artifact Hub)
+#  - name: package1
+#  - name: package2 # Exact match
+    


### PR DESCRIPTION
So that we can show up as a verified publisher.