### PR TITLE
fix: turn off gnome vrr by default

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -81,7 +81,7 @@ sort-directories-first=true
 sort-directories-first=true
 
 [org/gnome/mutter]
-experimental-features=['variable-refresh-rate','scale-monitor-framebuffer']
+experimental-features=['scale-monitor-framebuffer']
 
 [com/raggesilver/BlackBox]
 command-as-login-shell=true


### PR DESCRIPTION
This still appears to be problematic for some users, so let's just shut it off by default. The new `just gnome-vrr` is still there for people who want to opt in.