### PR TITLE
fix: exclude evdi on asus

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -48,8 +48,10 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
             /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
             /tmp/akmods-rpms/kmods/*wl*.rpm \
     ; fi && \
-    rpm-ostree install \
-        /tmp/akmods-rpms/kmods/*evdi*.rpm && \
+    if grep -qv "asus" <<< "${AKMODS_FLAVOR}"; then \
+        rpm-ostree install \
+            /tmp/akmods-rpms/kmods/*evdi*.rpm && \
+    ; fi && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 
 # Starship Shell Prompt

--- a/Containerfile
+++ b/Containerfile
@@ -51,7 +51,7 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
     # Don't install evdi on asus because of conflicts
     if grep -qv "asus" <<< "${AKMODS_FLAVOR}"; then \
         rpm-ostree install \
-            /tmp/akmods-rpms/kmods/*evdi*.rpm && \
+            /tmp/akmods-rpms/kmods/*evdi*.rpm \
     ; fi && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 

--- a/Containerfile
+++ b/Containerfile
@@ -48,6 +48,7 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
             /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
             /tmp/akmods-rpms/kmods/*wl*.rpm \
     ; fi && \
+    # Don't install evdi on asus because of conflicts
     if grep -qv "asus" <<< "${AKMODS_FLAVOR}"; then \
         rpm-ostree install \
             /tmp/akmods-rpms/kmods/*evdi*.rpm && \


### PR DESCRIPTION
Asus builds are currently failing, because it can't find the the evdi rpm to install. Because of conflicts with the asus kernel it is disabled in the akmods repo.

- https://github.com/ublue-os/akmods/pull/87

This PR will disable the installation of the evdi rpm on asus images.