### PR TITLE
fix: remove `--disable-content-trust` push flag

### DIFF
--- a/.github/workflows/build-bluefin-toolbox.yml
+++ b/.github/workflows/build-bluefin-toolbox.yml
@@ -81,8 +81,6 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-          extra-args: |
-            --disable-content-trust
             
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-fedora-toolbox.yml
+++ b/.github/workflows/build-fedora-toolbox.yml
@@ -73,8 +73,6 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-          extra-args: |
-            --disable-content-trust
             
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-ubuntu-toolbox.yml
+++ b/.github/workflows/build-ubuntu-toolbox.yml
@@ -73,8 +73,6 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-          extra-args: |
-            --disable-content-trust
             
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build-wolfi-toolbox.yml
+++ b/.github/workflows/build-wolfi-toolbox.yml
@@ -81,8 +81,6 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-          extra-args: |
-            --disable-content-trust
             
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,8 +189,6 @@ jobs:
           registry: ${{ steps.registry_case.outputs.lowercase }}
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
-          extra-args: |
-            --disable-content-trust
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
I do not believe this flag is necessary.  If someone knows the origin of this, and we still need it, happy to close this PR.

> When transferring data among networked systems, trust is a central concern. In particular, when communicating over an untrusted medium such as the internet, it is critical to ensure the integrity and the publisher of all the data a system operates on. You use Docker Engine to push and pull images (data) to a public or private registry. Content trust gives you the ability to verify both the integrity and the publisher of all the data received from a registry over any channel.