### PR TITLE
feat(just): add fleek/homebrew shortcut

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -23,6 +23,11 @@ aqua:
   printf '\n    export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"\n'
   printf '\n=> see https://aquaproj.github.io/docs/tutorial for more info\n'
 
+# Install the BLuefin CLI experience, powered by Homebrew and Fleek
+bluefin-cli:
+  echo "Installing Homebrew and Fleek ..."
+  curl --proto '=https' --tlsv1.2 -sSf -L https://brew.getfleek.dev/s/fleek | bash -s -- high
+
 # Install Homebrew for Linux
 brew:
   echo "Installing homebrew ..."


### PR DESCRIPTION
This will oneshot homebrew and fleek. We need to have our own profile at some point but this lets people play with it right away.

Our profile would need to be adjusted (for example git's already on the image, it doesn't need to be in here, but there's stuff on the image we might wanna move into here, like the k8s tools, etc.)