### PR TITLE
fix(just): devbox global shell hooks

### DIFF
--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -143,8 +143,8 @@ nix-devbox:
 nix-devbox-global:
   echo 'Installing devbox global profile.'
   devbox global pull https://devbox.getfleek.dev/high
-  echo 'run "devbox global run install-bash-hook" to configure bash shell'
-  echo 'run "devbox global run install-zsh-hook" to configure zsh shell'
+  echo 'run "devbox global run install-hook-bash" to configure bash shell'
+  echo 'run "devbox global run install-hook-zsh" to configure zsh shell'
   echo 'run "devbox global run" to see other available configuration commands'
 
 # Enable podmansh as user shell (EXPERIMENTAL)


### PR DESCRIPTION
When running `just nix-devbox-global` it echoes the commands to run to configure your `bash` or `zsh` shell but the devbox scripts are misnamed: `bash/zsh` < - > `hook`

```
$ devbox global run install-bash-hook
/var/home/robin/.local/share/devbox/global/default/.devbox/gen/scripts/.cmd.sh: line 3: install-bash-hook: command not found

$ devbox global run install-zsh-hook
/var/home/robin/.local/share/devbox/global/default/.devbox/gen/scripts/.cmd.sh: line 3: install-zsh-hook: command not found

```