### PR TITLE
fix: Assure that "Sort folders first" default in Nautilus applies

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -74,6 +74,9 @@ home=['<Super>e']
 [org/gnome/settings-daemon/plugins/power]
 power-button-action='interactive'
 
+[org/gtk/settings/file-chooser]
+sort-directories-first=true
+
 [org/gtk/gtk4/settings/file-chooser]
 sort-directories-first=true
 


### PR DESCRIPTION
Additional dconf value is needed for it to work (thanks to Akzel)