### PR TITLE
feat: add vscode and distrobox to dock if installed

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -1,5 +1,5 @@
 [org/gnome/shell] 
-favorite-apps = ['org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Rhythmbox3.desktop', 'org.libreoffice.LibreOffice.writer.desktop', 'org.gnome.Software.desktop', 'yelp.desktop']
+favorite-apps = ['org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Rhythmbox3.desktop', 'org.libreoffice.LibreOffice.writer.desktop', 'org.gnome.Software.desktop', 'code.desktop', 'ubuntu.desktop', 'yelp.desktop']
 enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'dash-to-dock@micxgx.gmail.com', 'blur-my-shell@aunetx', 'gsconnect@andyholmes.github.io']
 
 [org/gnome/desktop/background]


### PR DESCRIPTION
This worked out nicely instead of adding a dock-specific -dx section. If you're on the dx image this shows up, if not then it just doesn't show up.