### PR TITLE
fix: Replace new mutter-common package

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@ COPY usr /usr
 COPY --from=cgr.dev/chainguard/cosign:latest /usr/bin/cosign /usr/bin/cosign
 
 RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/kylegospo-gnome-vrr-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo
-RUN rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr mutter gnome-control-center gnome-control-center-filesystem xorg-x11-server-Xwayland
+RUN rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr mutter mutter-common gnome-control-center gnome-control-center-filesystem xorg-x11-server-Xwayland
 RUN rm -f /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo
 
 ADD packages.json /tmp/packages.json


### PR DESCRIPTION
Upstream split mutter into `mutter` and `mutter-common` -- modify install line for GNOME VRR to also replace `mutter-common`.