### PR TITLE
feat: add podman wrapper for vscode

### DIFF
--- a/usr/bin/podman-host
+++ b/usr/bin/podman-host
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -x
+
+PODMAN_COMMAND="$(command -v podman 2> /dev/null)"
+
+# if we're in a flatpak, use podman-remote
+# else we fallback to host-spawn
+if [ -n "$FLATPAK_ID" ]; then
+	if command -v podman-remote > /dev/null 2>&1; then
+		PODMAN_COMMAND="podman-remote"
+	else
+		PODMAN_COMMAND="flatpak-spawn --host podman"
+	fi
+fi
+
+# This little workaround is used to ensure
+# we use our $USER inside the containers, without
+# resorting to creating devcontainer.json or similar stuff
+arr=("$@")
+if echo "$@" | grep -q 'exec'; then
+	id="$(echo "$@" | grep -Eo ' [a-zA-Z0-9]{64} ' | tr -d ' ')"
+	# if exec && distrobox -> use distrobox-enter --
+	if [ "$($PODMAN_COMMAND inspect --type container --format '{{ index .Config.Labels "manager" }}' "${id}")" == "distrobox" ] ||
+		[ "$($PODMAN_COMMAND inspect --type container --format '{{ index .Config.Labels "com.github.containers.toolbox" }}' "${id}")" == "true" ]; then
+
+		for i in "${!arr[@]}"; do
+			if [[ ${arr[$i]} == *"root:root"* ]]; then
+				arr[$i]="$(echo "${arr[$i]}" | sed "s|root:root|$USER:$USER|g")"
+			fi
+		done
+	fi
+fi
+
+$PODMAN_COMMAND "${arr[@]}"


### PR DESCRIPTION
This script should be set up in VSCode as `Docker Path` like this:

![image](https://github.com/ublue-os/bluefin/assets/598882/0adc4661-1fe1-4db9-80a5-6c241ab40a06)

This wrapper will adjust the USER for Distrobox and Toolbx containers only

This wrapper will work both with host-installed VSCode and with Flatpak too

This will allow to use pet-containers more seamlessly with VSCode devcontainer extension

