### PR TITLE
feat: Add Logo Menu & Prepare for Prompt future

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -13,6 +13,8 @@
 				"gnome-shell-extension-dash-to-dock",
 				"gnome-shell-extension-gsconnect",
 				"gnome-shell-extension-tailscale-status",
+				"gnome-shell-extension-logo-menu",
+				"nautilus-open-any-terminal",
 				"hplip",
 				"ifuse",
 				"input-remapper",
@@ -106,6 +108,7 @@
 				"gnome-extensions-app",
 				"gnome-software-rpm-ostree",
 				"gnome-tour",
+				"gnome-terminal-nautilus",
 				"ublue-os-update-services"
 			],
 			"bluefin-dx": []

--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -1,6 +1,6 @@
 [org/gnome/shell] 
 favorite-apps = ['org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Rhythmbox3.desktop', 'org.libreoffice.LibreOffice.writer.desktop', 'org.gnome.Software.desktop', 'code.desktop', 'ubuntu.desktop', 'yelp.desktop']
-enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'dash-to-dock@micxgx.gmail.com', 'blur-my-shell@aunetx', 'gsconnect@andyholmes.github.io']
+enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'dash-to-dock@micxgx.gmail.com', 'blur-my-shell@aunetx', 'gsconnect@andyholmes.github.io', 'logomenu@aryan_k']
 
 [org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/bluefin/bluefin-winter-dynamic.xml'
@@ -97,3 +97,8 @@ window-height=650
 allow-updates=false
 download-updates=false
 download-updates-notify=false
+
+[org/gnome/shell/extensions/Logo-menu]
+menu-button-icon-image=1
+menu-button-system-monitor='flatpak run io.missioncenter.MissionCenter'
+menu-button-extensions-app='com.mattjakeman.ExtensionManager.desktop'


### PR DESCRIPTION
Split off from the Prompt PR, this is the LogoMenu and Nautilus extension changes only, with any prompt-specific changes removed.