### PR TITLE
feat: add distrobuilder to -dx

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -59,6 +59,7 @@
 				"containerd.io",
 				"dbus-x11",
                                 "devpod",
+				"distrobuilder",
 				"docker-ce",
 				"docker-ce-cli",
 				"docker-buildx-plugin",


### PR DESCRIPTION
Adds distrobuilder to -dx for building custom incus and lxd images.