### PR TITLE
fix: provide build workflow with write permissions to the repo contents

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
     name: Make
     runs-on: ubuntu-22.04
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
     strategy:


### PR DESCRIPTION
The new contributor action is failing due to lack of permissions.  Now providing write access so it can update the README.md