### PR TITLE
Fix: Don't delete ganto-lxc4 copr since not everything is on image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -161,7 +161,6 @@ RUN /tmp/workarounds.sh
 
 # Clean up repos, everything is on the image so we don't need them
 RUN rm -f /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo && \
-    rm -f /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo && \
     rm -f /etc/yum.repos.d/karmab-kcli-fedora-"${FEDORA_MAJOR_VERSION}".repo && \
     rm -f /etc/yum.repos.d/vscode.repo && \
     rm -f /etc/yum.repos.d/docker-ce.repo && \


### PR DESCRIPTION
Don't delete the ganto-lxc4 repo. There are additional packages that are installable. Namely lxd-tools, incus-tools, and lxd-migrate. These tools can convert traditional lxc style containers to the managed format. lxd-migrate can convert a physical machine to a VM. The corresponding tool is in incus-tools.