### PR TITLE
fix: Restore VRR functionality after update

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,7 +18,7 @@ COPY --from=docker.io/bketelsen/vanilla-os:v0.0.12 /usr/share/gnome-background-p
 COPY --from=cgr.dev/chainguard/cosign:latest /usr/bin/cosign /usr/bin/cosign
 
 RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/kylegospo-gnome-vrr-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo
-RUN rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr mutter gnome-control-center gnome-control-center-filesystem
+RUN rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr mutter gnome-control-center gnome-control-center-filesystem xorg-x11-server-Xwayland
 
 ADD packages.json /tmp/packages.json
 ADD build.sh /tmp/build.sh


### PR DESCRIPTION
Turns out this change was still needed, previous testing tainted by bad methodology. Apologies for the issues.