### PR TITLE
fix(-dx): Don't remove ganto-lxc4 repo.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -161,7 +161,6 @@ RUN /tmp/workarounds.sh
 
 # Clean up repos, everything is on the image so we don't need them
 RUN rm -f /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo && \
-    rm -f /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo && \
     rm -f /etc/yum.repos.d/karmab-kcli-fedora-"${FEDORA_MAJOR_VERSION}".repo && \
     rm -f /etc/yum.repos.d/vscode.repo && \
     rm -f /etc/yum.repos.d/docker-ce.repo && \


### PR DESCRIPTION
Not all packages from ganto-lxc4 repo are installed on the image. Additionally, these missing packages conflict and can't be installed without changing the build script. lxd-tools and incus-tools are the packages in conflict.

This allows a user to layer the respective tools if necessary. Incus-tools provides tooling of both lxd-tools and lxd-migrate.