### PR TITLE
chore: add concept fan-in required workflow job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -199,3 +199,11 @@ jobs:
         run: |
           echo "${{ toJSON(steps.push.outputs) }}"
 
+  check:
+    name: Check all builds successful
+    runs-on: ubuntu-latest
+    needs: [push-ghcr]
+    steps:
+      - name: Exit
+        shell: bash
+        run: exit 0


### PR DESCRIPTION
Adds a final step to the workflows containing a matrix.
This final step could be the only one marked as "required" by the repository since it needs all previous matrix jobs to be successful (in theory).

I have checked this in a repo which only I use, so I'm not sure if it's "production-ready".