### PR TITLE
feat: Enable Fedora 39 Surface images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,6 @@ jobs:
             is_latest_version: true
             is_stable_version: false
             is_gts_version: false
-        exclude:
-          - image_flavor: surface
-            major_version: 39
-          - image_flavor: surface-nvidia
-            major_version: 39
     steps:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6


### PR DESCRIPTION
Now that the Surface kernel is available on Fedora 39, these can be enabled