### PR TITLE
feat: Allow multiple justfiles.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,7 +16,7 @@ ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION}"
 ARG PACKAGE_LIST="bluefin"
 
 COPY usr /usr
-COPY just/custom.just /tmp/just/custom.just
+COPY just /tmp/just
 COPY etc/yum.repos.d/ /etc/yum.repos.d/
 COPY packages.json /tmp/packages.json
 COPY build.sh /tmp/build.sh
@@ -48,7 +48,7 @@ RUN /tmp/build.sh && \
     systemctl enable dconf-update.service && \
     fc-cache -f /usr/share/fonts/ubuntu && \
     fc-cache -f /usr/share/fonts/inter && \
-    cat /tmp/just/custom.just >> /usr/share/ublue-os/just/60-custom.just && \
+    find /tmp/just -iname '*.just' -exec printf "\n\n" \; -exec cat {} \; >> /usr/share/ublue-os/just/60-custom.just && \
     rm -f /etc/yum.repos.d/tailscale.repo && \
     rm -f /usr/share/applications/fish.desktop && \
     rm -f /usr/share/applications/htop.desktop && \


### PR DESCRIPTION
Proposed change:
* I can add multiple *.just files into the just/ folder, in addition to the core custom.just file.
* At build time, all *.just files are concatenated together. The new `find` command in the Containerfile makes sure that content is separated by 2 newlines, so that a possibly missing newline at the end of an individual file cannot break justfile syntax.

PS: I roll my own slightly changed image off ublue-os/bluefin. I prefer extending functionality by adding extra files, instead of mangling with existing core files. This proposed change enables that.

Usage example: https://github.com/hirnidrin/bluefin/tree/8bfb7a35cbe0503f6f8fabda581368fdd1939304/just
