### PR TITLE
feat: create open -> xdg-open shell alias

### DIFF
--- a/usr/etc/profile.d/open.sh
+++ b/usr/etc/profile.d/open.sh
@@ -1,0 +1,1 @@
+alias open="xdg-open &>/dev/null"


### PR DESCRIPTION
<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->

Adds an alias for the MacOS folks so that `open <file>` opens that file in the default application.  It means they don't need to know about xdg-open and have the massive terminal output from that command.