### PR TITLE
fix: remove 2nd cosign layer since upstream provides in RPM

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -67,7 +67,6 @@ RUN rpm-ostree install podmansh
 RUN wget https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 -O /tmp/docker-compose && \
     install -c -m 0755 /tmp/docker-compose /usr/bin
 
-COPY --from=cgr.dev/chainguard/cosign:latest /usr/bin/cosign /usr/bin/cosign
 COPY --from=cgr.dev/chainguard/flux:latest /usr/bin/flux /usr/bin/flux
 COPY --from=cgr.dev/chainguard/helm:latest /usr/bin/helm /usr/bin/helm
 COPY --from=cgr.dev/chainguard/ko:latest /usr/bin/ko /usr/bin/ko


### PR DESCRIPTION
I guess there were two places in the Containerfile where this layer was being added.
