### PR TITLE
feat: Add Warehouse

### DIFF
--- a/usr/etc/flatpak/user/install
+++ b/usr/etc/flatpak/user/install
@@ -17,6 +17,7 @@ org.gnome.clocks
 org.gnome.font-viewer
 com.mattjakeman.ExtensionManager
 com.github.tchx84.Flatseal
+io.github.flattool.Warehouse
 org.fedoraproject.MediaWriter
 io.missioncenter.MissionCenter
 io.github.celluloid_player.Celluloid


### PR DESCRIPTION
I was hesitant to open this because of this [PR](https://github.com/ublue-os/bluefin/pull/790).  However, I am interested if anyone would like this application preinstalled on Bluefin.

I added this back in October to Bazzite.  I'm not sure if this meets the project's goals, but it allows users to manage their Flatpaks.

This includes:
- Opening the userdata (~/.var/app/...) directory for each application
- Downgrading applications
- Disabling updates for applications
- Creating snapshots of userdata for backups

This management is usually done with the command line, but this is simplified with this GUI application (similar to Flatseal for permissions).

It also will warn users if a Flatpak installed is using an end-of-life runtime.  

Project page: https://github.com/flattool/warehouse