### PR TITLE
fix(just): pytorch intendation

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -179,9 +179,9 @@ pytorch:
   echo 'Follow the prompts and check the tutorial: https://docs.anaconda.com/free/anaconda/jupyter-notebooks/'
   podman pull docker.io/continuumio/miniconda3
   podman run -i -t -p 8888:8888 docker.io/continuumio/miniconda3 /bin/bash -c "/opt/conda/bin/conda install jupyter -y --quiet && mkdir \
-/opt/notebooks && /opt/conda/bin/jupyter notebook \
---notebook-dir=/opt/notebooks --ip='*' --port=8888 \
---no-browser --allow-root"
+  /opt/notebooks && /opt/conda/bin/jupyter notebook \
+  --notebook-dir=/opt/notebooks --ip='*' --port=8888 \
+  --no-browser --allow-root"
 
 # Run Tensorflow
 tensorflow: 


### PR DESCRIPTION
Just is currently broken because of an indentation error. 
```
just
error: Unknown start of token:
    |
349 | /opt/notebooks && /opt/conda/bin/jupyter notebook \
    |                                                   ^
```
This should be fixed now.