### PR TITLE
revert: "feat: swap out tailscale extension"

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -13,7 +13,7 @@
 				"gnome-shell-extension-blur-my-shell",
 				"gnome-shell-extension-dash-to-dock",
 				"gnome-shell-extension-gsconnect",
-				"gnome-shell-extension-tailscale-gnome-qs",
+				"gnome-shell-extension-tailscale-status",
 				"input-remapper",
 				"libgda-sqlite",
 				"libgda",


### PR DESCRIPTION
Reverts ublue-os/bluefin#593

The COPR only builds GNOME 45+ versions, this should be 39 only.