### PR TITLE
fix: Fix "Sort folders first" default in Nautilus

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -74,6 +74,9 @@ home=['<Super>e']
 [org/gnome/settings-daemon/plugins/power]
 power-button-action='interactive'
 
+[org/gtk/settings/file-chooser]
+sort-directories-first=true
+
 [org/gtk/gtk4/settings/file-chooser]
 sort-directories-first=true
 

--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -92,3 +92,8 @@ style-preference=2
 font="Ubuntu Mono 16"
 window-width=975
 window-height=650
+
+[org/gnome/software]
+allow-updates=false
+download-updates=false
+download-updates-notify=false

--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -92,8 +92,3 @@ style-preference=2
 font="Ubuntu Mono 16"
 window-width=975
 window-height=650
-
-[org/gnome/software]
-allow-updates=false
-download-updates=false
-download-updates-notify=false

--- a/usr/etc/dconf/db/local.d/locks/01-ublue-lock
+++ b/usr/etc/dconf/db/local.d/locks/01-ublue-lock
@@ -1,0 +1,4 @@
+[org/gnome/software]
+allow-updates=false
+download-updates=false
+download-updates-notify=false

--- a/usr/etc/dconf/db/local.d/locks/01-ublue-lock
+++ b/usr/etc/dconf/db/local.d/locks/01-ublue-lock
@@ -1,4 +1,0 @@
-[org/gnome/software]
-allow-updates=false
-download-updates=false
-download-updates-notify=false


### PR DESCRIPTION
This additional dconf is also needed for it to work (thanks to Akzel)