### PR TITLE
feat(bluefin-cli): Add host-spawn and create symlinks

### DIFF
--- a/toolboxes/Containerfile.bluefin-cli
+++ b/toolboxes/Containerfile.bluefin-cli
@@ -16,6 +16,20 @@ RUN grep -v '^#' /toolbox-packages | xargs apk add
 
 RUN rm /toolbox-packages
 
+# Get Distrobox-host-exec and host-spawn
+RUN git clone https://github.com/89luca89/distrobox.git --single-branch /tmp/distrobox && \
+    cp /tmp/distrobox/distrobox-host-exec /usr/bin/distrobox-host-exec && \
+    wget https://github.com/1player/host-spawn/releases/download/$(cat /tmp/distrobox/distrobox-host-exec | grep host_spawn_version= | cut -d "\"" -f 2)/host-spawn-$(uname -m) -O /usr/bin/host-spawn && \
+    chmod +x /usr/bin/host-spawn && \
+    rm -drf /tmp/distrobox
+
+# Make some symlinks
+RUN mkdir -p /usr/local/bin  && \
+    ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/docker && \
+    ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/flatpak && \ 
+    ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/podman && \
+    ln -fs /usr/bin/distrobox-host-exec /usr/local/bin/rpm-ostree
+
 # Make Sudo Work (Assumes UID = 1000)
 COPY ./toolboxes/files.bluefin-cli/etc/sudoers /etc/sudoers
 COPY ./toolboxes/files.bluefin-cli/etc/pam.d /etc/pam.d


### PR DESCRIPTION
Adds Distrobox-host-exec and host-spawn in the build process.

Creates symlinks for running host level things on the host.