### PR TITLE
feat: Initial Container wireup

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -78,6 +78,10 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"$
     mkdir -p /usr/etc/flatpak/remotes.d && \
     wget -q https://dl.flathub.org/repo/flathub.flatpakrepo -P /usr/etc/flatpak/remotes.d && \
     cp /tmp/ublue-update.toml /usr/etc/ublue-update/ublue-update.toml && \
+    mkdir -p /usr/etc/containers/systemd/user && \
+    wget -q https://raw.githubusercontent.com/ublue-os/toolboxes/main/quadlets/bluefin-cli/bluefin-cli.container -P /usr/etc/containers/systemd/user && \
+    printf "\n\n[Install]\nWantedBy=bluefin-cli.target" >> /usr/etc/containers/systemd/user/bluefin-cli.container  && \
+    sed -i '/AutoUpdate.*/ s/^#*/#/' /usr/etc/containers/systemd/user/bluefin-cli.container && \
     systemctl enable rpm-ostree-countme.service && \
     systemctl enable tailscaled.service && \
     systemctl enable dconf-update.service && \

--- a/just/custom.just
+++ b/just/custom.just
@@ -18,11 +18,65 @@ aqua:
     printf '\n    export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH"\n'
     printf '\n=> see https://aquaproj.github.io/docs/tutorial for more info\n'
 
+# Configure bluefin-cli Terminal Experience
 bluefin-cli:
-    #!/usr/bin/env bash 
-    distrobox-create --nvidia --image ghcr.io/ublue-os/bluefin-cli:latest -n bluefin
-    echo "Entering bluefin-cli" 
-    distrobox enter -n bluefin
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    printf "Set Up bluefin-cli\n"
+    printf "Would you like to use Host Terminal or Container as default Terminal?\n"
+    TERMINAL_CHOICE=$(Choose Host Container)
+    if test "$TERMINAL_CHOICE" = "Container"; then
+        printf "You have chosen Container.\nWould you like to use quadlets to manage your container?\n"
+        MANAGEMENT_CHOICE=$(Choose Quadlet Distrobox)
+    else
+        printf "You have chosen to use Host Terminal. Would you like to setup Bluefin-cli container?\n"
+        MANAGEMENT_CHOICE=$(Choose Quadlet Distrobox No)
+    fi
+    if /usr/bin/systemctl is-enabled --quiet bluefin-cli.target; then
+        printf "Bluefin quadlet is already enabled, would you like to disable it?\n"
+        DISABLE=$(Choose Yes No)
+        if test "$DISABLE" = "No"; then
+            printf "Not Disabling existing container quadlet.\n"
+            printf "Finished Bluefin-CLI setup, rerun with ujust bluefin-cli to reconfigure\n"
+            printf "Exiting...\n"
+            exit 0
+        elif test "$DISABLE" = "Yes"; then
+            printf "Disabling Bluefin-CLI\n"
+            /usr/bin/systemctl --user disable --now bluefin-cli.target
+            /usr/bin/systemctl --user stop bluefin-cli.service
+        fi
+    fi
+    if /usr/bin/env DBX_CONTAINER_MANAGER="podman" /usr/bin/distrobox-list | grep -qE "^| bluefin-cli .*"; then
+        printf "You already have a container named bluefin-cli. Would you like to destroy it?\n"
+        REBUILD=$(Choose Yes No)
+        if test "$REBUILD" = "No"; then
+            printf "Not replacing existing container.\n"
+            printf "Finished Bluefin-CLI setup, rerun with ujust bluefin-cli to reconfigure\n"
+            printf "Exiting...\n"
+            exit 0
+        elif test "$REBUILD" = "Yes"; then
+            printf "Destroying existing bluefin-cli container\n"
+            /usr/bin/env DBX_CONTAINER_MANAGER="podman" /usr/bin/distrobox-rm -f bluefin-cli
+        fi
+    fi
+    if test "$MANAGEMENT_CHOICE" = "Quadlet"; then
+        /usr/bin/systemctl --user enable --now bluefin-cli.target 
+        /usr/bin/systemctl --user start bluefin-cli.service
+    elif test "$MANAGEMENT_CHOICE" = "Distrobox"; then
+        /usr/bin/env DBX_CONTAINER_MANAGER="podman" /usr/bin/distrobox-create --nvidia Y --image ghcr.io/ublue-os/bluefin-cli:latest -n bluefin-cli --no-entry --pull
+        /usr/bin/env DBX_CONTAINER_MANAGER="podman" /usr/bin/distrobox-enter bluefin-cli -- bash -l -c "exit" 
+    else
+        printf "You have chosen none.\n"
+        printf "Finished Bluefin-CLI setup, rerun with ujust bluefin-cli to reconfigure\n"
+        printf "Exiting...\n"
+        exit 0
+    fi
+    if test "$TERMINAL_CHOICE" = "Container"; then
+        printf "Setting first terminal be Container for bash using ~/.bashrc.d\n"
+        printf "Enter into container using prompt's menu after first entry\n"
+        ln -sf /usr/share/ublue-os/bluefin-cli/bluefin-cli.sh ~/.bashrc.d/zz-container.sh
+    fi 
+    printf "Finished Bluefin-CLI setup, rerun with ujust bluefin-cli to reconfigure\n"
 
 # Enable Cockpit for web-based system management | https://cockpit-project.org/
 cockpit:

--- a/usr/lib/systemd/user/bluefin-cli-update.service
+++ b/usr/lib/systemd/user/bluefin-cli-update.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Restart bluefin-cli.service to rebuild container
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/bin/podman pull ghcr.io/ublue-os/bluefin-cli:latest
+ExecStart=-/usr/bin/systemctl --user restart bluefin-cli.service

--- a/usr/lib/systemd/user/bluefin-cli.target
+++ b/usr/lib/systemd/user/bluefin-cli.target
@@ -1,0 +1,5 @@
+[Unit]
+Description=Bluefin-CLI target for bluefin-cli quadlet
+
+[Install]
+WantedBy=default.target

--- a/usr/share/ublue-os/bluefin-cli/bluefin-cli.sh
+++ b/usr/share/ublue-os/bluefin-cli/bluefin-cli.sh
@@ -1,0 +1,6 @@
+#!/bin/sh 
+ 
+if test ! -f "/run/user/${UID}/container-entry" && test -n "$PS1"; then  
+    touch "/run/user/${UID}/container-entry"  
+    exec /usr/bin/distrobox-enter bluefin-cli 
+fi


### PR DESCRIPTION
Get quadlet from toolbox repo. Have target for not having quadlet always run.

Modify `ujust bluefin-cli` to be more of a setup script. Only limited to bluefin-cli container right now.

TODO: move bluefin-cli logic to it's own script instead of having everything inside of our just script.