### PR TITLE
fix: remove framework related just kargs

### DIFF
--- a/usr/share/ublue-os/just/60-custom.just
+++ b/usr/share/ublue-os/just/60-custom.just
@@ -105,10 +105,6 @@ distrobox-universal:
   echo 'Creating Universal Development distrobox ...'
   distrobox create --image mcr.microsoft.com/devcontainers/universal:latest -n universal -Y
 
-# Add boot parameters needed for a Framework 13 laptop
-framework-13:
-  rpm-ostree kargs --append="module_blacklist=hid_sensor_hub" --append="nvme.noacpi=1" --append="tpm_tis.interrupts=0" --append="rd.luks.options=discard"
-
 # Switch to the fish shell
 fish:
   sudo lchsh $USER /usr/bin/fish 


### PR DESCRIPTION
These just commands will be shipped via the framework repo. No need for them in here anymore.