### PR TITLE
feat: bluefin-cli enable sudo/chown linuxbrew

### DIFF
--- a/toolboxes/Containerfile.bluefin-cli
+++ b/toolboxes/Containerfile.bluefin-cli
@@ -16,6 +16,13 @@ RUN grep -v '^#' /toolbox-packages | xargs apk add
 
 RUN rm /toolbox-packages
 
+# Make Sudo Work (Assumes UID = 1000)
+COPY ./toolboxes/files.bluefin-cli/etc/sudoers /etc/sudoers
+COPY ./toolboxes/files.bluefin-cli/etc/pam.d /etc/pam.d
+
+# Have Linuxbrew owned by UID = 1000
+RUN chown -R 1000 /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew/bin
+
 # Change root shell to BASH
 
 RUN sed -i -e '/^root/s/\/bin\/ash/\/bin\/bash/' /etc/passwd

--- a/toolboxes/files.bluefin-cli/etc/pam.d/sudo
+++ b/toolboxes/files.bluefin-cli/etc/pam.d/sudo
@@ -1,0 +1,7 @@
+#%PAM-1.0
+
+auth	required	pam_env.so
+auth	sufficient	pam_unix.so
+account	required	pam_unix.so
+session	required	pam_limits.so
+session	required	pam_unix.so

--- a/toolboxes/files.bluefin-cli/etc/pam.d/sudo-i
+++ b/toolboxes/files.bluefin-cli/etc/pam.d/sudo-i
@@ -1,0 +1,7 @@
+#%PAM-1.0
+
+auth	required	pam_env.so
+auth	sufficient	pam_unix.so
+account	required	pam_unix.so
+session	required	pam_limits.so
+session	required	pam_unix.so

--- a/toolboxes/files.bluefin-cli/etc/sudoers
+++ b/toolboxes/files.bluefin-cli/etc/sudoers
@@ -1,0 +1,3 @@
+root ALL = (ALL:ALL) NOPASSWD:ALL
+# Make UID 1000 able to use sudo without a password
+#1000 ALL = (root) NOPASSWD:ALL


### PR DESCRIPTION
Enables sudo in the bluefin-cli.  It also chowns the linuxbrew files to UID 1000. This makes the assumption that the user has UID 1000.

For whatever reason, the groups are not generated correctly for the user so we cannot reuse adm/wheel. The only valid group for the user is their own. Since most users are user 1000, we can assume this is the case. If they are not, they will have to use the su-exec method that already exists to change /etc/sudoers and chown linuxbrew.