### PR TITLE
fix: pass IMAGE_NAME build arg for image-info.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,6 +122,7 @@ jobs:
           tags: |
             ${{ steps.generate-tags.outputs.alias_tags }}
           build-args: |
+            IMAGE_NAME=${{ env.IMAGE_NAME }}
             IMAGE_FLAVOR=${{ matrix.image_flavor }}
             FEDORA_MAJOR_VERSION=${{ matrix.major_version }}
             TARGET_BASE=${{ matrix.target_base }}


### PR DESCRIPTION
We removed the build-arg IMAGE_NAME earlier in PR #458  to suspress a not consumed argument. This argument is now used for `image-info.sh` but we didn't pass it in again. This leads to an empty image-name:
```
cat /usr/share/ublue-os/image-info.json
{
  "image-name": "",
  "image-flavor": "main",
  "image-vendor": "ublue-os",
  "image-ref": "ostree-image-signed:docker://ghcr.io/ublue-os/",
  "image-tag":"latest",
  "base-image-name": "",
  "fedora-version": "38"
}
```

Which then fails the new ublue-update service.
```
Oct 01 12:26:07 fedora ublue-update[6147]: [2023-10-01 12:26:07,221] ublue_update.cli:ERROR | /etc/ublue-update.d/system/00-system-update.sh returned error code: 1
Oct 01 12:26:07 fedora ublue-update[6147]:                         Program output:
Oct 01 12:26:07 fedora ublue-update[6147]:                         Pulling manifest: ostree-image-signed:docker://ghcr.io/ublue-os/:latest
```
