### PR TITLE
fix: set Prompt theme to Catpuccin

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -128,4 +128,4 @@ profile-uuids=['2871e8027773ae74d6c87a5f659bbc74']
 default-profile-uuid='2871e8027773ae74d6c87a5f659bbc74'
 
 [org/gnome/Prompt/Profiles/2871e8027773ae74d6c87a5f659bbc74]
-palette='Catpuccin Mocha'
+palette='Catpuccin'


### PR DESCRIPTION
If we set it to just Catpuccin it works in both light and dark.