### PR TITLE
fix(toolbox): wolfi package conflict

### DIFF
--- a/toolboxes/Containerfile.wolfi
+++ b/toolboxes/Containerfile.wolfi
@@ -13,10 +13,8 @@ RUN apk update && \
     apk upgrade
 
 # Add Distrobox specific packages
-# Remove procps due to conflict with coreutils
-RUN apk del procps && \
-    apk add sudo-rs \
-        coreutils \
+RUN apk add sudo-rs \
+        procps \
         bash \
         bzip2 \
         curl \
@@ -49,7 +47,7 @@ RUN git clone https://github.com/89luca89/distrobox.git --single-branch /tmp/dis
     cp /tmp/distrobox/distrobox-host-exec /usr/bin/distrobox-host-exec && \
     wget https://github.com/1player/host-spawn/releases/download/$(cat /tmp/distrobox/distrobox-host-exec | grep host_spawn_version= | cut -d "\"" -f 2)/host-spawn-$(uname -m) -O /usr/bin/host-spawn && \
     chmod +x /usr/bin/host-spawn && \
-    rm -drf /tmp/distrobox && \
+    rm -rf /tmp/distrobox
 
 # Add optional packages
 RUN grep -v '^#' /toolbox-packages | xargs apk add


### PR DESCRIPTION
Should fix #560 

Still produces warnings `Warning: there was a problem setting up the user` but the distrobox seems usable again.