### PR TITLE
fix: disable system flathub

### DIFF
--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -48,6 +48,7 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
   /usr/lib/fedora-third-party/fedora-third-party-opt-out
   /usr/bin/fedora-third-party disable
   flatpak remote-delete fedora --force
+  flatpak remote-modify flathub --disable --system
 
   FEDORA_FLATPAKS=$(flatpak list --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
   for flatpak in $FEDORA_FLATPAKS; do

--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -48,13 +48,15 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
   /usr/lib/fedora-third-party/fedora-third-party-opt-out
   /usr/bin/fedora-third-party disable
   flatpak remote-delete fedora --force
-  flatpak remote-modify flathub --disable --system
 
   FEDORA_FLATPAKS=$(flatpak list --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
   for flatpak in $FEDORA_FLATPAKS; do
     flatpak remove --system --noninteractive $flatpak
   done
 fi
+
+# Disable the system variant of the flathub repo
+flatpak remote-modify flathub --disable --system
 
 mkdir -p /etc/ublue
 echo $VER > $VER_FILE


### PR DESCRIPTION
Disables the system variant of the flathub flatpak repo. This way gnome-software will always prefer user flatpaks instead of system ones.