### PR TITLE
fix: force enable dconf-update service via symlink

### DIFF
--- a/usr/etc/systemd/system/multi-user.target.wants/dconf-update.service
+++ b/usr/etc/systemd/system/multi-user.target.wants/dconf-update.service
@@ -1,0 +1,1 @@
+../dconf-update.service


### PR DESCRIPTION
Since the systemd/system-preset enabled, but didn't create the target.wants symlink, we may need this to ensure the service starts as is expected.