### PR TITLE
fix: fedora userspace shortcut

### DIFF
--- a/etc/dconf/db/local.d/01-ublue
+++ b/etc/dconf/db/local.d/01-ublue
@@ -59,7 +59,7 @@ name='gnome-terminal'
 
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1]
 binding='<Control><Alt>u'
-command='flatpak run com.raggesilver.BlackBox'
+command='flatpak run com.raggesilver.BlackBox --command "distrobox enter ubuntu"'
 name='blackbox ubuntu'
 
 [org/gnome/settings-daemon/plugins/media-keys]
@@ -77,7 +77,7 @@ experimental-features=['scale-monitor-framebuffer']
 
 [com/raggesilver/BlackBox]
 command-as-login-shell=true
-use-custom-command=true
+use-custom-command=false
 custom-shell-command='distrobox enter ubuntu'
 theme-dark="Yaru"
 style-preference=2


### PR DESCRIPTION
This disables the `use-custom-command` setting from Blackbox. Setting it to true would block the use of any other custom command. So it would not been able to launch `flatpak run com.raggesilver.BlackBox --command "distrobox enter fedora"` for example.  Which is used for the fedora userspace shortcut.

This also means it added back the `--command "distrobox enter ubuntu"` to the ubuntu userspace shortcut, as it would otherwise launched a host system Blackbox.