### PR TITLE
fix: make removing flatpaks a little safer

### DIFF
--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -11,18 +11,6 @@ if [[ -f $VER_FILE && $VER = $VER_RAN ]]; then
   exit 0
 fi
 
-# Opt out of and remove Fedora's flatpak repo
-if grep -qz 'fedora' <<< $(flatpak remotes); then
-  /usr/lib/fedora-third-party/fedora-third-party-opt-out
-  /usr/bin/fedora-third-party disable
-  flatpak remote-delete fedora --force
-
-  FEDORA_FLATPAKS=$(flatpak list --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
-  for flatpak in $FEDORA_FLATPAKS; do
-    flatpak remove --system --noninteractive $flatpak
-  done
-fi
-
 notify-send "Flatpak installer" "Currently installing system flatpaks" --app-name="Flatpak installer" -u NORMAL
 
 # Remove fedora flatpak repo
@@ -52,6 +40,18 @@ if [[ -n $REMOVE_LIST ]]; then
     if grep -qz $flatpak <<< $FLATPAK_LIST; then
       flatpak remove --system --noninteractive $flatpak
     fi
+  done
+fi
+
+# Opt out of and remove Fedora's flatpak repo
+if grep -qz 'fedora' <<< $(flatpak remotes); then
+  /usr/lib/fedora-third-party/fedora-third-party-opt-out
+  /usr/bin/fedora-third-party disable
+  flatpak remote-delete fedora --force
+
+  FEDORA_FLATPAKS=$(flatpak list --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
+  for flatpak in $FEDORA_FLATPAKS; do
+    flatpak remove --system --noninteractive $flatpak
   done
 fi
 

--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -16,6 +16,11 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
   /usr/lib/fedora-third-party/fedora-third-party-opt-out
   /usr/bin/fedora-third-party disable
   flatpak remote-delete fedora --force
+
+  FEDORA_FLATPAKS=$(flatpak list --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
+  for flatpak in $FEDORA_FLATPAKS; do
+    flatpak remove --system --noninteractive $flatpak
+  done
 fi
 
 notify-send "Flatpak installer" "Currently installing system flatpaks" --app-name="Flatpak installer" -u NORMAL

--- a/usr/bin/ublue-system-setup
+++ b/usr/bin/ublue-system-setup
@@ -99,12 +99,6 @@ if [[ -f $HWS_VER_FILE && $HWS_VER = $HWS_VER_RAN ]]; then
   fi
 fi
 
-# Remove system flatpaks
-if flatpak remotes --system | grep -q fedora; then
-    flatpak remote-delete fedora --force
-    flatpak remove --system --noninteractive --all
-fi
-
 echo $HWS_VER > $HWS_VER_FILE
 echo $IMAGE_NAME > $KNOWN_IMAGE_NAME_FILE
 echo $IMAGE_FLAVOR > $KNOWN_IMAGE_FLAVOR_FILE


### PR DESCRIPTION
This PR makes a few changes to the order of operations on the new Flatpak services, to ensure users are not left without packages if the script fails part way through.


It removes duplicate fedora flatpak repo removal
It deletes Fedora flatpaks in the new manager service
It moves destructive fedora flatpak changes to after new packages are installed to ensure user is not left without packages

I would still like to use file hashes to determine whether these scripts should be ran again or not, but this works for now.