### PR TITLE
fix: use proper image ref for generating image info

### DIFF
--- a/image-info.sh
+++ b/image-info.sh
@@ -3,7 +3,7 @@
 set -oue pipefail
 
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"
-IMAGE_REF="docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
+IMAGE_REF="ostree-image-signed:docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
 
 case $FEDORA_MAJOR_VERSION in
   38)


### PR DESCRIPTION
Currently `ostree-image-signed` isn't included in `image-info` which bricks the system update function of `ublue-update`, as it is unable to rebase to an image without the prefix