### PR TITLE
feat: Generate image info for auto-signing via ublue-update

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,10 @@ ARG TARGET_BASE="${TARGET_BASE:-bluefin}"
 ## bluefin image section
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS bluefin
 
+ARG IMAGE_NAME="${IMAGE_NAME}"
+ARG IMAGE_VENDOR="ublue-os"
+ARG BASE_IMAGE_NAME="${BASE_IMAGE_NAME}"
+ARG IMAGE_FLAVOR="${IMAGE_FLAVOR}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
 ARG PACKAGE_LIST="bluefin"
 
@@ -15,6 +19,7 @@ COPY usr /usr
 COPY etc/yum.repos.d/ /etc/yum.repos.d/
 COPY packages.json /tmp/packages.json
 COPY build.sh /tmp/build.sh
+COPY image-info.sh /tmp/image-info.sh
 
 # Exclude gnome-vrr from F39
 RUN if grep -qv "39" <<< "${FEDORA_MAJOR_VERSION}"; then \
@@ -35,6 +40,7 @@ RUN curl -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases
   echo 'eval "$(starship init bash)"' >> /etc/bashrc
 
 RUN /tmp/build.sh && \
+    /tmp/image-info.sh && \
     pip install --prefix=/usr yafti && \
     systemctl enable rpm-ostree-countme.service && \
     systemctl enable tailscaled.service && \
@@ -56,6 +62,10 @@ RUN /tmp/build.sh && \
 ## bluefin-dx developer edition image section
 FROM bluefin AS bluefin-dx
 
+ARG IMAGE_NAME="${IMAGE_NAME}"
+ARG IMAGE_VENDOR="ublue-os"
+ARG BASE_IMAGE_NAME="${BASE_IMAGE_NAME}"
+ARG IMAGE_FLAVOR="${IMAGE_FLAVOR}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
 ARG PACKAGE_LIST="bluefin-dx"
 
@@ -65,6 +75,7 @@ COPY dx/etc/yum.repos.d/ /etc/yum.repos.d/
 COPY workarounds.sh /tmp/workarounds.sh
 COPY packages.json /tmp/packages.json
 COPY build.sh /tmp/build.sh
+COPY image-info.sh /tmp/image-info.sh
 
 # Apply IP Forwarding before installing Docker to prevent messing with LXC networking
 RUN sysctl -p
@@ -74,6 +85,7 @@ RUN wget https://copr.fedorainfracloud.org/coprs/bobslept/nerd-fonts/repo/fedora
 
 # Handle packages via packages.json
 RUN /tmp/build.sh
+RUN /tmp/image-info.sh
 
 RUN wget https://github.com/docker/compose/releases/latest/download/docker-compose-linux-x86_64 -O /tmp/docker-compose && \
     install -c -m 0755 /tmp/docker-compose /usr/bin

--- a/image-info.sh
+++ b/image-info.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -oue pipefail
+
+IMAGE_INFO="/usr/share/ublue-os/image-info.json"
+IMAGE_REF="docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
+
+case $FEDORA_MAJOR_VERSION in
+  38)
+    IMAGE_TAG="latest"
+    ;;
+  *)
+    IMAGE_TAG="$FEDORA_MAJOR_VERSION"
+    ;;
+esac
+
+cat > $IMAGE_INFO <<EOF
+{
+  "image-name": "$IMAGE_NAME",
+  "image-flavor": "$IMAGE_FLAVOR",
+  "image-vendor": "$IMAGE_VENDOR",
+  "image-ref": "$IMAGE_REF",
+  "image-tag":"$IMAGE_TAG",
+  "base-image-name": "$BASE_IMAGE_NAME",
+  "fedora-version": "$FEDORA_MAJOR_VERSION"
+}
+EOF


### PR DESCRIPTION
Generates information specific to the image being built. This is used for auto-signing via ublue-update but also has other practical purposes such as distuingishing which flavor or base may be in use