### PR TITLE
feat: bring back the brew

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -7,6 +7,7 @@
 				"evtest",
 				"fish",
 				"firewall-config",
+				"gcc",
 				"glow",
 				"gum",
 				"gnome-shell-extension-appindicator",

--- a/usr/etc/profile.d/brew.sh
+++ b/usr/etc/profile.d/brew.sh
@@ -1,0 +1,1 @@
+[[ $- == *i* ]] && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"


### PR DESCRIPTION
This PR adds `gcc` to the bluefin package list (to be inherited by -dx as well) and adds a script in /etc/profile.d/ to source the brew shellenv script only from interactive bash terminals.

It DOES NOT address zsh or fish. TODO