### PR TITLE
fix: remove `systemctl enable docker` from `just docker` command

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -305,8 +305,7 @@ zsh:
     sudo usermod $USER --shell /usr/bin/zsh 
     printf "${USER}'s shell is now %s." "$(cat /etc/passwd | grep ":$UID:" | cut '-d:' '-f7')"
 
-# Enable docker on the system
+# Configure Docker user permissions
 docker:
-    sudo systemctl enable --now docker
     sudo usermod -aG docker $USER
     newgrp docker


### PR DESCRIPTION
The `docker.service` unit is enabled when the user interacts with the `docker.socket`, so we do not need to explicitly start docker on boot.