### PR TITLE
fix(bluefin-cli): Make sure /usr/bin/sh exists

### DIFF
--- a/toolboxes/Containerfile.bluefin-cli
+++ b/toolboxes/Containerfile.bluefin-cli
@@ -21,7 +21,8 @@ RUN git clone https://github.com/89luca89/distrobox.git --single-branch /tmp/dis
     cp /tmp/distrobox/distrobox-host-exec /usr/bin/distrobox-host-exec && \
     wget https://github.com/1player/host-spawn/releases/download/$(cat /tmp/distrobox/distrobox-host-exec | grep host_spawn_version= | cut -d "\"" -f 2)/host-spawn-$(uname -m) -O /usr/bin/host-spawn && \
     chmod +x /usr/bin/host-spawn && \
-    rm -drf /tmp/distrobox
+    rm -drf /tmp/distrobox && \
+    ln -fs /bin/sh /usr/bin/sh
 
 # Make some symlinks
 RUN mkdir -p /usr/local/bin  && \


### PR DESCRIPTION
Alpine based distros do not have merged /usr.

Fedora changed distrobox-host-exec to have #!/usr/bin/sh as the shebang instead of #!/bin/sh which results in distrobox-host-exec not working on unmerged /usr. This fixes it for bluefin-cli.