### PR TITLE
feat: improve podman-host script for vscode integration

### DIFF
--- a/usr/bin/podman-host
+++ b/usr/bin/podman-host
@@ -1,7 +1,8 @@
-#!/bin/bash
-set -x
+#!/bin/sh
 
+id="$(echo "$@" | grep -Eo ' [a-zA-Z0-9]{64} ' | tr -d ' ')"
 PODMAN_COMMAND="$(command -v podman 2> /dev/null)"
+DISTROBOX_COMMAND="$(command -v distrobox 2> /dev/null)"
 
 # if we're in a flatpak, use podman-remote
 # else we fallback to host-spawn
@@ -11,24 +12,48 @@ if [ -n "$FLATPAK_ID" ]; then
 	else
 		PODMAN_COMMAND="flatpak-spawn --host podman"
 	fi
+	DISTROBOX_COMMAND="flatpak-spawn --host distrobox"
 fi
 
 # This little workaround is used to ensure
-# we use our $USER inside the containers, without
-# resorting to creating devcontainer.json or similar stuff
-arr=("$@")
+# we use our distrobox to properly enter the container
 if echo "$@" | grep -q 'exec'; then
-	id="$(echo "$@" | grep -Eo ' [a-zA-Z0-9]{64} ' | tr -d ' ')"
 	# if exec && distrobox -> use distrobox-enter --
-	if [ "$($PODMAN_COMMAND inspect --type container --format '{{ index .Config.Labels "manager" }}' "${id}")" == "distrobox" ] ||
-		[ "$($PODMAN_COMMAND inspect --type container --format '{{ index .Config.Labels "com.github.containers.toolbox" }}' "${id}")" == "true" ]; then
+	if [ "$($PODMAN_COMMAND inspect --type container --format '{{ index .Config.Labels "manager" }}' "${id}")" = "distrobox" ]; then
 
-		for i in "${!arr[@]}"; do
-			if [[ ${arr[$i]} == *"root:root"* ]]; then
-				arr[$i]="$(echo "${arr[$i]}" | sed "s|root:root|$USER:$USER|g")"
+		# Ensure that our distrobox containers will use different vscode-servers by symlinking to different paths
+		if [ -n "${id}" ]; then
+			$PODMAN_COMMAND exec -u "$USER" "${id}" /bin/sh -c '
+			if [ ! -L "${HOME}/.vscode-server" ]; then
+				[ -e "${HOME}/.vscode-server" ] && mv "${HOME}/.vscode-server" /var/tmp
+				[ -d /var/tmp/.vscode-server ] && mkdir /var/tmp/.vscode-server
+				ln -sf /var/tmp/.vscode-server "$HOME"
+			elif [ ! -e "${HOME}/.vscode-server" ]; then
+				mkdir /var/tmp/.vscode-server
+			fi'
+		fi
+
+		# Remove everything from $@ and leave only the execution part, we start
+		# capturing after we meet our ID
+		dbox_args="-e A=B"
+		capture="false"
+		for i; do
+			if [ $capture = "true" ]; then
+				set -- "$@" "$i"
+			elif echo "$i" | grep -q "VSCODE"; then
+				dbox_args="$dbox_args -e $i"
+			elif echo "$i" | grep -q "\-w"; then
+				dbox_args="$dbox_args -w $2"
 			fi
+			if [ "$i" = "${id}" ]; then
+				capture="true"
+			fi
+			shift
 		done
+
+		$DISTROBOX_COMMAND enter --additional-flags "${dbox_args}" "${id}" -- "$@"
+		exit $?
 	fi
 fi
 
-$PODMAN_COMMAND "${arr[@]}"
+$PODMAN_COMMAND "$@"


### PR DESCRIPTION
This improvement will correctly trick vscode to use distrobox to enter a container with `manager=distrobox` label.

This also symlinks the `~/.vscode-server` to `/var/tmp/` so that each distrobox has it's own server instance, avoiding possible conflicts

Fix #883 