### PR TITLE
fix: podmansh improvements

### DIFF
--- a/toolboxes/Containerfile.ubuntu
+++ b/toolboxes/Containerfile.ubuntu
@@ -20,3 +20,5 @@ RUN   ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/docker && \
       ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/flatpak && \ 
       ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/podman && \
       ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/rpm-ostree
+
+RUN echo "ALL            ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers

--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -170,6 +170,30 @@ podmansh-switch IMAGE:
   echo "Image now switched to {{IMAGE}}"
 
 # Install better touch-friendly GNOME extensions
+podmansh:
+  sudo mkdir -p /etc/containers/systemd/users/${UID}
+  sudo cp /usr/share/ublue-os/quadlets/podmansh.container /etc/containers/systemd/users/${UID}/podmansh.container
+  sudo lchsh $USER /usr/bin/podmansh
+  podman pull ghcr.io/ublue-os/ubuntu-toolbox:latest
+  
+  systemctl --user daemon-reload
+  systemctl --user start podmansh.service
+  echo "Shell now switched to podmansh. Spawn a new terminal to get going!"
+  echo "By default, the shell will be Bash. To override it, create ~/.profile with your preferred shell"
+  echo "Note: That shell must exist in the toolbox!"
+
+podmansh-switch IMAGE:
+  sudo sed -i "/Image\=.*$/c Image\={{IMAGE}}" /etc/containers/systemd/users/${UID}/podmansh.container
+  podman pull {{IMAGE}}
+  podman rm -f podmansh
+  systemctl --user daemon-reload
+  systemctl --user start podmansh.service
+  echo "Image now switched to {{IMAGE}}"
+
+tea:
+  echo 'Installing the tea package manager'
+  sh <(curl https://tea.xyz)
+  
 touch:
   pip install --upgrade gnome-extensions-cli
   gext install improvedosk@nick-shmyrev.dev

--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -189,6 +189,7 @@ podmansh-switch IMAGE:
   systemctl --user daemon-reload
   systemctl --user start podmansh.service
   echo "Image now switched to {{IMAGE}}"
+
 touch:
   pip install --upgrade gnome-extensions-cli
   gext install improvedosk@nick-shmyrev.dev

--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -189,11 +189,6 @@ podmansh-switch IMAGE:
   systemctl --user daemon-reload
   systemctl --user start podmansh.service
   echo "Image now switched to {{IMAGE}}"
-
-tea:
-  echo 'Installing the tea package manager'
-  sh <(curl https://tea.xyz)
-  
 touch:
   pip install --upgrade gnome-extensions-cli
   gext install improvedosk@nick-shmyrev.dev

--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -155,33 +155,13 @@ podmansh:
   podman pull ghcr.io/ublue-os/ubuntu-toolbox:latest
   
   systemctl --user daemon-reload
+  systemctl --user stop podmansh.service
   systemctl --user start podmansh.service
   echo "Shell now switched to podmansh. Spawn a new terminal to get going!"
   echo "By default, the shell will be Bash. To override it, create ~/.profile with your preferred shell"
   echo "Note: That shell must exist in the toolbox!"
 
 # Switch podmansh to another image (EXPERIMENTAL)
-podmansh-switch IMAGE:
-  sudo sed -i "/Image\=.*$/c Image\={{IMAGE}}" /etc/containers/systemd/users/${UID}/podmansh.container
-  podman pull {{IMAGE}}
-  podman rm -f podmansh
-  systemctl --user daemon-reload
-  systemctl --user start podmansh.service
-  echo "Image now switched to {{IMAGE}}"
-
-# Install better touch-friendly GNOME extensions
-podmansh:
-  sudo mkdir -p /etc/containers/systemd/users/${UID}
-  sudo cp /usr/share/ublue-os/quadlets/podmansh.container /etc/containers/systemd/users/${UID}/podmansh.container
-  sudo lchsh $USER /usr/bin/podmansh
-  podman pull ghcr.io/ublue-os/ubuntu-toolbox:latest
-  
-  systemctl --user daemon-reload
-  systemctl --user start podmansh.service
-  echo "Shell now switched to podmansh. Spawn a new terminal to get going!"
-  echo "By default, the shell will be Bash. To override it, create ~/.profile with your preferred shell"
-  echo "Note: That shell must exist in the toolbox!"
-
 podmansh-switch IMAGE:
   sudo sed -i "/Image\=.*$/c Image\={{IMAGE}}" /etc/containers/systemd/users/${UID}/podmansh.container
   podman pull {{IMAGE}}

--- a/usr/share/ublue-os/quadlets/podmansh.container
+++ b/usr/share/ublue-os/quadlets/podmansh.container
@@ -18,9 +18,15 @@ Volume=/:/run/host:rslave
 Volume=/dev:/dev:rslave
 Volume=/sys:/sys:rslave
 Volume=/tmp:/tmp:rslave
+Volume=/etc/passwd:/etc/passwd:rslave
+Volume=/etc/passwd-:/etc/passwd-:rslave
+Volume=/etc/group:/etc/group:rslave
+Volume=/etc/group-:/etc/group-:rslave
+Volume=/tmp:/tmp:rslave
 Volume=/sys/fs/selinux
+Volume=/etc/selinux:/etc/selinux:rslave
 Volume=/var/log/journal
-Volume=/run/user/1000:/run/user/1000:rslave
+Volume=/run/user/%U:/run/user/%U:rslave
 Volume=/etc/hosts:/etc/hosts:ro
 Volume=/etc/resolv.conf:/etc/resolv.conf:ro
 
@@ -29,7 +35,7 @@ Environment=ENV=%h/.profile
 PodmanArgs=--env-host
 PodmanArgs=--privileged
 PodmanArgs=--mount=type=devpts,destination=/dev/pts
-PodmanArgs=--userns=keep-id
+PodmanArgs=--userns=host
 PodmanArgs=--ulimit=host
 PodmanArgs=--security-opt=label=disable
 PodmanArgs=--cgroupns=private


### PR DESCRIPTION
- passes in passwd/group
- passes in selinux
- adds passwordless sudo to the toolbox
- adds a "stop" command when running `just podmansh` in case it was already running (should only run into this while debugging or messing around, not really common)