### PR TITLE
fix: add ddccontrol-db for monitor database

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -4,6 +4,7 @@
             "all": [
 	        "cockpit-bridge",
 		"ddccontrol", 
+		"ddccontrol-db", 
 		"ddccontrol-gtk",
 		"fish",
                 "gnome-shell-extension-appindicator",


### PR DESCRIPTION
add the monitor database so we aren't stuck with 10 year old monitor configs