### PR TITLE
chore: steamdeck rpm cleanup

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -50,9 +50,7 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
     ; fi && \
     rpm-ostree install \
         /tmp/akmods-rpms/kmods/*evdi*.rpm && \
-    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo && \
-    mkdir -p /etc/akmods-rpms/ && \
-    mv /tmp/akmods-rpms/kmods/*steamdeck*.rpm /etc/akmods-rpms/steamdeck.rpm
+    sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 
 # Starship Shell Prompt
 RUN curl -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz" && \


### PR DESCRIPTION
I think this was not added on purpose and thus can be cleaned up. 

Or do we have the intention to ship steamdeck.rpm on our image and did I miss something?
