### PR TITLE
fix: typo in gnome-extensions-app

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -90,7 +90,7 @@
 			"bluefin": [
 				"firefox-langpacks",
 				"firefox",
-				"gnome-extension-app",
+				"gnome-extensions-app",
 				"gnome-software-rpm-ostree",
 				"gnome-tour"
 			],


### PR DESCRIPTION
Application didn't get removed because of a typo