### PR TITLE
fix(dx): use distrobox-enter wrapper for non default images

### DIFF
--- a/dx/etc/dconf/db/local.d/01-ublue-dx
+++ b/dx/etc/dconf/db/local.d/01-ublue-dx
@@ -1,6 +1,6 @@
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2]
 binding='<Control><Alt>f'
-command='flatpak run com.raggesilver.BlackBox --command "distrobox enter fedora"'
+command='flatpak run com.raggesilver.BlackBox --command "bluefinbox-enter fedora"'
 name='blackbox fedora'
 
 [org/gnome/settings-daemon/plugins/media-keys]

--- a/dx/usr/bin/bluefinbox-enter
+++ b/dx/usr/bin/bluefinbox-enter
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Little helper script to launch other than default (ubuntu) distroboxes without manually
+# having to assemble them.
+
+container_name=$1
+if [ "${container_name}" == "" ]; then
+    echo "Please specify the container name you want to enter."
+    echo "For example: ${0} fedora"
+    exit 1
+fi
+
+# Inspect if the container is already present
+inspect_cmd="podman inspect --type container "${container_name}" --format {{.State.Status}} > /dev/null"
+eval "${inspect_cmd}"
+container_exists=$?
+
+if [ "$container_exists" -eq 0 ]; then
+    # No need to assemble, enjoy your stay
+    exec distrobox enter "${container_name}"
+else
+    # We don't have the container so we assemble it first. With distrobox version 1.5.0.2 
+    # or below we need to assemble all the entries that occur in the `distrobox.ini` manifest. 
+    # In future versions of distrobox we will be able to specify `--name $container_name` to
+    # only assemble the box we want to enter.
+    distrobox assemble create --replace --file /etc/distrobox/distrobox.ini
+
+    # All done, good to go
+    exec distrobox enter "${container_name}"
+fi


### PR DESCRIPTION
Fixes #383 

Add a wrapper script for entering non default boxes like fedora. `distrobox enter` will default to the ubuntu image so that shortcut don't have to be changed. 

In short it adds a script to see if the box exists locally, otherwise it assembles it first. At this moment it will assemble all the boxes in the `distrobox.ini` manifest. Upstream merged code for acting on a specific box in the manifest. So when a new version of distrobox is released it will be possible to assemble only the container that we want to enter.