### PR TITLE
chore(just): add docker description

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -236,6 +236,7 @@ zsh:
   sudo usermod $USER --shell /usr/bin/zsh 
   printf "${USER}'s shell is now %s." "$(cat /etc/passwd | grep ":$UID:" | cut '-d:' '-f7')"
 
+# Enable docker on the system
 docker:
   sudo systemctl enable --now docker
   sudo usermod -aG docker $USER


### PR DESCRIPTION
The `just docker` command didn't have a description when the user types `just` to list all the commands available.