### PR TITLE
fix(toolbox): add missing package to fedora

### DIFF
--- a/toolboxes/packages.fedora
+++ b/toolboxes/packages.fedora
@@ -1,2 +1,3 @@
 vim
 ripgrep
+pinentry


### PR DESCRIPTION
Adds `pinentry` to the `fedora-toolbox` 

Improves first run startup time of the box alot.