### PR TITLE
fix: typos in keyboard shortcut

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -68,7 +68,7 @@ command="flatpak run io.missioncenter.MissionCenter"
 name='mission-center'
 
 [org/gnome/settings-daemon/plugins/media-keys]
-custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', 'org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2']
+custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/']
 home=['<Super>e']
 
 [org/gnome/settings-daemon/plugins/power]


### PR DESCRIPTION
Should fix #564 

We missed some forward slashes, which leads to segfaults in `gsd-media-keys`. This only happend on bluefin, the bluefin-dx shortcuts where good.