### PR TITLE
feat: ship ublue-update default config

### DIFF
--- a/usr/etc/ublue-update/ublue-update.toml
+++ b/usr/etc/ublue-update/ublue-update.toml
@@ -1,0 +1,6 @@
+[checks]
+    min_battery_percent = 0.0
+    max_cpu_load_percent = 50.0
+    max_mem_percent = 90.0
+[notify]
+    dbus_notify = false


### PR DESCRIPTION
Ship a default config for ublue-update. Ignoring the battery levels and disables the notifications.