### PR TITLE
fix: Show as Bluefin in grub menu

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -37,6 +37,7 @@ RUN /tmp/build.sh && \
     rm -f /usr/share/applications/nvtop.desktop && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/user.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/system.conf && \
+    sed -i '/^PRETTY_NAME/s/Silverblue/Bluefin/' /usr/lib/os-release && \
     rm -rf /tmp/* /var/* && \
     ostree container commit && \
     mkdir -p /var/tmp && \


### PR DESCRIPTION
This PR will replace the Silverblue text with Bluefin in the os-release file. This is only replaced on the PRETTY_NAME line. 

Which results in a grub menu showing like the image below:
![image](https://github.com/ublue-os/bluefin/assets/38557801/6abd623d-0e57-4e8d-b00c-11b5021f68a1)

As a side result the about page in gnome-settings will also show this name.
![image](https://github.com/ublue-os/bluefin/assets/38557801/112ce21e-f48a-4567-9cdd-766839cd899e)


If this is allowed, and merged an then maybe picked up by ublue-main image to do the same. We need to change this to match their name of choice. That is something to remind.