### PR TITLE
fix: remove gnome-software-rpm-ostree

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -34,18 +34,9 @@
             "all": [
                 "firefox",
                 "firefox-langpacks",
+	        "gnome-software-rpm-ostree", 
                 "gnome-tour"
             ]
-        }
-    },
-    "37": {
-        "include": {
-            "all": [
-	        "podman-docker"
-	    ]
-        },
-        "exclude": {
-            "all": []
         }
     },
     "38": {


### PR DESCRIPTION
We can finally remove this again, gnome-software renders the store stuff just fine now without this. Goodbye!