### PR TITLE
fix: add missing virt-viewer for -dx

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -116,7 +116,8 @@
 				"systemtap",
 				"ubuntu-nerd-fonts",
 				"ubuntumono-nerd-fonts",
-				"virt-manager"
+				"virt-manager",
+				"virt-viewer"
 			]
 		},
 		"exclude": {


### PR DESCRIPTION
virt-viewer is required to connect to spice consoles for incus and lxd virtual machines.