### PR TITLE
feat: Fix caps-lock input delay

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -23,6 +23,9 @@ picture-options='zoom'
 primary-color='000000'
 secondary-color='FFFFFF'
 
+[org/gnome/desktop/input-sources]
+xkb-options=['caps:ctrl_modifier']
+
 [org/gnome/desktop/interface]
 enable-hot-corners=false
 clock-show-weekday=true

--- a/usr/share/X11/xkb/symbols/capslock
+++ b/usr/share/X11/xkb/symbols/capslock
@@ -1,0 +1,85 @@
+default  hidden partial modifier_keys
+xkb_symbols "capslock" {
+    replace key <CAPS> { [ Caps_Lock ], type[group1] = "ONE_LEVEL" };
+    modifier_map Lock { Caps_Lock };
+};
+
+hidden partial modifier_keys
+xkb_symbols "shiftlock" {
+    replace key <CAPS> { [ Shift_Lock ], type[group1] = "ONE_LEVEL" };
+    modifier_map Shift { Shift_Lock };
+};
+
+hidden partial modifier_keys
+xkb_symbols "swapescape" {
+    key <CAPS> { [ Escape ], type[group1] = "ONE_LEVEL" };
+    key <ESC>  { [ Caps_Lock ] };
+};
+
+hidden partial modifier_keys
+xkb_symbols "escape" {
+    key <CAPS> { [ Escape ], type[group1] = "ONE_LEVEL" };
+};
+
+hidden partial modifier_keys
+xkb_symbols "escape_shifted_capslock" {
+    key <CAPS> {
+        type[Group1] = "TWO_LEVEL",
+        symbols[Group1] = [ Escape, Caps_Lock ],
+        actions[Group1] = [ NoAction(), LockMods(modifiers = Lock) ]
+    };
+};
+
+hidden partial modifier_keys
+xkb_symbols "escape_shifted_compose" {
+    key <CAPS> {
+        type[Group1] = "TWO_LEVEL",
+        symbols[Group1] = [ Escape, Multi_key ],
+        actions[Group1] = [ NoAction(), NoAction() ]
+    };
+};
+
+hidden partial modifier_keys
+xkb_symbols "backspace" {
+    key <CAPS> { [ BackSpace ], type[group1] = "ONE_LEVEL" };
+};
+
+hidden partial modifier_keys
+xkb_symbols "super" {
+    key <CAPS> { [ Super_L ], type[group1] = "ONE_LEVEL" };
+    modifier_map Mod4 { <CAPS> };
+};
+
+hidden partial modifier_keys
+xkb_symbols "hyper" {
+    key <CAPS> { [ Hyper_L ], type[group1] = "ONE_LEVEL" };
+    modifier_map Mod4 { <CAPS> };
+};
+
+hidden partial modifier_keys
+xkb_symbols "menu" {
+    key <CAPS> { [ Menu ], type[group1] = "ONE_LEVEL" };
+};
+
+hidden partial modifier_keys
+xkb_symbols "numlock" {
+    key <CAPS> { [ Num_Lock ], type[group1] = "ONE_LEVEL" };
+};
+
+// This changes the <CAPS> key to become a Control modifier,
+// but it will still produce the Caps_Lock keysym.
+hidden partial modifier_keys
+xkb_symbols "ctrl_modifier" {
+		  key <CAPS> {
+		      type="ALPHABETIC",
+		      repeat=No,
+		      symbols[Group1]= [ Caps_Lock, Caps_Lock ],
+		      actions[Group1]= [ LockMods(modifiers=Lock),
+		                         LockMods(modifiers=Shift+Lock,affect=unlock) ]
+		  };
+};
+
+hidden partial modifier_keys
+xkb_symbols "none" {
+    key <CAPS> { [ VoidSymbol ], type[group1] = "ONE_LEVEL" };
+};


### PR DESCRIPTION
This is one of the 1st issues which ex-Windows users notice when they switch to Linux. I am one of those users who uses Caps-Lock instead of Shift for uppercase letters.

This will get rid of input delay, while the "light indicator" delay is still the same (I mentioned this distinction to not confuse you if you don't "see" any changes).

To test, type "Helo" repeatedly & quickly using Caps Lock.
You will no longer see "HElo" in your texts.

Fix took from here:
https://forum.manjaro.org/t/caps-lock-behaviour-wayland/79868/8