### PR TITLE
fix: flag order for just shells

### DIFF
--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -75,7 +75,7 @@ framework-13:
   rpm-ostree kargs --append="module_blacklist=hid_sensor_hub" --append="nvme.noacpi=1" --append="tpm_tis.interrupts=0"
 
 fish:
-  sudo lchsh $USER /usr/bin/fish
+  sudo lchsh -s /usr/bin/fish $USER
 
 gnome-extensions:
   pip install --upgrade gnome-extensions-cli
@@ -127,4 +127,4 @@ yafti:
   yafti /etc/yafti.yml
 
 zsh:
-  sudo lchsh $USER /usr/bin/zsh
+  sudo lchsh -s /usr/bin/zsh $USER


### PR DESCRIPTION
just zsh and just fish had params out of order