### PR TITLE
fix: Correct default font applied to VSCode

### DIFF
--- a/dx/usr/etc/skel/.config/Code/User/settings.json
+++ b/dx/usr/etc/skel/.config/Code/User/settings.json
@@ -1,4 +1,4 @@
 {
     "window.titleBarStyle": "custom",
-    "editor.fontFamily": "'CaskaydiaCove Nerd Font Mono', 'Droid Sans Mono', 'monospace', monospace"
+    "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace"
 }


### PR DESCRIPTION
Previously shipped CascadiaCove Nerd Fonts, which is a fork of Cascadia Code to add nerd fonts -- name change required by the license. Thanks to che/nerd fonts copr, the original Cascadia Code font can now be used w/ fallbacks to Nerd Fonts for missing symbols.