### PR TITLE
fix: Only enable ublue-update on F39 builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -51,7 +51,11 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/bling/repo/fedora-$(rp
     systemctl enable rpm-ostree-countme.service && \
     systemctl enable tailscaled.service && \
     systemctl enable dconf-update.service && \
-    systemctl enable ublue-update.timer && \
+    if [ ${FEDORA_MAJOR_VERSION} -gt 38 ]; then \
+        systemctl enable ublue-update.timer \
+    ; else \
+        systemctl disable ublue-update.timer \
+    ; fi && \
     systemctl enable ublue-system-setup.service && \
     systemctl enable ublue-system-flatpak-manager.service && \
     systemctl --global enable ublue-user-flatpak-manager.service && \


### PR DESCRIPTION
 Gives us time to telegraph needed supporting changes downstream.