### PR TITLE
fix(just): correct the arg order for AssembleList when making mlbox

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -140,7 +140,7 @@ distrobox-mlbox:
     #!/usr/bin/bash
     source /usr/lib/ujust/ujust.sh
     echo 'Assembling pytorch-nvidia mlbox distrobox ...'
-    AssembleList create "/usr/share/ublue-os/distrobox/pytorch-nvidia.ini" "mlbox"
+    AssembleList "/usr/share/ublue-os/distrobox/pytorch-nvidia.ini" create "mlbox"
 
 # Create a Wolfi OS container | https://github.com/wolfi-dev
 distrobox-wolfi:


### PR DESCRIPTION
The recipe for mlbox accidentally used the Assemble argument order (action, file, container/name) similar to the `distrobox assemble` command, instead of the AssembleList order (file, action, name) which is "Assemble a list from `file` we want to `action` from and `name` just just a quick selection"

This fixes #842 