### PR TITLE
fix: split flatpak app and runtime removal

### DIFF
--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -48,7 +48,14 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
   /usr/bin/fedora-third-party disable
   flatpak remote-delete fedora --force
 
-  FEDORA_FLATPAKS=$(flatpak list --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
+  # Remove flatpak apps from origin fedora
+  FEDORA_FLATPAKS=$(flatpak list --app --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
+  for flatpak in $FEDORA_FLATPAKS; do
+    flatpak remove --system --noninteractive $flatpak
+  done
+
+  # Remove flatpak runtimes from origin fedora
+  FEDORA_FLATPAKS=$(flatpak list --runtime --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
   for flatpak in $FEDORA_FLATPAKS; do
     flatpak remove --system --noninteractive $flatpak
   done


### PR DESCRIPTION
Currently when we remove system flatpaks from the fedora repo (which we replace with flathub ones). There is always one flatpak that doesn't get removed. That is `org.fedoraproject.Platform` which is the runtime for other applications. 

Because we currently remove them at the same time, the runtime will not be removed, because it is needed for apps which are not yet removed. 

```
flatpak list
Name                    Application ID                    Version        Branch        Installation
Fedora Platform         org.fedoraproject.Platform        38             f38           system
```

```
Uninstalling runtime/org.fedoraproject.Platform/x86_64/f38
Error: Failed to uninstall org.fedoraproject.Platform: Can't remove org.fedoraproject.Platform/x86_64/f38, it is needed for: org.gnome.Calculator, org.gnome.Calendar, org.gnome.Characters, org.gnome.Connections, org.gnome.Contacts, org.gnome.Evince, org.gnome.Extensions, org.gnome.Logs, org.gnome.Maps, org.gnome.NautilusPreviewer, org.gnome.TextEditor, org.gnome.Weather, org.gnome.baobab, org.gnome.clocks, org.gnome.font-viewer
```

To solve this problem I have split up the removal part. First remove the applications, and after that remove the runtime. 