### PR TITLE
Use `usermod` instead of `lchsh` in custom.just

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -107,7 +107,8 @@ distrobox-universal:
 
 # Switch to the fish shell
 fish:
-  sudo lchsh $USER /usr/bin/fish 
+  sudo usermod $USER --shell /usr/bin/fish 
+  printf "${USER}'s shell is now %s." "$(cat /etc/passwd | grep ":$UID:" | cut '-d:' '-f7')"
 
 # Install recommended GNOME extensions
 gnome-extensions:
@@ -155,7 +156,8 @@ nix-devbox-global:
 podmansh:
   sudo mkdir -p /etc/containers/systemd/users/${UID}
   sudo cp /usr/share/ublue-os/quadlets/podmansh.container /etc/containers/systemd/users/${UID}/podmansh.container
-  sudo lchsh $USER /usr/bin/podmansh
+  sudo usermod $USER --shell /usr/bin/podmansh
+  printf "${USER}'s shell is now %s." "$(cat /etc/passwd | grep ":$UID:" | cut '-d:' '-f7')"
   podman pull ghcr.io/ublue-os/ubuntu-toolbox:latest
   
   systemctl --user daemon-reload
@@ -215,7 +217,8 @@ yafti:
 
 # Switch to the zsh shell
 zsh:
-  sudo lchsh $USER /usr/bin/zsh 
+  sudo usermod $USER --shell /usr/bin/zsh 
+  printf "${USER}'s shell is now %s." "$(cat /etc/passwd | grep ":$UID:" | cut '-d:' '-f7')"
 
 docker:
   sudo systemctl enable --now docker


### PR DESCRIPTION
This fixes #408 (`just fish` and `just zsh` failing). The problem (and the reason that #420 doesn't fix it) is because the `lchsh` command actually doesn't accept the new shell as a CLI argument at all!

Another way to do this (and continue using `lchsh`) would be to instead run the commands as, e.g., `echo /usr/bin/zsh | sudo lchsh $USER`, but this results in an empty (and thus slightly misleading) prompt being shown to the user:

```console
$ echo /usr/bin/zsh | sudo lchsh $USER
[sudo] password for bri: 
Changing shell for bri.
New Shell [/usr/bin/zsh]: Shell changed.
```

If we just use `usermod` it doesn't actually give any feedback, so I also threw in a little posix pipe to parse the shell back out of /etc/passwd after.