### PR TITLE
fix: remove gnome-extensions-app

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -90,6 +90,7 @@
 			"bluefin": [
 				"firefox-langpacks",
 				"firefox",
+				"gnome-extension-app",
 				"gnome-software-rpm-ostree",
 				"gnome-tour"
 			],


### PR DESCRIPTION
This is a dupe and we prefer gnome-extensions-manager anyway.