### PR TITLE
fix: just brew-shell will create .zprofile and .bash_profile if needed

### DIFF
--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -28,6 +28,8 @@ brew-shell:
   #!/usr/bin/env bash
   set -euxo pipefail
   echo "Adding homebrew to shell configuration"
+  touch $HOME/.zprofile
+  touch $HOME/.bash_profile
   if grep -q "linuxbrew" $HOME/.zprofile
   then
     echo "Brew configuration already present in .zprofile"


### PR DESCRIPTION
should resolve errors if zsh isn't installed when running `just brew-shell`