### PR TITLE
feat(just): add garden.io

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -152,25 +152,27 @@ jetbrains-toolbox:
 # Install garden.io, the Cloud Native DevOps automation platform | https://garden.io
 garden:
     #!/usr/bin/env bash
-    command -v garden &> /dev/null || (
-      ASSET_URL=$(curl -s https://api.github.com/repos/garden-io/garden/releases/latest | \
-        jq -r '.assets[] | select(.browser_download_url | test("linux-amd64.tar.gz$")) | .browser_download_url')
-      curl -sSL $ASSET_URL | tar xz && \
-      GARDEN_DIR=${HOME}/.garden
-      TARGET_PATH=${GARDEN_DIR}/bin
-      mkdir -p "${GARDEN_DIR}"
-      mv linux-amd64/* "${TARGET_PATH}")
+    if ! command -v garden &> /dev/null; then
+        ASSET_URL=$(curl -s https://api.github.com/repos/garden-io/garden/releases/latest | \
+            jq -r '.assets[] | select(.browser_download_url | test("linux-amd64.tar.gz$")) | .browser_download_url')
+        GARDEN_DIR="${HOME}/.garden/bin"
+        TMP_DIR=$(mktemp -d)
+        curl -sSL "$ASSET_URL" | tar -xz -C "$TMP_DIR"
+        mkdir -p "$GARDEN_DIR"
+        mv "$TMP_DIR"/linux-amd64/garden "$GARDEN_DIR"
+        rm -rf "$TMP_DIR"
 
-    echo ""
-    echo "🌺🌻  Garden has been successfully installed 🌷💐"
-    echo ""
-    echo "Add the Garden CLI to your path by adding the following to your .bashrc/.zshrc:"
-    echo ""
-    echo "  export PATH=\$PATH:\$HOME/.garden/bin"
-    echo ""
-    echo "Head over to our documentation for next steps: https://docs.garden.io"
-    echo ""
-    
+        echo ""
+        echo "🌺🌻  Garden has been successfully installed 🌷💐"
+        echo ""
+        echo "Add the Garden CLI to your path by adding the following to your .bashrc/.zshrc:"
+        echo ""
+        echo "  export PATH=\$PATH:\$HOME/.garden/bin"
+        echo ""
+        echo "Head over to our documentation for next steps: https://docs.garden.io"
+        echo ""
+    fi
+
 # Install nix and Devbox
 nix-devbox:
     echo 'Setting phasers to kill. Installing nix.'

--- a/just/custom.just
+++ b/just/custom.just
@@ -150,16 +150,27 @@ jetbrains-toolbox:
     ./jetbrains-toolbox-"${BUILD_VERSION}"/jetbrains-toolbox
 
 # Install garden.io, the Cloud Native DevOps automation platform | https://garden.io
-  #!/usr/bin/env bash
-  command -v garden &> /dev/null || (
-    ASSET_URL=$(curl -s https://api.github.com/repos/garden-io/garden/releases/latest | \
-      jq -r '.assets[] | select(.browser_download_url | test("linux-amd64.tar.gz$")) | .browser_download_url')
-    curl -sSL $ASSET_URL | tar xz && \
-    GARDEN_DIR=${HOME}/.garden
-    TARGET_PATH=${GARDEN_DIR}/bin
-    mkdir -p "${GARDEN_DIR}"
-    mv linux-amd64/* "${TARGET_PATH}"
+garden:
+    #!/usr/bin/env bash
+    command -v garden &> /dev/null || (
+      ASSET_URL=$(curl -s https://api.github.com/repos/garden-io/garden/releases/latest | \
+        jq -r '.assets[] | select(.browser_download_url | test("linux-amd64.tar.gz$")) | .browser_download_url')
+      curl -sSL $ASSET_URL | tar xz && \
+      GARDEN_DIR=${HOME}/.garden
+      TARGET_PATH=${GARDEN_DIR}/bin
+      mkdir -p "${GARDEN_DIR}"
+      mv linux-amd64/* "${TARGET_PATH}")
 
+    echo ""
+    echo "🌺🌻  Garden has been successfully installed 🌷💐"
+    echo ""
+    echo "Add the Garden CLI to your path by adding the following to your .bashrc/.zshrc:"
+    echo ""
+    echo "  export PATH=\$PATH:\$HOME/.garden/bin"
+    echo ""
+    echo "Head over to our documentation for next steps: https://docs.garden.io"
+    echo ""
+    
 # Install nix and Devbox
 nix-devbox:
     echo 'Setting phasers to kill. Installing nix.'

--- a/just/custom.just
+++ b/just/custom.just
@@ -149,6 +149,17 @@ jetbrains-toolbox:
     echo "Launching JetBrains Toolbox"
     ./jetbrains-toolbox-"${BUILD_VERSION}"/jetbrains-toolbox
 
+# Install garden.io, the Cloud Native DevOps automation platform | https://garden.io
+  #!/usr/bin/env bash
+  command -v garden &> /dev/null || (
+    ASSET_URL=$(curl -s https://api.github.com/repos/garden-io/garden/releases/latest | \
+      jq -r '.assets[] | select(.browser_download_url | test("linux-amd64.tar.gz$")) | .browser_download_url')
+    curl -sSL $ASSET_URL | tar xz && \
+    GARDEN_DIR=${HOME}/.garden
+    TARGET_PATH=${GARDEN_DIR}/bin
+    mkdir -p "${GARDEN_DIR}"
+    mv linux-amd64/* "${TARGET_PATH}"
+
 # Install nix and Devbox
 nix-devbox:
     echo 'Setting phasers to kill. Installing nix.'


### PR DESCRIPTION
This adds an easy install command for [garden.io](garden.io), a Cloud Native tool enabling portable pipelines, ephemeral Kubernetes clusters, powerful remote K8s workflows, templating and more.

Disclaimer: I am the Head of DevRel at [garden.io](garden.io).