### PR TITLE
chore: Make brew-shell just command more accurate

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -40,14 +40,14 @@ brew-shell:
     echo "Brew configuration already present in .zprofile"
   else 
     echo "Adding Brew configuration to .zprofile"
-    echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> $HOME/.zprofile
+    echo 'eval "$(/var/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> $HOME/.zprofile
   fi
   if grep -q "linuxbrew" $HOME/.bash_profile
   then
     echo "Brew configuration already present in .bash_profile"
   else 
     echo "Adding Brew configuration to .bash_profile"
-    echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> $HOME/.bash_profile
+    echo 'eval "$(/var/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> $HOME/.bash_profile
   fi
 
 # Enable Cockpit for web-based system management | https://cockpit-project.org/


### PR DESCRIPTION
/var/home should be used rather than /home