### PR TITLE
fix: cleanup gnome-vrr repo

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,6 +19,7 @@ COPY --from=cgr.dev/chainguard/cosign:latest /usr/bin/cosign /usr/bin/cosign
 
 RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/kylegospo-gnome-vrr-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo
 RUN rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr mutter gnome-control-center gnome-control-center-filesystem xorg-x11-server-Xwayland
+RUN rm -f /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo
 
 ADD packages.json /tmp/packages.json
 ADD build.sh /tmp/build.sh


### PR DESCRIPTION
In #31 the cleanup was removed, probably because the repo was commented out. It is now used again, so let's clean it up after everything is installed. To be sure it didn't got lost again in the future I've placed it right below, so it is grouped.