### PR TITLE
feat: Reorganizing Yafti with new submenus

### DIFF
--- a/usr/etc/yafti.yml
+++ b/usr/etc/yafti.yml
@@ -34,8 +34,6 @@ screens:
           description: Core Applications
           default: true
           packages:
-          - Backup: org.gnome.DejaDup
-          - Blackbox Terminal: com.raggesilver.BlackBox
           - Calculator: org.gnome.Calculator
           - Calendar: org.gnome.Calendar
           - Characters: org.gnome.Characters
@@ -50,16 +48,13 @@ screens:
           - Logs: org.gnome.Logs
           - Maps: org.gnome.Maps
           - Nautilus Preview: org.gnome.NautilusPreviewer
-          - PinApp Menu Editor: io.github.fabrialberio.pinapp
-          - Syncthing: com.github.zocker_160.SyncThingy
           - Text Editor: org.gnome.TextEditor
           - Weather: org.gnome.Weather
           - Disk Usage Analyzer: org.gnome.baobab
           - Clocks: org.gnome.clocks
           - Picture Viewer: org.gnome.eog
           - Font Viewer: org.gnome.font-viewer
-          - Font Downloader: org.gustavoperedo.FontDownloader
-        Web Browsers:
+        Other Web Browsers:
           description: Additional browsers to complement Firefox
           default: false
           packages:
@@ -72,13 +67,13 @@ screens:
           default: false
           packages:
           - Bottles: com.usebottles.bottles
-          - Discord: com.discordapp.Discord
           - Heroic Games Launcher: com.heroicgameslauncher.hgl
           - Lutris: net.lutris.Lutris
           - MangoHUD: org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
           - Steam: com.valvesoftware.Steam
           - Gamescope for Steam: org.freedesktop.Platform.VulkanLayer.gamescope
-          - Proton Updater for Steam: net.davidotek.pupgui2
+          - Proton Updater (QT) for Steam: net.davidotek.pupgui2
+          - Proton Updater (GTK) for Steam: com.vysp3r.ProtonPlus
         Office:
           description: Bow to Capitalism
           default: false
@@ -87,7 +82,6 @@ screens:
           - LibreOffice: org.libreoffice.LibreOffice
           - Obsidian: md.obsidian.Obsidian
           - OnlyOffice: org.onlyoffice.desktopeditors
-          - Slack: com.slack.Slack
           - Standard Notes: org.standardnotes.standardnotes
           - Thunderbird Email: org.mozilla.Thunderbird
         Streaming:
@@ -99,6 +93,20 @@ screens:
           - Gstreamer for OBS: com.obsproject.Studio.Plugin.Gstreamer
           - Gstreamer VAAPI for OBS: com.obsproject.Studio.Plugin.GStreamerVaapi
           - Boatswain for Streamdeck: com.feaneron.Boatswain
+        Communication:
+          description: Tools to communicate and collaborate
+          packages:
+          - Discord: com.discordapp.Discord
+          - Slack: com.slack.Slack
+        Utilities:
+          description: Useful Utilities
+          default: true
+          packagess:
+          - Font Downloader: org.gustavoperedo.FontDownloader
+          - PinApp Menu Editor: io.github.fabrialberio.pinapp
+          - Backup: org.gnome.DejaDup
+          - Blackbox Terminal: com.raggesilver.BlackBox
+          - Syncthing: com.github.zocker_160.SyncThingy
         Admin Tools:
           description: Helper Utilities for Administration
           default: false

--- a/usr/etc/yafti.yml
+++ b/usr/etc/yafti.yml
@@ -54,6 +54,7 @@ screens:
           - Clocks: org.gnome.clocks
           - Picture Viewer: org.gnome.eog
           - Font Viewer: org.gnome.font-viewer
+          - Blackbox Terminal: com.raggesilver.BlackBox
         Other Web Browsers:
           description: Additional browsers to complement Firefox
           default: false
@@ -72,7 +73,6 @@ screens:
           - MangoHUD: org.freedesktop.Platform.VulkanLayer.MangoHud//22.08
           - Steam: com.valvesoftware.Steam
           - Gamescope for Steam: org.freedesktop.Platform.VulkanLayer.gamescope
-          - Proton Updater (QT) for Steam: net.davidotek.pupgui2
           - Proton Updater (GTK) for Steam: com.vysp3r.ProtonPlus
         Office:
           description: Bow to Capitalism
@@ -105,7 +105,6 @@ screens:
           - Font Downloader: org.gustavoperedo.FontDownloader
           - PinApp Menu Editor: io.github.fabrialberio.pinapp
           - Backup: org.gnome.DejaDup
-          - Blackbox Terminal: com.raggesilver.BlackBox
           - Syncthing: com.github.zocker_160.SyncThingy
         Admin Tools:
           description: Helper Utilities for Administration


### PR DESCRIPTION
Defaults are still exactly the same, just reorganized a bit to be more readable, atleast in my opinion. Feel free to merge it or not, and if there are any questions, im always open to change things up. :)
I also added an alternative Steam Proton Updater, which is made in GTK, so it fits the desktop quite a bit better. The Tool added is here: https://flathub.org/apps/com.vysp3r.ProtonPlus