### PR TITLE
fix(yafti): add link to announcements and discussions

### DIFF
--- a/usr/etc/yafti.yml
+++ b/usr/etc/yafti.yml
@@ -115,6 +115,8 @@ screens:
             run: /usr/bin/gnome-software
         - "Website":
             run: /usr/bin/xdg-open https://ublue.it
+        - "Discussions and Announcements":
+            run: /usr/bin/xdg-open https://github.com/orgs/ublue-os/discussions/categories/bluefin
         - "Join the Discord Community":
             run: /usr/bin/xdg-open https://discord.gg/XjG48C7VHx 
       description: |


### PR DESCRIPTION
Adds a  link to the Discussions and Announcements page on the final screen.