### PR TITLE
fix: remove not consumed build arg

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,6 @@ jobs:
           tags: |
             ${{ steps.generate-tags.outputs.alias_tags }}
           build-args: |
-            IMAGE_NAME=${{ env.IMAGE_NAME }}
             IMAGE_FLAVOR=${{ matrix.image_flavor }}
             FEDORA_MAJOR_VERSION=${{ matrix.major_version }}
             TARGET_BASE=${{ matrix.target_base }}


### PR DESCRIPTION
We are not using `IMAGE_NAME` in our `Containerfile` anymore after PR #457.  

Because it was still passing that as a build argument. It would lead to the following warning while building the images. `Warning:  one or more build args were not consumed: [IMAGE_NAME]` 

This PR removes it from the `build-args` and should give us a clear build without warnings.