### PR TITLE
fix(toolbox/ubuntu): add missing distrobox dependency

### DIFF
--- a/toolboxes/packages.ubuntu
+++ b/toolboxes/packages.ubuntu
@@ -94,3 +94,4 @@ libxdmcp6
 libxext6
 libxfixes3
 libxml2
+pigz


### PR DESCRIPTION
Adds a missing dependency on the startup of the ubuntu container when launched with distrobox. This avoids the need of installing it when opening the box the first time. 