### PR TITLE
feat(toolbox): base fedora of ublue fedora-distrobox

### DIFF
--- a/toolboxes/Containerfile.fedora
+++ b/toolboxes/Containerfile.fedora
@@ -1,5 +1,5 @@
-FROM registry.fedoraproject.org/fedora-toolbox:38
-# From https://github.com/containers/toolbox/tree/main/images/fedora/f38
+FROM ghcr.io/ublue-os/fedora-distrobox:latest
+# From https://github.com/ublue-os/fedora-distrobox
 
 LABEL com.github.containers.toolbox="true" \
       usage="This image is meant to be used with the toolbox or distrobox command" \

--- a/toolboxes/packages.fedora
+++ b/toolboxes/packages.fedora
@@ -1,3 +1,2 @@
 vim
 ripgrep
-pinentry


### PR DESCRIPTION
Base our fedora toolbox of ublue-os/fedora-distrobox that is already optimized for distrobox usage.