### PR TITLE
feat: ship default vscode settings.json

### DIFF
--- a/dx/usr/etc/profile.d/vscode-bluefin-profile.sh
+++ b/dx/usr/etc/profile.d/vscode-bluefin-profile.sh
@@ -1,0 +1,7 @@
+if test "$(id -u)" -gt "0" && test -d "$HOME"; then
+    # Add default settings when there are no settings
+    if test ! -e "$HOME"/.config/Code/User/settings.json; then
+        mkdir -p "$HOME"/.config/Code/User
+        cp -f /etc/skel.d/.config/Code/User/settings.json "$HOME"/.config/Code/User/settings.json
+    fi
+fi

--- a/dx/usr/etc/skel.d/.config/Code/User/settings.json
+++ b/dx/usr/etc/skel.d/.config/Code/User/settings.json
@@ -1,0 +1,6 @@
+{
+    "dev.containers.dockerComposePath": "podman-compose",
+    "dev.containers.dockerPath": "podman",
+    "window.titleBarStyle": "custom",
+    "editor.fontFamily": "'CaskaydiaCove Nerd Font Mono', 'Droid Sans Mono', 'monospace', monospace"
+}


### PR DESCRIPTION
This PR contains a part of #285 and will ship a default `settings.json` based on the settings from `just vscode-profile`

It will only set it when there is no existing version of `settings.json` so it will not change it when there is already a config. 

I was unable to figure out how to ship default extensions that where used in `just vscode-profile`