### PR TITLE
fix: Add proper cjk fonts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -95,7 +95,7 @@ RUN systemctl disable pmlogger.service
 
 RUN /tmp/workarounds.sh
 
-# Clean up repos, everything is on the image so we don't need them
+# Clean up repos, everything is on the image so we don't need them. Also link cjk fonts to hardcoded steam paths.
 RUN rm -f /etc/yum.repos.d/terra.repo
 RUN rm -f /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
 RUN rm -f /etc/yum.repos.d/vscode.repo

--- a/Containerfile
+++ b/Containerfile
@@ -72,6 +72,7 @@ COPY --from=cgr.dev/chainguard/helm:latest /usr/bin/helm /usr/bin/helm
 COPY --from=cgr.dev/chainguard/ko:latest /usr/bin/ko /usr/bin/ko
 COPY --from=cgr.dev/chainguard/minio-client:latest /usr/bin/mc /usr/bin/mc
 COPY --from=cgr.dev/chainguard/kubectl:latest /usr/bin/kubectl /usr/bin/kubectl
+RUN ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk"
 
 RUN curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/latest/download/kind-$(uname)-amd64"
 RUN chmod +x ./kind
@@ -101,7 +102,6 @@ RUN rm -f /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
 RUN rm -f /etc/yum.repos.d/vscode.repo
 RUN rm -f /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:phracek:PyCharm.repo
 RUN rm -f /etc/yum.repos.d/fedora-cisco-openh264.repo
-RUN ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk"
 
 RUN rm -rf /tmp/* /var/*
 RUN ostree container commit

--- a/Containerfile
+++ b/Containerfile
@@ -33,6 +33,7 @@ RUN /tmp/build.sh && \
     systemctl enable dconf-update.service && \
     fc-cache -f /usr/share/fonts/ubuntu && \
     fc-cache -f /usr/share/fonts/inter && \
+    ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk" && \
     rm -f /etc/yum.repos.d/tailscale.repo && \
     rm -f /usr/share/applications/fish.desktop && \
     rm -f /usr/share/applications/htop.desktop && \
@@ -72,7 +73,6 @@ COPY --from=cgr.dev/chainguard/helm:latest /usr/bin/helm /usr/bin/helm
 COPY --from=cgr.dev/chainguard/ko:latest /usr/bin/ko /usr/bin/ko
 COPY --from=cgr.dev/chainguard/minio-client:latest /usr/bin/mc /usr/bin/mc
 COPY --from=cgr.dev/chainguard/kubectl:latest /usr/bin/kubectl /usr/bin/kubectl
-RUN ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk"
 
 RUN curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/latest/download/kind-$(uname)-amd64"
 RUN chmod +x ./kind
@@ -96,7 +96,7 @@ RUN systemctl disable pmlogger.service
 
 RUN /tmp/workarounds.sh
 
-# Clean up repos, everything is on the image so we don't need them. Also link cjk fonts to hardcoded steam paths.
+# Clean up repos, everything is on the image so we don't need them.
 RUN rm -f /etc/yum.repos.d/terra.repo
 RUN rm -f /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
 RUN rm -f /etc/yum.repos.d/vscode.repo

--- a/Containerfile
+++ b/Containerfile
@@ -101,6 +101,7 @@ RUN rm -f /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
 RUN rm -f /etc/yum.repos.d/vscode.repo
 RUN rm -f /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:phracek:PyCharm.repo
 RUN rm -f /etc/yum.repos.d/fedora-cisco-openh264.repo
+RUN ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk"
 
 RUN rm -rf /tmp/* /var/*
 RUN ostree container commit

--- a/packages.json
+++ b/packages.json
@@ -30,7 +30,8 @@
 				"wireguard-tools",
 				"xprop",
 				"yaru-theme",
-				"zsh"
+				"zsh",
+				"google-noto-sans-cjk-fonts"
 			],
 			"bluefin-dx": [
 				"adobe-source-code-pro-fonts",
@@ -89,7 +90,8 @@
 				"firefox-langpacks",
 				"firefox",
 				"gnome-software-rpm-ostree",
-				"gnome-tour"
+				"gnome-tour",
+				"google-noto-sans-cjk-vf-fonts"
 			],
 			"bluefin-dx": [],
 			"bluefin-framework": [


### PR DESCRIPTION
to avoid issues of certain flatpaks (like steam) not showing CJK fonts properly.
How its looking without this patch:
![image](https://github.com/ublue-os/bluefin/assets/21346945/6f11a536-6a9d-45e5-b75b-beccee189175)
how it looks with the patch:
![image](https://github.com/ublue-os/bluefin/assets/21346945/d25ae893-f8ff-4c03-b116-2bf15082248b)

it could also potentially need a fc-cache flush. in case of it not working from the get go. the fontconfig folder must be nuked in `/var/home/$USERNAME/.var/app/com.valvesoftware.Steam/cache/fontconfig` and recreated with `flatpak run --command=fc-cache com.valvesoftware.Steam`