### PR TITLE
feat(dx): Add wheel users to docker,incus-admin,lxd,libvirt groups

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -159,6 +159,7 @@ RUN wget https://raw.githubusercontent.com/ahmetb/kubectx/master/kubectx -O /usr
 RUN systemctl enable docker.socket && \
     systemctl enable podman.socket && \
     systemctl enable swtpm-workaround.service && \
+    systemctl enable bluefin-dx-groups.service && \
     systemctl enable --global bluefin-dx-user-vscode.service && \
     systemctl disable pmie.service && \
     systemctl disable pmlogger.service

--- a/dx/usr/bin/bluefin-dx-groups
+++ b/dx/usr/bin/bluefin-dx-groups
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# SCRIPT VERSION
+GROUP_SETUP_VER=1
+GROUP_SETUP_VER_FILE="/etc/ublue/dx-groups"
+GROUP_SETUP_VER_RAN=$(cat "$GROUP_SETUP_VER_FILE")
+
+# Run script if updated
+if [[ -f $GROUP_SETUP_VER_FILE && "$GROUP_SETUP_VER" = "$GROUP_SETUP_VER_RAN" ]]; then
+  echo "Group setup has already run. Exiting..."
+  exit 0
+fi
+
+# Setup Groups
+wheelarray=($(getent group wheel | cut -d ":" -f 4 | tr  ',' '\n'))
+for user in $wheelarray
+do
+  usermod -aG docker $user
+  usermod -aG incus-admin $user
+  usermod -aG lxd $user
+  usermod -aG libvirt $user
+done
+
+# Prevent future executions
+echo "Writing state file"
+echo "$GROUP_SETUP_VER" > "$GROUP_SETUP_VER_FILE"

--- a/dx/usr/lib/systemd/system/bluefin-dx-groups.service
+++ b/dx/usr/lib/systemd/system/bluefin-dx-groups.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Add wheel members to docker,incus-admin, and lxd groups
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bluefin-dx-groups
+Restart=on-failure
+RestartSec=30
+StartLimitInterval=0
+
+[Install]
+WantedBy=default.target

--- a/just/custom.just
+++ b/just/custom.just
@@ -305,7 +305,10 @@ zsh:
     sudo usermod $USER --shell /usr/bin/zsh 
     printf "${USER}'s shell is now %s." "$(cat /etc/passwd | grep ":$UID:" | cut '-d:' '-f7')"
 
-# Configure Docker user permissions
-docker:
+# Configure docker,incus-admin,lxd,libvirt container manager permissions
+dx-group:
     sudo usermod -aG docker $USER
-    newgrp docker
+    sudo usermod -aG incus-admin $USER
+    sudo usermod -aG lxd $USER
+    sudo usermod -aG libvirt $USER
+    @echo "Logout to use docker, incus-admin, lxd, libvirt"


### PR DESCRIPTION
Run a onetime service to add members of the wheel group to docker, incus-admin, lxd , and libvirt groups.

Removed just docker and replaced with just dx-groups to add the current user to docker, incus-admin, lxd, libvirt groups