### PR TITLE
fix(ci): never skip successful builds check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,9 +206,14 @@ jobs:
 
   check:
     name: Check all builds successful
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     needs: [push-ghcr]
     steps:
+      - name: Exit on failure
+        if: ${{ needs.push-ghcr.result == 'failure' }}
+        shell: bash
+        run: exit 1
       - name: Exit
         shell: bash
         run: exit 0


### PR DESCRIPTION
In some situations the general `Check all builds successful` will be skipped. There for it is possible that the required check in the PR will be ignored, even if a build is not build successful.

This implementation will ensure that the check is always run, unless it is canceled. When it runs it checks the result for failure. 

It should only turn green if all builds are green.