### PR TITLE
fix(just): improve JetBrains Toolbox installation

### DIFF
--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -122,14 +122,20 @@ gnome-extensions:
 # Install JetBrains Toolbox | https://www.jetbrains.com/toolbox-app/
 jetbrains-toolbox:
   #!/usr/bin/env bash
-  BUILD_VERSION="2.0.2.16660"
-  echo "Installing JetBrains Toolbox"
   pushd "$(mktemp -d)"
-  curl -sSfL -O https://download.jetbrains.com/toolbox/jetbrains-toolbox-$BUILD_VERSION.tar.gz
-  curl -sSfL https://download.jetbrains.com/toolbox/jetbrains-toolbox-$BUILD_VERSION.tar.gz.sha256 | sha256sum -c
-  tar zxf jetbrains-toolbox-$BUILD_VERSION.tar.gz
+  echo "Get latest JetBrains Toolbox version"
+  # Get the json with latest releases
+  curl -sSfL -o releases.json "https://data.services.jetbrains.com/products/releases?code=TBA&latest=true&type=release"
+  # Extract information
+  BUILD_VERSION=$(jq -r '.TBA[0].build' ./releases.json)
+  DOWNLOAD_LINK=$(jq -r '.TBA[0].downloads.linux.link' ./releases.json)
+  CHECKSUM_LINK=$(jq -r '.TBA[0].downloads.linux.checksumLink' ./releases.json)
+  echo "Installing JetBrains Toolbox ${BUILD_VERSION}"
+  curl -sSfL -O "${DOWNLOAD_LINK}"
+  curl -sSfL "${CHECKSUM_LINK}" | sha256sum -c
+  tar zxf jetbrains-toolbox-"${BUILD_VERSION}".tar.gz
   echo "Launching JetBrains Toolbox"
-  ./jetbrains-toolbox-$BUILD_VERSION/jetbrains-toolbox
+  ./jetbrains-toolbox-"${BUILD_VERSION}"/jetbrains-toolbox
 
 # Install nix and Devbox
 nix-devbox:


### PR DESCRIPTION
Improved version of the `just jetbrains-toolbox` command. This should now always install the latest version without us having to specify it.