### PR TITLE
feat(ci): Verify base/Chainguard image(s) with cosign before building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,12 +40,17 @@ jobs:
             is_stable_version: true
             is_gts_version: false
     steps:
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@v6
-
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
         uses: actions/checkout@v4
+
+      - name: Verify base image
+        uses: EyeCantCU/cosign-action/verify@v0.2.1
+        with:
+          containers: silverblue-${{ matrix.image_flavor }}:${{ matrix.major_version }}
+
+      - name: Maximize build space
+        uses: ublue-os/remove-unwanted-software@v6
 
       - name: Check just syntax
         uses: ublue-os/just-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,15 @@ jobs:
         with:
           containers: silverblue-${{ matrix.image_flavor }}:${{ matrix.major_version }}
 
+      - name: Verify Chainguard images
+        uses: EyeCantCU/cosign-action/verify@v0.2.1
+        if: ${{ matrix.base_name }} == "bluefin-dx"
+        with:
+          containers: flux, helm, ko, minio, kubectl
+          cert-identity: https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main
+          oidc-issuer: https://token.actions.githubusercontent.com
+          registry: cgr.dev/chainguard
+
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@v6
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,8 +50,8 @@ jobs:
           containers: silverblue-${{ matrix.image_flavor }}:${{ matrix.major_version }}
 
       - name: Verify Chainguard images
+        if: matrix.base_name != 'bluefin'
         uses: EyeCantCU/cosign-action/verify@v0.2.1
-        if: ${{ matrix.base_name }} == "bluefin-dx"
         with:
           containers: flux, helm, ko, minio, kubectl
           cert-identity: https://github.com/chainguard-images/images/.github/workflows/release.yaml@refs/heads/main


### PR DESCRIPTION
Validates the integrity of the base image being built from, and the Chainguard images in DX, via cosign before continuing to build. Ensures we only build with signed images