### PR TITLE
fix(dx): improve distrobox-enter wrapper

### DIFF
--- a/dx/usr/bin/bluefinbox-enter
+++ b/dx/usr/bin/bluefinbox-enter
@@ -19,11 +19,8 @@ if [ "$container_exists" -eq 0 ]; then
     # No need to assemble, enjoy your stay
     exec distrobox enter "${container_name}"
 else
-    # We don't have the container so we assemble it first. With distrobox version 1.5.0.2 
-    # or below we need to assemble all the entries that occur in the `distrobox.ini` manifest. 
-    # In future versions of distrobox we will be able to specify `--name $container_name` to
-    # only assemble the box we want to enter.
-    distrobox assemble create --replace --file /etc/distrobox/distrobox.ini
+    # We don't have the container so we assemble it first.
+    distrobox assemble create --name "${container_name}" --replace --file /etc/distrobox/distrobox.ini
 
     # All done, good to go
     exec distrobox enter "${container_name}"


### PR DESCRIPTION
With distrobox 1.6 entering stable soon, we are able to assemble a distrobox specified by `--name` instead of assembling them all at once. This means when hitting the keyboard shortcut for entering a fedora distrobox it will only assemble the fedora one.

~As long as distrobox 1.6 is not in stable leave this as draft.~
distrobox 1.6 is now available on the image, so this can be merged.
`distrobox-1.6.0.1-1.fc39.noarch`

Follow up on 
- https://github.com/ublue-os/bluefin/pull/439