### PR TITLE
fix: handle removal of multiple branches of same runtime

### DIFF
--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -55,7 +55,7 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
   done
 
   # Remove flatpak runtimes from origin fedora
-  FEDORA_FLATPAKS=$(flatpak list --runtime --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
+  FEDORA_FLATPAKS=$(flatpak list --runtime --columns=application,arch,branch,origin | grep -w 'fedora' | awk '{print $1"/"$2"/"$3}')
   for flatpak in $FEDORA_FLATPAKS; do
     flatpak remove --system --noninteractive $flatpak
   done


### PR DESCRIPTION
Current setup works great if you only have one installed branch version, for example f38. But leads to problems when multiple are installed. 

```
flatpak remove org.fedoraproject.Platform
Similar installed refs found for ‘org.fedoraproject.Platform’:

   1) runtime/org.fedoraproject.Platform/x86_64/f38 (system)
   2) runtime/org.fedoraproject.Platform/x86_64/f39 (system)
   3) All of the above

Which do you want to use (0 to abort)? [0-3]: 0 
```

This PR adds the branch and the arch of the runtime, so it knows which one to remove.