### PR TITLE
feat(dx): Use DevPod from the ublue-os/staging copr

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -146,11 +146,6 @@ RUN curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/latest/dow
     chmod +x ./kind && \
     mv ./kind /usr/bin/kind
 
-# Install DevPod
-RUN rpm-ostree install https://github.com/loft-sh/devpod/releases/download/v0.3.7/DevPod_linux_x86_64.rpm && \
-    wget https://github.com/loft-sh/devpod/releases/download/v0.3.7/devpod-linux-amd64 -O /tmp/devpod && \
-    install -c -m 0755 /tmp/devpod /usr/bin
-
 # Install kns/kctx and add completions for Bash
 RUN wget https://raw.githubusercontent.com/ahmetb/kubectx/master/kubectx -O /usr/bin/kubectx && \
     wget https://raw.githubusercontent.com/ahmetb/kubectx/master/kubens -O /usr/bin/kubens && \

--- a/packages.json
+++ b/packages.json
@@ -58,6 +58,7 @@
 				"code",
 				"containerd.io",
 				"dbus-x11",
+                                "devpod",
 				"docker-ce",
 				"docker-ce-cli",
 				"docker-buildx-plugin",


### PR DESCRIPTION
Allows us to continue shipping an up-to-date RPM for DevPod on DX images.