### PR TITLE
feat(bluefin-cli): Persist State of Cellar

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -25,13 +25,15 @@ aqua:
 
 [private]
 bluefin-cli:
-    #!/usr/bin/env bash
-    if [ ! -f "${HOME}/.brew_pkgs" ]; then
-       echo dysk > "${HOME}/.brew_pkgs"
-    fi;
-    distrobox-create --nvidia --image ghcr.io/ublue-os/bluefin-cli:latest -n bluefin -Y -a "--env BREW_PKGS=.brew_pkgs"
-    echo "Entering bluefin-cli"
-    distrobox enter bluefin
+    #!/usr/bin/env bash 
+    if [ ! -d "${XDG_DATA_HOME:-$HOME/.local/share}/bluefin-cli/Cellar" ]; then 
+       mkdir -p "${XDG_DATA_HOME:-$HOME/.local/share}/bluefin-cli/Cellar" 
+    fi; 
+    distrobox-create --nvidia --image ghcr.io/ublue-os/bluefin-cli:latest -n bluefin --volume "${XDG_DATA_HOME:-$HOME/.local/share}/bluefin-cli/Cellar":/home/linuxbrew/.linuxbrew/Cellar:z
+    echo "Setting up bluefin-cli" 
+    distrobox enter -n bluefin -T -e brew_script
+    echo "Entering bluefin-cli" 
+    distrobox enter -n bluefin
 
 # Enable Cockpit for web-based system management | https://cockpit-project.org/
 cockpit:

--- a/toolboxes/Containerfile.bluefin-cli
+++ b/toolboxes/Containerfile.bluefin-cli
@@ -7,6 +7,10 @@ LABEL com.github.containers.toolbox="true" \
 
 COPY ./toolboxes/packages.bluefin-cli /toolbox-packages
 
+# Install brew_script
+COPY ./toolboxes/files.bluefin-cli/brew_script.bluefin-cli /tmp/brew_script
+RUN install -Dm755 /tmp/brew_script /usr/bin/brew_script
+
 # Update image
 RUN apk update && \
     apk upgrade
@@ -36,7 +40,7 @@ COPY ./toolboxes/files.bluefin-cli/etc/sudoers /etc/sudoers
 COPY ./toolboxes/files.bluefin-cli/etc/pam.d /etc/pam.d
 
 # Have Linuxbrew owned by UID = 1000
-RUN chown -R 1000 /home/linuxbrew/.linuxbrew /home/linuxbrew/.linuxbrew/bin
+RUN chown -R 1000 /home/linuxbrew
 
 # Change root shell to BASH
 

--- a/toolboxes/brew_script.bluefin-cli
+++ b/toolboxes/brew_script.bluefin-cli
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-if [ ! -f /home/linuxbrew/.firstrun ] && [ -n "${BREW_PKGS}" ]; then
-  touch /home/linuxbrew/.firstrun
-  # `brew update-reset` is currently needed
-  # because somekind of issue with brew
-  brew update-reset
-  xargs brew install < "${HOME}"/"${BREW_PKGS}"
-fi

--- a/toolboxes/files.bluefin-cli/brew_script.bluefin-cli
+++ b/toolboxes/files.bluefin-cli/brew_script.bluefin-cli
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash 
+
+if [ ! -f /home/linuxbrew/.firstrun ]; then
+  touch /home/linuxbrew/.firstrun
+  
+  # Package Relink
+  if [ -n "$(ls -A /home/linuxbrew/.linuxbrew/Cellar)" ]; then
+    echo "Relinking Homebrew Cellar"
+    /home/linuxbrew/.linuxbrew/bin/brew list -1 | while read line
+    do
+      /home/linuxbrew/.linuxbrew/bin/brew unlink $line
+      /home/linuxbrew/.linuxbrew/bin/brew link $line
+    done
+    echo "Reinstalling explicictly installed Homebrew packages"
+    /home/linuxbrew/.linuxbrew/bin/brew leaves | while read line
+    do
+      /home/linuxbrew/.linuxbrew/bin/brew reinstall $line
+    done
+  fi
+fi


### PR DESCRIPTION
Persist the state of Homebrew's Cellar for #768

If the Cellar does not exist. It will be created in the User's home under $XDG_DATA_HOME. It is then volume mounted into the container making it accessible on any distrobox enter for the container.

This will relink all packages and reinstall explicitly installed homebrew packages.