### PR TITLE
fix: Add missing quotes to dconf string value.

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -114,7 +114,7 @@ menu-button-system-monitor='flatpak run io.missioncenter.MissionCenter'
 menu-button-extensions-app='com.mattjakeman.ExtensionManager.desktop'
 
 [org/gnome/Prompt]
-interface-style=system
+interface-style='system'
 restore-session=false
 restore-window-size=false
 profile-uuids=['2871e8027773ae74d6c87a5f659bbc74']


### PR DESCRIPTION
`dconf update` throws an error and stops compiling if quotes are missing.