### PR TITLE
fix: tweak build.sh handling of package.json

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -12,24 +12,18 @@ EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (select(.\"$PACKAGE_LIST\" != null)
                              | sort | unique[]" /tmp/packages.json))
 
 
+
+if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    rpm-ostree install \
+        ${INCLUDED_PACKAGES[@]}
+else
+    echo "No packages to install."
+fi
+
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
 fi
-
-if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
-    rpm-ostree install \
-        ${INCLUDED_PACKAGES[@]}
-
-elif [[ "${#INCLUDED_PACKAGES[@]}" -eq 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     rpm-ostree override remove \
         ${EXCLUDED_PACKAGES[@]}
-
-elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    rpm-ostree override remove \
-        ${EXCLUDED_PACKAGES[@]} \
-        $(printf -- "--install=%s " ${INCLUDED_PACKAGES[@]})
-
-else
-    echo "No packages to install."
-
 fi


### PR DESCRIPTION
The includes and excludes are handled a bit oddly in the old build.sh pattern.

This change always does the requested installs, but then always does the override remove for excludes, which enables excluding dependancies of packages which were just requested to be installed.

This should cause #519 to work as expected.