### PR TITLE
fix: start docker.service on-demand instead of on-boot

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -156,7 +156,7 @@ RUN wget https://raw.githubusercontent.com/ahmetb/kubectx/master/kubectx -O /usr
     chmod +x /usr/bin/kubectx /usr/bin/kubens
 
 # Set up services
-RUN systemctl enable docker.service && \
+RUN systemctl enable docker.socket && \
     systemctl enable podman.socket && \
     systemctl enable swtpm-workaround.service && \
     systemctl enable --global bluefin-dx-user-vscode.service && \


### PR DESCRIPTION
Timothée Ravier from RedHat has informed us that running both Podman and Docker can result in unexpected behaviour.  
This PR does not start the Docker service by default, but whenever someone interacts with the socket (e.g. `docker container ls`) the `docker.service` unit will be started automatically.  This seems to replicate the current CoreOS behaviour.

> It is worth noting that in Fedora CoreOS we have docker.service disabled by default but it is easily started if anything communicates with the /var/run/docker.sock because docker.socket is enabled by default. This means that if a user runs any docker command (via sudo docker) then the daemon will be activated.
[Source](https://docs.fedoraproject.org/en-US/fedora-coreos/faq/#_can_i_run_containers_via_docker_and_podman_at_the_same_time)

Please see below for tests ran to confirm if this works as expected:

<details>

To confirm this behaviour, I did the following:
1. Stopped the `docker.service` systemd unit
2. Confirmed the `docker.socket` was running and `docker.service` was stopped
3. Ran `docker container ls` which returned expected results
4. Confirmed the `docker.service` was running

```
redpanda-sample-quadlet on  redpanda-sample-quadlet on ☁️  (eu-west-1) 
❯ systemctl status docker.socket 
● docker.socket - Docker Socket for the API
     Loaded: loaded (/usr/lib/systemd/system/docker.socket; disabled; preset: enabled)
     Active: active (running) since Mon 2024-01-01 12:23:05 GMT; 10h ago
   Triggers: ● docker.service
     Listen: /run/docker.sock (Stream)
      Tasks: 0 (limit: 37362)
     Memory: 0B
        CPU: 1ms
     CGroup: /system.slice/docker.socket

Jan 01 12:23:05 fedora systemd[1]: Starting docker.socket - Docker Socket for the API...
Jan 01 12:23:05 fedora systemd[1]: Listening on docker.socket - Docker Socket for the API.

redpanda-sample-quadlet on  redpanda-sample-quadlet on ☁️  (eu-west-1) 
❯ systemctl status docker.service
● docker.service - Docker Application Container Engine
     Loaded: loaded (/usr/lib/systemd/system/docker.service; enabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: active (running) since Mon 2024-01-01 12:23:16 GMT; 10h ago
TriggeredBy: ● docker.socket
       Docs: https://docs.docker.com
   Main PID: 1852 (dockerd)
      Tasks: 41
     Memory: 186.6M
        CPU: 4.611s
     CGroup: /system.slice/docker.service
             ├─1852 /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
             └─2728 /usr/bin/docker-proxy -proto tcp -host-ip 127.0.0.1 -host-port 36269 -container-ip 172.18.0.5 -container-port 6443

Jan 01 12:23:15 fedora dockerd[1852]: time="2024-01-01T12:23:15.361488135Z" level=info msg="IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 200>
Jan 01 12:23:15 fedora dockerd[1852]: time="2024-01-01T12:23:15.425903442Z" level=info msg="No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserv>
Jan 01 12:23:15 fedora dockerd[1852]: time="2024-01-01T12:23:15.426010473Z" level=info msg="IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 200>
Jan 01 12:23:15 fedora dockerd[1852]: time="2024-01-01T12:23:15.483494027Z" level=info msg="No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [nameserv>
Jan 01 12:23:15 fedora dockerd[1852]: time="2024-01-01T12:23:15.483506044Z" level=info msg="IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver 200>
Jan 01 12:23:15 fedora dockerd[1852]: time="2024-01-01T12:23:15.747024900Z" level=info msg="Loading containers: done."
Jan 01 12:23:15 fedora dockerd[1852]: time="2024-01-01T12:23:15.796405146Z" level=info msg="Docker daemon" commit=311b9ff graphdriver=overlay2 version=24.0.7
Jan 01 12:23:15 fedora dockerd[1852]: time="2024-01-01T12:23:15.796460110Z" level=info msg="Daemon has completed initialization"
Jan 01 12:23:16 fedora dockerd[1852]: time="2024-01-01T12:23:16.306556552Z" level=info msg="API listen on /run/docker.sock"
Jan 01 12:23:16 fedora systemd[1]: Started docker.service - Docker Application Container Engine.

redpanda-sample-quadlet on  redpanda-sample-quadlet on ☁️  (eu-west-1) 
❯ sudo systemctl stop docker.service
[sudo] password for admin: 
Stopping 'docker.service', but its triggering units are still active:
docker.socket

redpanda-sample-quadlet on  redpanda-sample-quadlet on ☁️  (eu-west-1) 
❯ systemctl status docker.service
○ docker.service - Docker Application Container Engine
     Loaded: loaded (/usr/lib/systemd/system/docker.service; enabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: inactive (dead) since Mon 2024-01-01 22:59:54 GMT; 5s ago
   Duration: 10h 36min 27.729s
TriggeredBy: ● docker.socket
       Docs: https://docs.docker.com
    Process: 1852 ExecStart=/usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock (code=exited, status=0/SUCCESS)
   Main PID: 1852 (code=exited, status=0/SUCCESS)
        CPU: 4.761s

Jan 01 22:59:54 fedora dockerd[1852]: time="2024-01-01T22:59:54.201385814Z" level=info msg="ignoring event" container=2fdddcc6feec108b09fa3140bb831bc135297edcfb9f59d90ba33717a7b0616a module=l>
Jan 01 22:59:54 fedora dockerd[1852]: time="2024-01-01T22:59:54.206545461Z" level=warning msg="ShouldRestart failed, container will not be restarted" container=ade1d00a523e176b1b051d1fd68036e>
Jan 01 22:59:54 fedora dockerd[1852]: time="2024-01-01T22:59:54.206590661Z" level=warning msg="ShouldRestart failed, container will not be restarted" container=651e9ab5b94f728dd5ca73abdc064a0>
Jan 01 22:59:54 fedora dockerd[1852]: time="2024-01-01T22:59:54.206547401Z" level=warning msg="ShouldRestart failed, container will not be restarted" container=d360b50f84012cf784fc8d38f51eea1>
Jan 01 22:59:54 fedora dockerd[1852]: time="2024-01-01T22:59:54.206597392Z" level=warning msg="ShouldRestart failed, container will not be restarted" container=2fdddcc6feec108b09fa3140bb831bc>
Jan 01 22:59:54 fedora dockerd[1852]: time="2024-01-01T22:59:54.593385553Z" level=info msg="stopping event stream following graceful shutdown" error="<nil>" module=libcontainerd namespace=moby
Jan 01 22:59:54 fedora dockerd[1852]: time="2024-01-01T22:59:54.593605515Z" level=info msg="Daemon shutdown complete"
Jan 01 22:59:54 fedora systemd[1]: docker.service: Deactivated successfully.
Jan 01 22:59:54 fedora systemd[1]: Stopped docker.service - Docker Application Container Engine.
Jan 01 22:59:54 fedora systemd[1]: docker.service: Consumed 4.761s CPU time.

redpanda-sample-quadlet on  redpanda-sample-quadlet on ☁️  (eu-west-1) 
❯ docker container ls
CONTAINER ID   IMAGE                  COMMAND                  CREATED        STATUS                  PORTS                       NAMES
d360b50f8401   kindest/node:v1.27.3   "/usr/local/bin/entr…"   46 hours ago   Up Less than a second                               local-cluster-worker2
2fdddcc6feec   kindest/node:v1.27.3   "/usr/local/bin/entr…"   46 hours ago   Up Less than a second   127.0.0.1:36269->6443/tcp   local-cluster-control-plane
ade1d00a523e   kindest/node:v1.27.3   "/usr/local/bin/entr…"   46 hours ago   Up Less than a second                               local-cluster-worker
651e9ab5b94f   kindest/node:v1.27.3   "/usr/local/bin/entr…"   46 hours ago   Up Less than a second                               local-cluster-worker3

redpanda-sample-quadlet on  redpanda-sample-quadlet on ☁️  (eu-west-1) 
❯ systemctl status docker.service
● docker.service - Docker Application Container Engine
     Loaded: loaded (/usr/lib/systemd/system/docker.service; enabled; preset: disabled)
    Drop-In: /usr/lib/systemd/system/service.d
             └─10-timeout-abort.conf
     Active: active (running) since Mon 2024-01-01 23:00:39 GMT; 2s ago
TriggeredBy: ● docker.socket
       Docs: https://docs.docker.com
   Main PID: 1063658 (dockerd)
      Tasks: 37
     Memory: 43.3M
        CPU: 417ms
     CGroup: /system.slice/docker.service
             ├─1063658 /usr/bin/dockerd -H fd:// --containerd=/run/containerd/containerd.sock
             └─1063999 /usr/bin/docker-proxy -proto tcp -host-ip 127.0.0.1 -host-port 36269 -container-ip 172.18.0.5 -container-port 6443

Jan 01 23:00:38 fedora dockerd[1063658]: time="2024-01-01T23:00:38.317713091Z" level=info msg="IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver >
Jan 01 23:00:38 fedora dockerd[1063658]: time="2024-01-01T23:00:38.423939512Z" level=info msg="No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [names>
Jan 01 23:00:38 fedora dockerd[1063658]: time="2024-01-01T23:00:38.423958522Z" level=info msg="IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver >
Jan 01 23:00:38 fedora dockerd[1063658]: time="2024-01-01T23:00:38.529232501Z" level=info msg="No non-localhost DNS nameservers are left in resolv.conf. Using default external servers: [names>
Jan 01 23:00:38 fedora dockerd[1063658]: time="2024-01-01T23:00:38.529245211Z" level=info msg="IPv6 enabled; Adding default IPv6 external servers: [nameserver 2001:4860:4860::8888 nameserver >
Jan 01 23:00:38 fedora dockerd[1063658]: time="2024-01-01T23:00:38.737180185Z" level=info msg="Loading containers: done."
Jan 01 23:00:38 fedora dockerd[1063658]: time="2024-01-01T23:00:38.770042937Z" level=info msg="Docker daemon" commit=311b9ff graphdriver=overlay2 version=24.0.7
Jan 01 23:00:38 fedora dockerd[1063658]: time="2024-01-01T23:00:38.770290620Z" level=info msg="Daemon has completed initialization"
Jan 01 23:00:39 fedora dockerd[1063658]: time="2024-01-01T23:00:39.217715284Z" level=info msg="API listen on /run/docker.sock"
Jan 01 23:00:39 fedora systemd[1]: Started docker.service - Docker Application Container Engine
```

</details>