### PR TITLE
feat(just/custom): add aquaproj install target

### DIFF
--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -6,6 +6,18 @@ assemble:
   echo 'Assembling and replacing distroboxes ...'
   distrobox assemble create --replace --file /etc/distrobox/distrobox.ini
 
+# Install aqua | https://aquaproj.github.io
+aqua:
+  @printf '\n=>Installing aqua ...\n\n'
+  pushd "$(mktemp -d)"
+  curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v2.1.1/aqua-installer
+  echo "c2af02bdd15da6794f9c98db40332c804224930212f553a805425441f8331665  aqua-installer" | sha256sum -c
+  chmod +x aqua-installer
+  ./aqua-installer
+  @printf '\n=> Make sure the ${AQUA_ROOT_DIR}/bin environment variable is added to your PATH (.bashrc/.zshrc):\n'
+  @printf '\n    export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"\n'
+  @printf '\n=> see https://aquaproj.github.io/docs/tutorial for more info\n'
+
 brew:
   echo "Installing homebrew ..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -24,7 +36,7 @@ code-profile:
 
 distrobox-wolfi:
   echo 'Creating WolfiOS distrobox ...'
-  distrobox create --image ghcr.io/ublue-os/wolfi-toolbox:latest -n wolfi 
+  distrobox create --image ghcr.io/ublue-os/wolfi-toolbox:latest -n wolfi
 
 distrobox-universal:
   echo 'Creating Universal Development distrobox ...'
@@ -61,7 +73,7 @@ nix-devbox-global:
 tea:
   echo 'Installing the tea package manager'
   sh <(curl https://tea.xyz)
-  
+
 touch:
   pip install --upgrade gnome-extensions-cli
   gext install improvedosk@nick-shmyrev.dev
@@ -70,7 +82,7 @@ touch:
 update-distrobox-git:
   echo 'Installing latest git snapshot of Distrobox'
   curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --next --prefix ~/.local
-    
+
 yafti:
   yafti /etc/yafti.yml
 


### PR DESCRIPTION
Adds target to `usr/share/ublue-os/just/custom.just` to install [aqua](https://aquaproj.github.io)

Results from testing:

```
$ just

=> Installing aqua ...

pushd "$(mktemp -d)"
/tmp/tmp.14Op44xUmE ~
curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/v2.1.1/aqua-installer
echo "c2af02bdd15da6794f9c98db40332c804224930212f553a805425441f8331665  aqua-installer" | sha256sum -c
aqua-installer: OK
chmod +x aqua-installer
./aqua-installer
===> Installing aqua v2.2.3 for bootstraping...
===> Downloading https://github.com/aquaproj/aqua/releases/download/v2.2.3/aqua_linux_amd64.tar.gz ...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100 6371k  100 6371k    0     0  34.8M      0 --:--:-- --:--:-- --:--:-- 34.8M
===> Verifying checksum of aqua v2.2.3 ...
aqua_linux_amd64.tar.gz: OK
===> /tmp/tmp.sclzwPDRjv/aqua update-aqua
aqua version 2.10.1 (fbf3b157b21897fa2f315fbc30474acafded108d)

=> Make sure the ${AQUA_ROOT_DIR}/bin environment variable is added to your PATH (.bashrc/.zshrc):

    export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"

=> see https://aquaproj.github.io/docs/tutorial for more info
```