### PR TITLE
fix: enable ublue-update

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -48,7 +48,7 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/bling/repo/fedora-$(rp
     systemctl enable rpm-ostree-countme.service && \
     systemctl enable tailscaled.service && \
     systemctl enable dconf-update.service && \
-    systemctl disable ublue-update.timer && \
+    systemctl enable ublue-update.timer && \
     systemctl enable ublue-system-setup.service && \
     systemctl enable ublue-system-flatpak-manager.service && \
     systemctl --global enable ublue-user-flatpak-manager.service && \


### PR DESCRIPTION
The ublue-update service now rebases the unsigned images the correct way by preserving the installed tag. Tested on two fresh installed VM's. Output below after running the service.

```
Deployments:
  ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-dx:38
                   Digest: sha256:b6f9f6a8f9ef134fcc4a7634a652f764b54976af1f29ae0c766557a3c95fb695
                  Version: 38.20231003.0 (2023-10-03T19:29:48Z)

● ostree-unverified-registry:ghcr.io/ublue-os/bluefin-dx:38
                   Digest: sha256:b6f9f6a8f9ef134fcc4a7634a652f764b54976af1f29ae0c766557a3c95fb695
                  Version: 38.20231003.0 (2023-10-03T19:29:48Z)
```


```
Deployments:
  ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-dx:38
                   Digest: sha256:b6f9f6a8f9ef134fcc4a7634a652f764b54976af1f29ae0c766557a3c95fb695
                  Version: 38.20231003.0 (2023-10-03T19:29:48Z)

● ostree-unverified-image:docker://ghcr.io/ublue-os/bluefin-dx:38
                   Digest: sha256:b6f9f6a8f9ef134fcc4a7634a652f764b54976af1f29ae0c766557a3c95fb695
                  Version: 38.20231003.0 (2023-10-03T19:29:48Z)
```

Problems solved in PR https://github.com/ublue-os/ublue-update/pull/75