### PR TITLE
chore(ci): improve queue by canceling jobs

### DIFF
--- a/.github/workflows/build-fedora-toolbox.yml
+++ b/.github/workflows/build-fedora-toolbox.yml
@@ -10,6 +10,10 @@ env:
     IMAGE_TAGS: latest
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   push-ghcr:
     name: Build and push image

--- a/.github/workflows/build-ubuntu-toolbox.yml
+++ b/.github/workflows/build-ubuntu-toolbox.yml
@@ -10,6 +10,10 @@ env:
     IMAGE_TAGS: latest
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   push-ghcr:
     name: Build and push image

--- a/.github/workflows/build-wolfi-toolbox.yml
+++ b/.github/workflows/build-wolfi-toolbox.yml
@@ -10,6 +10,10 @@ env:
     IMAGE_TAGS: latest
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   push-ghcr:
     name: Build and push image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,10 @@ on:
 env:
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   push-ghcr:
     name: Make


### PR DESCRIPTION
Yesterday I noticed when I made a typo, and pushed a commit into my PR, the actions keep on running. Which make no sense when there is a new commit, and with 28 images builds per commit, the queue would be pretty full after a few commits. Building stuff that doesn't matter anymore. 

I've found the following documentation and tried to implement it on my personal fork to see if this would work. 
https://docs.github.com/en/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow

It did work perfect, so I would like to try it out here. If this works good here, it would definitely  something to implement for other repo's building a lot of images to keep the queue clean.

Hope it works out as intended here, it would be a big improved. If not well, we can revert this PR.