### PR TITLE
fix(just): name bluefin-cli -> bluefin

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -29,7 +29,7 @@ bluefin-cli:
     if [ ! -f "${HOME}/.brew_pkgs" ]; then
        echo dysk > "${HOME}/.brew_pkgs"
     fi;
-    distrobox-create --nvidia --image ghcr.io/ublue-os/bluefin-cli:latest -n bluefin-cli -Y -a "--env BREW_PKGS=.brew_pkgs"
+    distrobox-create --nvidia --image ghcr.io/ublue-os/bluefin-cli:latest -n bluefin -Y -a "--env BREW_PKGS=.brew_pkgs"
     echo "Entering bluefin-cli"
     distrobox enter bluefin-cli
 


### PR DESCRIPTION
Cleaner on the prompt if it's named this way.