### PR TITLE
fix: switch to copr for nerd-fonts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -59,7 +59,7 @@ COPY packages.json /tmp/packages.json
 COPY build.sh /tmp/build.sh
 
 RUN wget https://copr.fedorainfracloud.org/coprs/ganto/lxc4/repo/fedora-"${FEDORA_MAJOR_VERSION}"/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
-RUN wget https://terra.fyralabs.com/terra.repo -O /etc/yum.repos.d/terra.repo
+RUN wget https://copr.fedorainfracloud.org/coprs/bobslept/nerd-fonts/repo/fedora-"${FEDORA_MAJOR_VERSION}"/bobslept-nerd-fonts-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/bobslept-nerd-fonts-fedora-"${FEDORA_MAJOR_VERSION}".repo
 
 # Handle packages via packages.json
 RUN /tmp/build.sh
@@ -96,7 +96,7 @@ RUN systemctl disable pmlogger.service
 RUN /tmp/workarounds.sh
 
 # Clean up repos, everything is on the image so we don't need them
-RUN rm -f /etc/yum.repos.d/terra.repo
+RUN rm -f /etc/yum.repos.d/bobslept-nerd-fonts-fedora-"${FEDORA_MAJOR_VERSION}".repo
 RUN rm -f /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
 RUN rm -f /etc/yum.repos.d/vscode.repo
 RUN rm -f /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:phracek:PyCharm.repo


### PR DESCRIPTION
We used terra repo for our nerd fonts, but lately their repo is very unstable which resulted in lots of failing builds. I've forked their spec repo and set the specific nerd-fonts.spec up on copr. This should save us some from failing builds.

The spec I used is available here:
https://github.com/bobslept/terra-packages-specs/blob/f38/anda/fonts/nerd-fonts/nerd-fonts.spec
And the copr:
https://copr.fedorainfracloud.org/coprs/bobslept/nerd-fonts/