### PR TITLE
feat: Add ublue-update service

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,7 @@ COPY packages.json /tmp/packages.json
 COPY build.sh /tmp/build.sh
 COPY image-info.sh /tmp/image-info.sh
 
-# Exclude gnome-vrr from F39
+# GNOME VRR
 RUN if grep -qv "39" <<< "${FEDORA_MAJOR_VERSION}"; then \
     wget https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/kylegospo-gnome-vrr-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo && \
     if [ ${FEDORA_MAJOR_VERSION} -lt 39 ]; then \
@@ -39,16 +39,19 @@ RUN curl -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases
   install -c -m 0755 /tmp/starship /usr/bin && \
   echo 'eval "$(starship init bash)"' >> /etc/bashrc
 
-RUN /tmp/build.sh && \
+RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/bling/repo/fedora-$(rpm -E %fedora)/ublue-os-bling-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_ublue-os-bling.repo && \
+    /tmp/build.sh && \
     /tmp/image-info.sh && \
     pip install --prefix=/usr yafti && \
     systemctl enable rpm-ostree-countme.service && \
     systemctl enable tailscaled.service && \
     systemctl enable dconf-update.service && \
+    systemctl enable ublue-update.timer && \
     fc-cache -f /usr/share/fonts/ubuntu && \
     fc-cache -f /usr/share/fonts/inter && \
     find /tmp/just -iname '*.just' -exec printf "\n\n" \; -exec cat {} \; >> /usr/share/ublue-os/just/60-custom.just && \
     rm -f /etc/yum.repos.d/tailscale.repo && \
+    rm -f /etc/yum.repos.d/_copr_ublue-os-bling.repo && \
     rm -f /usr/share/applications/fish.desktop && \
     rm -f /usr/share/applications/htop.desktop && \
     rm -f /usr/share/applications/nvtop.desktop && \

--- a/packages.json
+++ b/packages.json
@@ -30,6 +30,7 @@
 				"stress-ng",
 				"tailscale",
 				"tmux",
+				"ublue-update",
 				"wireguard-tools",
 				"xprop",
 				"yaru-theme",
@@ -94,7 +95,8 @@
 				"firefox",
 				"gnome-extensions-app",
 				"gnome-software-rpm-ostree",
-				"gnome-tour"
+				"gnome-tour",
+				"ublue-os-update-services"
 			],
 			"bluefin-dx": []
 		}


### PR DESCRIPTION
This PR adds the service and enables the timer, but does nothing to the built in rpm-ostree updater.