### PR TITLE
chore(ci): rename job title to make

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   push-ghcr:
-    name: Build and push image
+    name: Make
     runs-on: ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
Shortens it up to make reading the builds easier, and bazzite already did this so a win for consistency too.