### PR TITLE
feat: add gaming, gamingutilities, utilities folders in gnome

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -2,20 +2,6 @@
 favorite-apps = ['org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Rhythmbox3.desktop', 'org.libreoffice.LibreOffice.writer.desktop', 'org.gnome.Software.desktop', 'code.desktop', 'ubuntu.desktop', 'yelp.desktop']
 enabled-extensions = ['appindicatorsupport@rgcjonas.gmail.com', 'dash-to-dock@micxgx.gmail.com', 'blur-my-shell@aunetx', 'gsconnect@andyholmes.github.io', 'logomenu@aryan_k', 'tailscale@joaophi.github.com']
 
-[org/gnome/desktop/app-folders]
-folder-children=['Utilities', 'Distrobox', 'Wine', 'YaST', 'Pardus']
-
-[org/gnome/desktop/app-folders/folders/Distrobox]
-categories=['Distrobox']
-name='Distrobox'
-translate=false
-
-[org/gnome/desktop/app-folders/folders/Wine]
-apps=['winetricks.desktop']
-categories=['X-Wine', 'wine-wine']
-name='Wine'
-translate=false
-
 [org/gnome/desktop/background]
 picture-uri='file:///usr/share/backgrounds/bluefin/bluefin-winter-dynamic.xml'
 picture-uri-dark='file:///usr/share/backgrounds/bluefin/bluefin-winter-dynamic.xml'

--- a/usr/etc/dconf/db/local.d/02-bluefin-folders
+++ b/usr/etc/dconf/db/local.d/02-bluefin-folders
@@ -1,0 +1,30 @@
+[org/gnome/desktop/app-folders]
+folder-children=['Games', 'GamingUtilities', 'Utilities', 'Distrobox', 'Wine', 'YaST', 'Pardus']
+
+[org/gnome/desktop/app-folders/folders/GamingUtilities]
+apps=['protontricks.desktop', 'discover_overlay_configure.desktop', 'com.vysp3r.ProtonPlus.desktop', 'io.github.benjamimgois.goverlay.desktop', 'com.gerbilsoft.rom-properties.rp-config.desktop', 'input-remapper-gtk.desktop', 'steamos-nested-desktop.desktop']
+name='Gaming Utilities'
+translate=false
+
+[org/gnome/desktop/app-folders/folders/Utilities]
+apps=['com.github.tchx84.Flatseal.desktop', 'io.github.flattool.Warehouse.desktop', 'com.mattjakeman.ExtensionManager.desktop', 'org.gnome.tweaks.desktop', 'firewall-config.desktop', 'ca.desrt.dconf-editor.desktop']
+categories=['X-GNOME-Utilities']
+name='X-GNOME-Utilities.directory'
+translate=true
+
+[org/gnome/desktop/app-folders/folders/Games]
+excluded-apps=['steam.desktop', 'net.lutris.Lutris.desktop', 'io.github.benjamimgois.goverlay.desktop', 'com.vysp3r.ProtonPlus.desktop', 'io.github.fastrizwaan.WineZGUI.desktop']
+categories=['Game']
+name='Games'
+translate=false
+
+[org/gnome/desktop/app-folders/folders/Distrobox]
+categories=['Distrobox']
+name='Distrobox'
+translate=false
+
+[org/gnome/desktop/app-folders/folders/Wine]
+apps=['winetricks.desktop']
+categories=['X-Wine', 'wine-wine']
+name='Wine'
+translate=false


### PR DESCRIPTION
I cleaned up the commits and opened a new PR, just with the folders.