### PR TITLE
fix: ensure that package override replace works properly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,7 @@ RELEASE="$(rpm -E %fedora)"
 INCLUDED_PACKAGES=($(jq -r "[(.all.include | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[]), \
                              (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".include | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[])] \
                              | sort | unique[]" /tmp/packages.json))
+
 # build list of all packages requested for exclusion
 EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[]), \
                              (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[])] \
@@ -20,7 +21,6 @@ if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
 fi
 
 # simple case to install where no packages need excluding
-if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
 if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
     rpm-ostree install \
         ${INCLUDED_PACKAGES[@]}
@@ -41,6 +41,7 @@ fi
 EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[]), \
                              (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[])] \
                              | sort | unique[]" /tmp/packages.json))
+
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
 fi

--- a/build.sh
+++ b/build.sh
@@ -4,25 +4,48 @@ set -ouex pipefail
 
 RELEASE="$(rpm -E %fedora)"
 
+# build list of all packages requested for inclusion
 INCLUDED_PACKAGES=($(jq -r "[(.all.include | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[]), \
                              (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".include | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[])] \
                              | sort | unique[]" /tmp/packages.json))
+# build list of all packages requested for exclusion
 EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[]), \
                              (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[])] \
                              | sort | unique[]" /tmp/packages.json))
 
 
-
-if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    rpm-ostree install \
-        ${INCLUDED_PACKAGES[@]}
-else
-    echo "No packages to install."
-fi
-
+# ensure exclusion list only contains packages already present on image
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
 fi
+
+# simple case to install where no packages need excluding
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
+    rpm-ostree install \
+        ${INCLUDED_PACKAGES[@]}
+
+# install/excluded packages both at same time
+elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    rpm-ostree override remove \
+        ${EXCLUDED_PACKAGES[@]} \
+        $(printf -- "--install=%s " ${INCLUDED_PACKAGES[@]})
+
+else
+    echo "No packages to install."
+
+fi
+
+# check if any excluded packages are still present
+# (this can happen if an included package pulls in a dependency)
+EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[]), \
+                             (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (select(.\"$PACKAGE_LIST\" != null).\"$PACKAGE_LIST\")[])] \
+                             | sort | unique[]" /tmp/packages.json))
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
+fi
+
+# remove any exluded packages which are still present on image
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     rpm-ostree override remove \
         ${EXCLUDED_PACKAGES[@]}


### PR DESCRIPTION
This is an addtion to PR #525 which maintains the goal of that PR, allowing for packages installed as a depdency to be later excluded, but also fixes the bug which was inadvertently created.

