### PR TITLE
chore: add an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,36 @@
+name: Bug Report
+description: Report an issue about using Bluefin
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to fill out this bug report! (She bites sometimes)
+  - type: textarea
+    id: describe-bug
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what happened!
+      value: "When I entered 2 + 2, I got the answer 6."
+    validations:
+      required: true
+  - type: textarea
+    id: expected-bahavior
+    attributes:
+      label: What did you expect to happen?
+      description: A clear and concise description of what you expected to happen.
+      placeholder: What were you expecting to happen?
+      value: "I expected 2 + 2 to equal 4, but instead 2 + 2 equaled 6!"
+    validations:
+      required: true
+  - type: textarea
+    id: version
+    attributes:
+      label: Output of `rpm-ostree status`
+      description: Please run `rpm-ostree status` and paste the output here.
+      render: shell
+  - type: textarea
+    id: extra-context
+    attributes:
+      label: Extra information or context
+      description: Add any other context about the problem here.


### PR DESCRIPTION
We need to get more info on incoming bug reports, this at leasts asks them to put in an `rpm-ostree status`