### PR TITLE
fix: make use of packages.json for all images

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -5,6 +5,7 @@ ARG BASE_IMAGE="ghcr.io/ublue-os/${SOURCE_IMAGE}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
 ARG TARGET_BASE="${TARGET_BASE:-bluefin}"
 
+## bluefin image section
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS bluefin
 
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
@@ -12,6 +13,8 @@ ARG PACKAGE_LIST="bluefin"
 
 COPY usr /usr
 COPY etc/yum.repos.d/ /etc/yum.repos.d/
+COPY packages.json /tmp/packages.json
+COPY build.sh /tmp/build.sh
 
 # gnome-vrr
 RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/kylegospo-gnome-vrr-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo
@@ -22,9 +25,6 @@ RUN rm -f /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo
 RUN wget https://copr.fedorainfracloud.org/coprs/rhcontainerbot/bootc/repo/fedora-"${FEDORA_MAJOR_VERSION}"/bootc-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/bootc.repo
 RUN rpm-ostree install bootc
 RUN rm -f /etc/yum.repos.d/bootc-"${FEDORA_MAJOR_VERSION}".repo
-
-ADD packages.json /tmp/packages.json
-ADD build.sh /tmp/build.sh
 
 RUN /tmp/build.sh && \
     pip install --prefix=/usr yafti && \
@@ -46,8 +46,6 @@ RUN /tmp/build.sh && \
     chmod -R 1777 /var/tmp
 
 ## bluefin-dx developer edition image section
-# TODO: this should be in packages.json but yolo for now
-
 FROM bluefin AS bluefin-dx
 
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
@@ -63,7 +61,7 @@ COPY build.sh /tmp/build.sh
 RUN wget https://copr.fedorainfracloud.org/coprs/ganto/lxc4/repo/fedora-"${FEDORA_MAJOR_VERSION}"/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
 RUN wget https://terra.fyralabs.com/terra.repo -O /etc/yum.repos.d/terra.repo
 
-# install packages from packages.json
+# Handle packages via packages.json
 RUN /tmp/build.sh
 
 RUN wget https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 -O /tmp/docker-compose && \
@@ -117,7 +115,7 @@ COPY framework/usr /usr
 COPY packages.json /tmp/packages.json
 COPY build.sh /tmp/build.sh
 
-# install packages from packages.json
+# Handle packages via packages.json
 RUN /tmp/build.sh
 
 RUN systemctl enable tlp

--- a/Containerfile
+++ b/Containerfile
@@ -112,10 +112,15 @@ RUN ostree container commit
 # Image for Framework laptops
 FROM bluefin AS bluefin-framework
 
-COPY framework/usr /usr
+ARG PACKAGE_LIST="bluefin-framework"
 
-RUN rpm-ostree install tlp tlp-rdw stress-ng
-RUN rpm-ostree override remove power-profiles-daemon
+COPY framework/usr /usr
+COPY packages.json /tmp/packages.json
+COPY build.sh /tmp/build.sh
+
+# install packages from packages.json
+RUN /tmp/build.sh
+
 RUN systemctl enable tlp
 RUN systemctl enable fprintd.service
 

--- a/Containerfile
+++ b/Containerfile
@@ -9,6 +9,7 @@ FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS bluefin
 
 ARG IMAGE_NAME="${IMAGE_NAME}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
+ARG PACKAGE_LIST="bluefin"
 
 COPY usr /usr
 COPY etc/yum.repos.d/ /etc/yum.repos.d/

--- a/Containerfile
+++ b/Containerfile
@@ -53,23 +53,20 @@ FROM bluefin AS bluefin-dx
 
 ARG IMAGE_NAME="${IMAGE_NAME}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
+ARG PACKAGE_LIST="bluefin-dx"
 
 # dx specific files come from the dx directory in this repo
 COPY dx/usr /usr
 COPY dx/etc/yum.repos.d/ /etc/yum.repos.d/
 COPY workarounds.sh /tmp/workarounds.sh
+COPY packages.json /tmp/packages.json
+COPY build.sh /tmp/build.sh
 
 RUN wget https://copr.fedorainfracloud.org/coprs/ganto/lxc4/repo/fedora-"${FEDORA_MAJOR_VERSION}"/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
 RUN wget https://terra.fyralabs.com/terra.repo -O /etc/yum.repos.d/terra.repo
 
-RUN rpm-ostree install code
-RUN rpm-ostree install lxd lxc lxd-agent
-RUN rpm-ostree install iotop dbus-x11 podman-plugins podman-tui
-RUN rpm-ostree install adobe-source-code-pro-fonts cascadiacode-nerd-fonts google-droid-sans-mono-fonts google-go-mono-fonts ibm-plex-mono-fonts jetbrains-mono-fonts-all mozilla-fira-mono-fonts powerline-fonts ubuntumono-nerd-fonts ubuntu-nerd-fonts
-RUN rpm-ostree install qemu qemu-user-static qemu-user-binfmt virt-manager libvirt edk2-ovmf edk2-ovmf genisoimage qemu-img qemu-system-x86-core qemu-char-spice qemu-device-usb-redirect qemu-device-display-virtio-vga qemu-device-display-virtio-gpu
-RUN rpm-ostree install cockpit-system cockpit-ostree cockpit-networkmanager cockpit-selinux cockpit-storaged cockpit-podman cockpit-machines cockpit-pcp
-RUN rpm-ostree install p7zip p7zip-plugins powertop
-RUN rpm-ostree install podmansh
+# install packages from packages.json
+RUN /tmp/build.sh
 
 RUN wget https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 -O /tmp/docker-compose && \
     install -c -m 0755 /tmp/docker-compose /usr/bin

--- a/Containerfile
+++ b/Containerfile
@@ -7,7 +7,6 @@ ARG TARGET_BASE="${TARGET_BASE:-bluefin}"
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS bluefin
 
-ARG IMAGE_NAME="${IMAGE_NAME}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
 ARG PACKAGE_LIST="bluefin"
 
@@ -51,7 +50,6 @@ RUN /tmp/build.sh && \
 
 FROM bluefin AS bluefin-dx
 
-ARG IMAGE_NAME="${IMAGE_NAME}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
 ARG PACKAGE_LIST="bluefin-dx"
 
@@ -112,6 +110,7 @@ RUN ostree container commit
 # Image for Framework laptops
 FROM bluefin AS bluefin-framework
 
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
 ARG PACKAGE_LIST="bluefin-framework"
 
 COPY framework/usr /usr

--- a/build.sh
+++ b/build.sh
@@ -4,11 +4,11 @@ set -ouex pipefail
 
 RELEASE="$(rpm -E %fedora)"
 
-INCLUDED_PACKAGES=($(jq -r "[(.all.include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
-                             (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
+INCLUDED_PACKAGES=($(jq -r "[(.all.include | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[]), \
+                             (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".include | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[])] \
                              | sort | unique[]" /tmp/packages.json))
-EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
-                             (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
+EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[]), \
+                             (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[])] \
                              | sort | unique[]" /tmp/packages.json))
 
 

--- a/packages.json
+++ b/packages.json
@@ -76,6 +76,11 @@
                 "p7zip-plugins",
                 "powertop",
                 "podmansh"
+            ],
+            "bluefin-framework": [
+                "tlp",
+                "tlp-rdw",
+                "stress-ng"
             ]
         },
         "exclude": {
@@ -85,19 +90,24 @@
                 "gnome-software-rpm-ostree",
                 "gnome-tour"
             ],
-            "bluefin-dx": []
+            "bluefin-dx": [],
+            "bluefin-framework": [
+                "power-profiles-daemon"
+            ]
         }
     },
     "38": {
         "include": {
             "bluefin": [],
-            "bluefin-dx": []
+            "bluefin-dx": [],
+            "bluefin-framework": []
         },
         "exclude": {
             "bluefin": [
                 "podman-docker"
             ],
-            "bluefin-dx": []
+            "bluefin-dx": [],
+            "bluefin-framework": []
         }
     }
 }

--- a/packages.json
+++ b/packages.json
@@ -2,11 +2,11 @@
     "all": {
         "include": {
             "bluefin": [
-	        "cockpit-bridge",
-		"ddccontrol", 
-		"ddccontrol-db", 
-		"ddccontrol-gtk",
-		"fish",
+                "cockpit-bridge",
+                "ddccontrol",
+                "ddccontrol-db",
+                "ddccontrol-gtk",
+                "fish",
                 "gnome-shell-extension-appindicator",
                 "gnome-shell-extension-dash-to-dock",
                 "gnome-shell-extension-blur-my-shell",
@@ -15,40 +15,89 @@
                 "libgda",
                 "libgda-sqlite",
                 "libratbag-ratbagd",
-		"nautilus-gsconnect",
-		"pulseaudio-utils",
+                "nautilus-gsconnect",
+                "pulseaudio-utils",
                 "python3-pip",
-		"samba",
-		"samba-ldb-ldap-modules", 
-		"samba-dcerpc",
-		"samba-winbind-clients",
-		"samba-winbind-modules",
-		"solaar",
+                "samba",
+                "samba-ldb-ldap-modules",
+                "samba-dcerpc",
+                "samba-winbind-clients",
+                "samba-winbind-modules",
+                "solaar",
                 "tailscale",
-		"tmux",
+                "tmux",
                 "wireguard-tools",
                 "xprop",
                 "yaru-theme",
-		"zsh"
+                "zsh"
+            ],
+            "bluefin-dx": [
+                "code",
+                "lxd",
+                "lxc",
+                "lxd-agent",
+                "iotop",
+                "dbus-x11",
+                "podman-plugins",
+                "podman-tui",
+                "adobe-source-code-pro-fonts",
+                "cascadiacode-nerd-fonts",
+                "google-droid-sans-mono-fonts",
+                "google-go-mono-fonts",
+                "ibm-plex-mono-fonts",
+                "jetbrains-mono-fonts-all",
+                "mozilla-fira-mono-fonts",
+                "powerline-fonts",
+                "ubuntumono-nerd-fonts",
+                "ubuntu-nerd-fonts",
+                "qemu",
+                "qemu-user-static",
+                "qemu-user-binfmt",
+                "virt-manager",
+                "libvirt",
+                "edk2-ovmf",
+                "edk2-ovmf",
+                "genisoimage",
+                "qemu-img",
+                "qemu-system-x86-core",
+                "qemu-char-spice",
+                "qemu-device-usb-redirect",
+                "qemu-device-display-virtio-vga",
+                "qemu-device-display-virtio-gpu",
+                "cockpit-system",
+                "cockpit-ostree",
+                "cockpit-networkmanager",
+                "cockpit-selinux",
+                "cockpit-storaged",
+                "cockpit-podman",
+                "cockpit-machines",
+                "cockpit-pcp",
+                "p7zip",
+                "p7zip-plugins",
+                "powertop",
+                "podmansh"
             ]
         },
         "exclude": {
             "bluefin": [
                 "firefox",
                 "firefox-langpacks",
-	        "gnome-software-rpm-ostree", 
+                "gnome-software-rpm-ostree",
                 "gnome-tour"
-            ]
+            ],
+            "bluefin-dx": []
         }
     },
     "38": {
         "include": {
-            "bluefin": []
+            "bluefin": [],
+            "bluefin-dx": []
         },
         "exclude": {
             "bluefin": [
-	        "podman-docker"
-	    ]
+                "podman-docker"
+            ],
+            "bluefin-dx": []
         }
     }
 }

--- a/packages.json
+++ b/packages.json
@@ -1,7 +1,7 @@
 {
     "all": {
         "include": {
-            "all": [
+            "bluefin": [
 	        "cockpit-bridge",
 		"ddccontrol", 
 		"ddccontrol-db", 
@@ -33,7 +33,7 @@
             ]
         },
         "exclude": {
-            "all": [
+            "bluefin": [
                 "firefox",
                 "firefox-langpacks",
 	        "gnome-software-rpm-ostree", 
@@ -43,10 +43,10 @@
     },
     "38": {
         "include": {
-            "all": []
+            "bluefin": []
         },
         "exclude": {
-            "all": [
+            "bluefin": [
 	        "podman-docker"
 	    ]
         }

--- a/packages.json
+++ b/packages.json
@@ -1,113 +1,113 @@
 {
-    "all": {
-        "include": {
-            "bluefin": [
-                "cockpit-bridge",
-                "ddccontrol",
-                "ddccontrol-db",
-                "ddccontrol-gtk",
-                "fish",
-                "gnome-shell-extension-appindicator",
-                "gnome-shell-extension-dash-to-dock",
-                "gnome-shell-extension-blur-my-shell",
-                "gnome-shell-extension-gsconnect",
-                "input-remapper",
-                "libgda",
-                "libgda-sqlite",
-                "libratbag-ratbagd",
-                "nautilus-gsconnect",
-                "pulseaudio-utils",
-                "python3-pip",
-                "samba",
-                "samba-ldb-ldap-modules",
-                "samba-dcerpc",
-                "samba-winbind-clients",
-                "samba-winbind-modules",
-                "solaar",
-                "tailscale",
-                "tmux",
-                "wireguard-tools",
-                "xprop",
-                "yaru-theme",
-                "zsh"
-            ],
-            "bluefin-dx": [
-                "code",
-                "lxd",
-                "lxc",
-                "lxd-agent",
-                "iotop",
-                "dbus-x11",
-                "podman-plugins",
-                "podman-tui",
-                "adobe-source-code-pro-fonts",
-                "cascadiacode-nerd-fonts",
-                "google-droid-sans-mono-fonts",
-                "google-go-mono-fonts",
-                "ibm-plex-mono-fonts",
-                "jetbrains-mono-fonts-all",
-                "mozilla-fira-mono-fonts",
-                "powerline-fonts",
-                "ubuntumono-nerd-fonts",
-                "ubuntu-nerd-fonts",
-                "qemu",
-                "qemu-user-static",
-                "qemu-user-binfmt",
-                "virt-manager",
-                "libvirt",
-                "edk2-ovmf",
-                "edk2-ovmf",
-                "genisoimage",
-                "qemu-img",
-                "qemu-system-x86-core",
-                "qemu-char-spice",
-                "qemu-device-usb-redirect",
-                "qemu-device-display-virtio-vga",
-                "qemu-device-display-virtio-gpu",
-                "cockpit-system",
-                "cockpit-ostree",
-                "cockpit-networkmanager",
-                "cockpit-selinux",
-                "cockpit-storaged",
-                "cockpit-podman",
-                "cockpit-machines",
-                "cockpit-pcp",
-                "p7zip",
-                "p7zip-plugins",
-                "powertop",
-                "podmansh"
-            ],
-            "bluefin-framework": [
-                "tlp",
-                "tlp-rdw",
-                "stress-ng"
-            ]
-        },
-        "exclude": {
-            "bluefin": [
-                "firefox",
-                "firefox-langpacks",
-                "gnome-software-rpm-ostree",
-                "gnome-tour"
-            ],
-            "bluefin-dx": [],
-            "bluefin-framework": [
-                "power-profiles-daemon"
-            ]
-        }
-    },
-    "38": {
-        "include": {
-            "bluefin": [],
-            "bluefin-dx": [],
-            "bluefin-framework": []
-        },
-        "exclude": {
-            "bluefin": [
-                "podman-docker"
-            ],
-            "bluefin-dx": [],
-            "bluefin-framework": []
-        }
-    }
+	"all": {
+		"include": {
+			"bluefin": [
+				"cockpit-bridge",
+				"ddccontrol-db",
+				"ddccontrol-gtk",
+				"ddccontrol",
+				"fish",
+				"gnome-shell-extension-appindicator",
+				"gnome-shell-extension-blur-my-shell",
+				"gnome-shell-extension-dash-to-dock",
+				"gnome-shell-extension-gsconnect",
+				"input-remapper",
+				"libgda-sqlite",
+				"libgda",
+				"libratbag-ratbagd",
+				"nautilus-gsconnect",
+				"pulseaudio-utils",
+				"python3-pip",
+				"samba-dcerpc",
+				"samba-ldb-ldap-modules",
+				"samba-winbind-clients",
+				"samba-winbind-modules",
+				"samba",
+				"solaar",
+				"tailscale",
+				"tmux",
+				"wireguard-tools",
+				"xprop",
+				"yaru-theme",
+				"zsh"
+			],
+			"bluefin-dx": [
+				"adobe-source-code-pro-fonts",
+				"cascadiacode-nerd-fonts",
+				"cockpit-machines",
+				"cockpit-networkmanager",
+				"cockpit-ostree",
+				"cockpit-pcp",
+				"cockpit-podman",
+				"cockpit-selinux",
+				"cockpit-storaged",
+				"cockpit-system",
+				"code",
+				"dbus-x11",
+				"edk2-ovmf",
+				"edk2-ovmf",
+				"genisoimage",
+				"google-droid-sans-mono-fonts",
+				"google-go-mono-fonts",
+				"ibm-plex-mono-fonts",
+				"iotop",
+				"jetbrains-mono-fonts-all",
+				"libvirt",
+				"lxc",
+				"lxd-agent",
+				"lxd",
+				"mozilla-fira-mono-fonts",
+				"p7zip-plugins",
+				"p7zip",
+				"podman-plugins",
+				"podman-tui",
+				"podmansh",
+				"powerline-fonts",
+				"powertop",
+				"qemu-char-spice",
+				"qemu-device-display-virtio-gpu",
+				"qemu-device-display-virtio-vga",
+				"qemu-device-usb-redirect",
+				"qemu-img",
+				"qemu-system-x86-core",
+				"qemu-user-binfmt",
+				"qemu-user-static",
+				"qemu",
+				"ubuntu-nerd-fonts",
+				"ubuntumono-nerd-fonts",
+				"virt-manager"
+			],
+			"bluefin-framework": [
+				"stress-ng",
+				"tlp-rdw",
+				"tlp"
+			]
+		},
+		"exclude": {
+			"bluefin": [
+				"firefox-langpacks",
+				"firefox",
+				"gnome-software-rpm-ostree",
+				"gnome-tour"
+			],
+			"bluefin-dx": [],
+			"bluefin-framework": [
+				"power-profiles-daemon"
+			]
+		}
+	},
+	"38": {
+		"include": {
+			"bluefin": [],
+			"bluefin-dx": [],
+			"bluefin-framework": []
+		},
+		"exclude": {
+			"bluefin": [
+				"podman-docker"
+			],
+			"bluefin-dx": [],
+			"bluefin-framework": []
+		}
+	}
 }


### PR DESCRIPTION
This uses a new introduced `ARG PACKAGE_LIST` to define which image we are building, and take the corresponding packages out of `packages.json`. Includes and excludes all work like before, just a slighty more narrowed down approach to make it work with the bluefin build proces.

Fixes: #276 