### PR TITLE
feat: add input-leap

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -111,7 +111,9 @@
 	},
 	"39": {
 		"include": {
-			"bluefin": [],
+			"bluefin": [
+				"input-leap"	
+			],
 			"bluefin-dx": [],
 			"bluefin-framework": []
 		},


### PR DESCRIPTION
This has support in gnome 45 now so I wanna try it. It's by the folks who did barrier:

https://github.com/input-leap/input-leap