### PR TITLE
fix: flatpak-manager exit and retry on failure

### DIFF
--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -11,8 +11,6 @@ if [[ -f $VER_FILE && $VER = $VER_RAN ]]; then
   exit 0
 fi
 
-notify-send "Flatpak installer" "Currently installing system flatpaks" --app-name="Flatpak installer" -u NORMAL
-
 # Remove fedora flatpak repo
 if grep -qz 'fedora' <<< $(flatpak remotes); then
   flatpak remote-delete --user fedora --force
@@ -27,12 +25,13 @@ REMOVE_LIST=$(cat /etc/flatpak/system/remove)
 if [[ -n $INSTALL_LIST ]]; then
   for flatpak in $INSTALL_LIST; do
     if grep -qvz $flatpak <<< $FLATPAK_LIST; then
-      flatpak install --system --noninteractive flathub $flatpak
+      if ! flatpak install --system --noninteractive flathub $flatpak; then
+        # exit on error
+        exit 1
+      fi
     fi
   done
 fi
-
-notify-send "Flatpak installer" "Finished installing system flatpaks" --app-name="Flatpak installer" -u NORMAL
 
 # Remove flatpaks in list
 if [[ -n $REMOVE_LIST ]]; then
@@ -51,12 +50,17 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
 
   FEDORA_FLATPAKS=$(flatpak list --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
   for flatpak in $FEDORA_FLATPAKS; do
-    flatpak remove --system --noninteractive $flatpak
+    if ! flatpak remove --system --noninteractive $flatpak; then
+      # exit on error
+      exit 1
+    fi
   done
 fi
 
 # Disable the system variant of the flathub repo
 flatpak remote-modify flathub --disable --system
+
+notify-send "Flatpak installer" "Finished installing system flatpaks" --app-name="Flatpak installer" -u NORMAL
 
 mkdir -p /etc/ublue
 echo $VER > $VER_FILE

--- a/usr/bin/ublue-user-flatpak-manager
+++ b/usr/bin/ublue-user-flatpak-manager
@@ -19,27 +19,30 @@ FLATPAK_LIST=$(flatpak list --columns=application)
 INSTALL_LIST=$(cat /etc/flatpak/user/install)
 REMOVE_LIST=$(cat /etc/flatpak/user/remove)
 
-notify-send "Flatpak installer" "Currently installing user flatpaks" --app-name="Flatpak installer" -u NORMAL
-
 # Install flatpaks in list
 if [[ -n $INSTALL_LIST ]]; then
   for flatpak in $INSTALL_LIST; do
     if grep -qvz $flatpak <<< $FLATPAK_LIST; then
-      flatpak install --user --noninteractive flathub $flatpak
+      if ! flatpak install --user --noninteractive flathub $flatpak; then
+        # exit on error
+        exit 1
+      fi
     fi
   done
 fi
-
-notify-send "Flatpak installer" "Finished installing user flatpaks" --app-name="Flatpak installer" -u NORMAL
-
 
 # Remove flatpaks in list
 if [[ -n $REMOVE_LIST ]]; then
   for flatpak in $REMOVE_LIST; do
     if grep -qz $flatpak <<< $FLATPAK_LIST; then
-      flatpak remove --user --noninteractive $flatpak
+      if ! flatpak remove --user --noninteractive $flatpak; then
+        # exit on error
+        exit 1
+      fi
     fi
   done
 fi
+
+notify-send "Flatpak installer" "Finished installing user flatpaks" --app-name="Flatpak installer" -u NORMAL
 
 echo $VER > $VER_FILE

--- a/usr/lib/systemd/system/ublue-system-flatpak-manager.service
+++ b/usr/lib/systemd/system/ublue-system-flatpak-manager.service
@@ -8,6 +8,8 @@ After=network-online.target ublue-system-setup.service
 Type=oneshot
 ExecStart=/usr/bin/ublue-system-flatpak-manager
 Restart=on-failure
+RestartSec=30
+StartLimitInterval=0
 
 [Install]
 WantedBy=multi-user.target

--- a/usr/lib/systemd/user/ublue-user-flatpak-manager.service
+++ b/usr/lib/systemd/user/ublue-user-flatpak-manager.service
@@ -8,6 +8,8 @@ After=network-online.target
 Type=oneshot
 ExecStart=/usr/bin/ublue-user-flatpak-manager
 Restart=on-failure
+RestartSec=30
+StartLimitInterval=0
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
In the current setup the flatpak-user-manager will always write a "lock" file, even if commands failed to run. 

The new version exits on an error so it will not write the lock file and it will try again later. 5 times via systemd and otherwise it tries again on reboot.

I removed the start install notification, because it will flood your notifications on retries and moved the finished notifcation right above the write of the lock file. 

And add the same changes to flatpak-system-manager too.