### PR TITLE
Add wl-clipboard to installed packages

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -82,7 +82,8 @@
 				"qemu",
 				"ubuntu-nerd-fonts",
 				"ubuntumono-nerd-fonts",
-				"virt-manager"
+				"virt-manager",
+				"wl-clipboard"
 			],
 			"bluefin-framework": [
 				"tlp",


### PR DESCRIPTION
wl-clipboard offers similar functionality to xclip, but for Wayland users.

The specific reason I need wl-clipboard is to use the Image Paste extension for Visual Studio Code. It allows you to quickly paste images into Markdown files. Plus, I'd like to be able to copy and paste files from the terminal.