### PR TITLE
chore: actually enable gnome-vrr on f39 builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -25,15 +25,13 @@ COPY image-info.sh /tmp/image-info.sh
 COPY usr/etc/ublue-update/ublue-update.toml /tmp/ublue-update.toml
 
 # GNOME VRR
-RUN if grep -qv "39" <<< "${FEDORA_MAJOR_VERSION}"; then \
-    wget https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/kylegospo-gnome-vrr-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo && \
+RUN wget https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/kylegospo-gnome-vrr-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo && \
     if [ ${FEDORA_MAJOR_VERSION} -lt 39 ]; then \
         rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr mutter mutter-common gnome-control-center gnome-control-center-filesystem xorg-x11-server-Xwayland \
     ; else \
         rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr mutter mutter-common gnome-control-center gnome-control-center-filesystem \
     ; fi && \
-    rm -f /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo \
-    ; fi
+    rm -f /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo
 
 # Starship Shell Prompt
 RUN curl -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz" && \


### PR DESCRIPTION
Let's get vrr installed for all versions, it should be compatible.

The checks where in there, but it only acted on non 39 builds to go in there. By removing the check at the top we give f39 builds a fair chance. 

And it seems to work out seeing the green builds. Perfect.