### PR TITLE
chore(flatpak-manager): Only remove flatpaks a single time

### DIFF
--- a/usr/bin/ublue-system-flatpak-manager
+++ b/usr/bin/ublue-system-flatpak-manager
@@ -33,8 +33,8 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
   fi
 fi
 
-# Remove flatpaks in list
-if [[ -f $REMOVE_LIST_FILE ]]; then
+# Remove flatpaks in list once
+if [[ ! -f $VER_FILE && -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo $FLATPAK_LIST | grep -f - $REMOVE_LIST_FILE)
   if [[ -n $REMOVE_LIST ]]; then
     flatpak remove --system --noninteractive ${REMOVE_LIST[@]}

--- a/usr/bin/ublue-user-flatpak-manager
+++ b/usr/bin/ublue-user-flatpak-manager
@@ -30,8 +30,8 @@ if [[ -f $INSTALL_LIST_FILE ]]; then
   fi
 fi
 
-# Remove flatpaks in list
-if [[ -f $REMOVE_LIST_FILE ]]; then
+# Remove flatpaks in list once
+if [[ ! -f $VER_FILE && -f $REMOVE_LIST_FILE ]]; then
   REMOVE_LIST=$(echo $FLATPAK_LIST | grep -f - $REMOVE_LIST_FILE)
   if [[ -n $REMOVE_LIST ]]; then
     flatpak remove --user --noninteractive ${REMOVE_LIST[@]}


### PR DESCRIPTION
Someone may choose to install a flatpak on the removal list intentionally, in which case we don't want to forcibly remove it

This verifies the version file exists following a successful run and skips the removal process if it does