### PR TITLE
feat: add a declarative update command

### DIFF
--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -184,12 +184,12 @@ touch:
 
 # A preview of what the update system would look like in the future
 update-ng:
-  echo 'Assembling and replacing distroboxes ...'
-  distrobox assemble create --replace --file /etc/distrobox/distrobox.ini
-  echo 'Upgrading flatpaks...'
-  flatpak update -y
   echo 'Upgrading system...'
   sudo bootc upgrade
+  echo 'Upgrading flatpaks...'
+  flatpak update -y
+  echo 'Assembling and replacing distroboxes ...'
+  distrobox assemble create --replace --file /etc/distrobox/distrobox.ini
 
 # Upgrade Distrobox to the latest git version
 distrobox-git:

--- a/usr/share/ublue-os/just/custom.just
+++ b/usr/share/ublue-os/just/custom.just
@@ -182,8 +182,17 @@ touch:
   gext install improvedosk@nick-shmyrev.dev
   gext install gestureImprovements@gestures
 
+# A preview of what the update system would look like in the future
+update-ng:
+  echo 'Assembling and replacing distroboxes ...'
+  distrobox assemble create --replace --file /etc/distrobox/distrobox.ini
+  echo 'Upgrading flatpaks...'
+  flatpak update -y
+  echo 'Upgrading system...'
+  sudo bootc upgrade
+
 # Upgrade Distrobox to the latest git version
-update-distrobox-git:
+distrobox-git:
   echo 'Installing latest git snapshot of Distrobox'
   curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sh -s -- --next --prefix ~/.local
 


### PR DESCRIPTION
This destroys pets and reassembles them as cattle, and then uses bootc upgrade. Layered packages currently not supported via bootc upgrade.