### PR TITLE
fix: flatpak-manager may fail on removal

### DIFF
--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -50,10 +50,7 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
 
   FEDORA_FLATPAKS=$(flatpak list --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
   for flatpak in $FEDORA_FLATPAKS; do
-    if ! flatpak remove --system --noninteractive $flatpak; then
-      # exit on error
-      exit 1
-    fi
+    flatpak remove --system --noninteractive $flatpak
   done
 fi
 

--- a/usr/bin/ublue-user-flatpak-manager
+++ b/usr/bin/ublue-user-flatpak-manager
@@ -35,10 +35,7 @@ fi
 if [[ -n $REMOVE_LIST ]]; then
   for flatpak in $REMOVE_LIST; do
     if grep -qz $flatpak <<< $FLATPAK_LIST; then
-      if ! flatpak remove --user --noninteractive $flatpak; then
-        # exit on error
-        exit 1
-      fi
+      flatpak remove --user --noninteractive $flatpak
     fi
   done
 fi

--- a/usr/etc/flatpak/system/remove
+++ b/usr/etc/flatpak/system/remove
@@ -1,0 +1,2 @@
+org.gnome.Cheese
+org.gnome.eog

--- a/usr/etc/flatpak/user/remove
+++ b/usr/etc/flatpak/user/remove
@@ -1,2 +1,0 @@
-org.gnome.Cheese
-org.gnome.eog


### PR DESCRIPTION
After adding error checking in the flatpak-managers I've spotted two issues. 

Due to the new error check it will always fail if it wants to remove a package that does not exist on the system. This can lead to problems so I've removed the error check on removal.

Another thing I spotted (via the now removed error check) that we wanted to remove system flatpaks via the user remove list, which errors out. So I moved them to the system remove list.

Below an example of what was happening.
```
❯ flatpak remove --user org.gnome.Cheese
error: No installed refs found for ‘org.gnome.Cheese’

~ 
❯ flatpak remove --system org.gnome.Cheese


        ID                     Branch       Op
 1.     org.gnome.Cheese       stable       r

Proceed with these changes to the system installation? [Y/n]: n
```

You may ask why did the `org.gnome.Cheese` was still being removed? This is because we do another loop in system, that goes over all the fedora repo packages and remove them. So in the end it was being removed, but not via the intent of the remove list.
```
  FEDORA_FLATPAKS=$(flatpak list --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
  for flatpak in $FEDORA_FLATPAKS; do
    flatpak remove --system --noninteractive $flatpak; then
  done
```

So lets keep only error checks on installation. This way it may give an error when the package does not exists when we want to remove it. But keep the error checks on installation, to make sure packages are being installed.