### PR TITLE
fix: remove fedora shortcut from -dx

### DIFF
--- a/dx/usr/etc/dconf/db/local.d/01-ublue-dx
+++ b/dx/usr/etc/dconf/db/local.d/01-ublue-dx
@@ -1,11 +1,2 @@
 [org/gnome/shell] 
 favorite-apps = ['org.mozilla.firefox.desktop', 'org.mozilla.Thunderbird.desktop', 'org.gnome.Nautilus.desktop', 'org.gnome.Rhythmbox3.desktop', 'org.libreoffice.LibreOffice.writer.desktop', 'org.gnome.Software.desktop', 'code.desktop', 'org.gnome.Prompt.desktop', 'ubuntu.desktop', 'yelp.desktop']
-
-[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3]
-binding='<Control><Alt>f'
-command='xdg-terminal-exec -- bluefinbox-enter fedora'
-name='Fedora Prompt'
-
-[org/gnome/settings-daemon/plugins/media-keys]
-custom-keybindings=['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/']
-home=['<Super>e']


### PR DESCRIPTION
This is handled in the stock config, no need to set it here.