### PR TITLE
fix: improve flatpak-manager to use less commands

### DIFF
--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -23,23 +23,15 @@ REMOVE_LIST=$(cat /etc/flatpak/system/remove)
 
 # Install flatpaks in list
 if [[ -n $INSTALL_LIST ]]; then
-  for flatpak in $INSTALL_LIST; do
-    if grep -qvz $flatpak <<< $FLATPAK_LIST; then
-      if ! flatpak install --system --noninteractive flathub $flatpak; then
-        # exit on error
-        exit 1
-      fi
-    fi
-  done
+  if ! flatpak install --system --noninteractive flathub ${INSTALL_LIST[@]}; then
+    # exit on error
+    exit 1
+  fi
 fi
 
 # Remove flatpaks in list
 if [[ -n $REMOVE_LIST ]]; then
-  for flatpak in $REMOVE_LIST; do
-    if grep -qz $flatpak <<< $FLATPAK_LIST; then
-      flatpak remove --system --noninteractive $flatpak
-    fi
-  done
+  flatpak remove --system --noninteractive ${REMOVE_LIST[@]}
 fi
 
 # Opt out of and remove Fedora's flatpak repo
@@ -50,15 +42,11 @@ if grep -qz 'fedora' <<< $(flatpak remotes); then
 
   # Remove flatpak apps from origin fedora
   FEDORA_FLATPAKS=$(flatpak list --app --columns=application,origin | grep -w 'fedora' | awk '{print $1}')
-  for flatpak in $FEDORA_FLATPAKS; do
-    flatpak remove --system --noninteractive $flatpak
-  done
+  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
 
   # Remove flatpak runtimes from origin fedora
   FEDORA_FLATPAKS=$(flatpak list --runtime --columns=application,arch,branch,origin | grep -w 'fedora' | awk '{print $1"/"$2"/"$3}')
-  for flatpak in $FEDORA_FLATPAKS; do
-    flatpak remove --system --noninteractive $flatpak
-  done
+  flatpak remove --system --noninteractive ${FEDORA_FLATPAKS[@]}
 fi
 
 # Disable the system variant of the flathub repo

--- a/usr/bin/ublue-user-flatpak-manager
+++ b/usr/bin/ublue-user-flatpak-manager
@@ -21,23 +21,15 @@ REMOVE_LIST=$(cat /etc/flatpak/user/remove)
 
 # Install flatpaks in list
 if [[ -n $INSTALL_LIST ]]; then
-  for flatpak in $INSTALL_LIST; do
-    if grep -qvz $flatpak <<< $FLATPAK_LIST; then
-      if ! flatpak install --user --noninteractive flathub $flatpak; then
-        # exit on error
-        exit 1
-      fi
-    fi
-  done
+  if ! flatpak install --user --noninteractive flathub ${INSTALL_LIST[@]}; then
+    # exit on error
+    exit 1
+  fi
 fi
 
 # Remove flatpaks in list
 if [[ -n $REMOVE_LIST ]]; then
-  for flatpak in $REMOVE_LIST; do
-    if grep -qz $flatpak <<< $FLATPAK_LIST; then
-      flatpak remove --user --noninteractive $flatpak
-    fi
-  done
+  flatpak remove --user --noninteractive ${REMOVE_LIST[@]}
 fi
 
 notify-send "Flatpak installer" "Finished installing user flatpaks" --app-name="Flatpak installer" -u NORMAL


### PR DESCRIPTION
Instead of running a single `flatpak install/remove` command for every package. Try use a single command with all the packages. This seems to improve the stability a lot. 

I've tried multiple fresh installs with this code. And every time I end up with the same  packages that are listed in the `flatpak/user/install` file.