### PR TITLE
fix: Make Wolfi build again.

### DIFF
--- a/toolboxes/packages.wolfi
+++ b/toolboxes/packages.wolfi
@@ -10,7 +10,7 @@ gpg
 iproute2
 iputils
 keyutils
-libcap
+libcap=2.68-r0
 mount
 ncurses
 ncurses-terminfo


### PR DESCRIPTION
Wolfi build fails since 2 days due to a libcap version confilict originating from chainguard. distrobox init needs libcap -> every chainguard image building on wolfi-base is affected when trying to use it with distrobox.
```
ERROR: unable to select packages:
  libcap-2.68-r0:
    conflicts: libcap-2.69-r1
               libcap-2.69-r1[so:libcap.so.2=2]
    satisfies: world[libcap]
               iputils-20231222-r0[so:libcap.so.2]
               libcap-2.69-r1[so:libpsx.so.2]
  libcap-2.69-r1:
    conflicts: libcap-2.68-r0
               libcap-2.68-r0[so:libcap.so.2=2]
    satisfies: world[libcap]
               iputils-20231222-r0[so:libcap.so.2]
```
Temporary fix: Pin libcap=2.68-r0 until this is sorted out upstream.
