### PR TITLE
feat: remove tailscale extension from pre-installed packages (#891)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -59,7 +59,7 @@
 				"code",
 				"containerd.io",
 				"dbus-x11",
-                "devpod",
+                                "devpod",
 				"distrobuilder",
 				"docker-ce",
 				"docker-ce-cli",
@@ -116,9 +116,7 @@
 	},
 	"38": {
 		"include": {
-			"bluefin": [
-				"gnome-shell-extension-tailscale-status"
-			],
+			"bluefin": [],
 			"bluefin-dx": [],
 			"bluefin-framework": []
 		},
@@ -132,7 +130,6 @@
 	"39": {
 		"include": {
 			"bluefin": [
-				"gnome-shell-extension-tailscale-gnome-qs",
 				"input-leap",
 				"nautilus-open-any-terminal",
 				"tuned",


### PR DESCRIPTION
This could be installed by users later via GNOME extensions but feels really out of place in the default installation.