### PR TITLE
fix: Allow brew-install to escalate when needed, fixes permission issue.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -100,8 +100,9 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"$
     systemctl enable dconf-update.service && \
     systemctl enable ublue-update.timer && \
     systemctl enable ublue-system-setup.service && \
-    systemctl enable ublue-system-flatpak-manager.service && \
-    systemctl --global enable ublue-user-flatpak-manager.service && \
+    systemctl enable ublue-system-networked-tasks.service && \
+    systemctl enable brew-install-workaround.service && \
+    systemctl --global enable ublue-user-networked-tasks.service && \
     systemctl --global enable ublue-user-setup.service && \
     fc-cache -f /usr/share/fonts/ubuntu && \
     fc-cache -f /usr/share/fonts/inter && \

--- a/usr/lib/systemd/system/brew-install-workaround.service
+++ b/usr/lib/systemd/system/brew-install-workaround.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Workaround brew-install not having the correct caps
+ConditionFileIsExecutable=/usr/libexec/brew-install
+After=local-fs.target
+
+[Service]
+Type=oneshot
+# Copy if it doesn't exist
+ExecStartPre=/usr/bin/bash -c "[ -x /usr/local/libexec/.brew-install ] || /usr/bin/cp /usr/libexec/brew-install /usr/local/libexec/.brew-install"
+# This is faster than using .mount unit. Also allows for the previous line/cleanup
+ExecStartPre=/usr/bin/mount --bind /usr/local/libexec/.brew-install /usr/libexec/brew-install
+# Fix caps
+ExecStart=/usr/sbin/setcap 'cap_sys_admin+p' /usr/libexec/brew-install
+# Clean-up after ourselves
+ExecStop=/usr/bin/umount /usr/libexec/brew-install
+ExecStop=/usr/bin/rm /usr/local/libexec/.brew-install
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/systemd/system/ublue-system-networked-tasks.service
+++ b/usr/lib/systemd/system/ublue-system-networked-tasks.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=Manage system flatpaks
+Description=Manage tasks that require network access (Flatpaks)
 Documentation=https://github.com/ublue-os/endlish-oesque/issues/10
 Wants=network-online.target
 After=network-online.target ublue-system-setup.service
 
 [Service]
 Type=oneshot
-ExecStart=/usr/libexec/ublue-system-flatpak-manager
+ExecStart=/usr/libexec/ublue-system-networked-tasks
 Restart=on-failure
 RestartSec=30
 StartLimitInterval=0

--- a/usr/lib/systemd/user/ublue-user-networked-tasks.service
+++ b/usr/lib/systemd/user/ublue-user-networked-tasks.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=Manage user flatpaks
+Description=Manage user activities that require network access (Flatpaks, Brew)
 Documentation=https://github.com/ublue-os/endlish-oesque/issues/10
 Wants=network-online.target
 After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=/usr/libexec/ublue-user-flatpak-manager
+ExecStart=/usr/libexec/ublue-user-networked-tasks
 Restart=on-failure
 RestartSec=30
 StartLimitInterval=0

--- a/usr/libexec/ublue-system-networked-tasks
+++ b/usr/libexec/ublue-system-networked-tasks
@@ -2,12 +2,12 @@
 
 # Script Version
 VER=3
-VER_FILE="/etc/ublue/flatpak_manager_version"
+VER_FILE="/etc/ublue/networked_tasks_version"
 VER_RAN=$(cat $VER_FILE)
 
 # Run script if updated
 if [[ -f $VER_FILE && $VER = $VER_RAN ]]; then
-  echo "Flatpak manager v$VER has already ran. Exiting..."
+  echo "Networked tasks v$VER has already ran. Exiting..."
   exit 0
 fi
 

--- a/usr/libexec/ublue-user-networked-tasks
+++ b/usr/libexec/ublue-user-networked-tasks
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 # Script Version
-VER=3
-VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/flatpak_manager_version"
+VER=4
+VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/networked_tasks_version"
 VER_RAN=$(cat $VER_FILE)
 
 mkdir -p "$(dirname "$VER_FILE")" || exit 1
@@ -11,7 +11,7 @@ mkdir -p "$(dirname "$VER_FILE")" || exit 1
 # Exit if v1 file is present.
 VER_1_FILE="$HOME/.ublue_flatpak_manager_version"
 if [[ -f $VER_1_FILE  ]]; then
-  echo "Flatpak manager v1 has already ran. Exiting..."
+  echo "Networked tasks v$VER has already ran. Exiting..."
   rm $VER_1_FILE
   echo $VER > $VER_FILE
   exit 0
@@ -49,5 +49,12 @@ if [[ ! -f $VER_FILE && -n $REMOVE_LIST ]]; then
 fi
 
 notify-send "Flatpak installer" "Finished installing user flatpaks" --app-name="Flatpak installer" -u NORMAL
+
+# Install brew
+if [[ ! -x /var/home/linuxbrew/.linuxbrew/bin/brew ]]; then
+  NONINTERACTIVE=1 /usr/libexec/brew-install
+fi
+
+notify-send "Brew installer" "Finished installing brew package manager" --app-name="Brew installer" -u NORMAL
 
 echo $VER > $VER_FILE

--- a/usr/libexec/ublue-user-setup
+++ b/usr/libexec/ublue-user-setup
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # SCRIPT VERSION
-USER_SETUP_VER=4
+USER_SETUP_VER=5
 USER_SETUP_VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/user-setup"
 USER_SETUP_VER_RAN=$(cat $USER_SETUP_VER_FILE)
 
@@ -34,11 +34,6 @@ PTYXIS_DIR="$HOME/.local/share/org.gnome.Ptyxis/palettes"
 mkdir -p "$PTYXIS_DIR"
 if [[ ! -f "$PTYXIS_DIR/catppuccin-dynamic.palette" ]]; then
   cp "$PTYXIS_THEME_DIR/catppuccin-dynamic.palette" "$PTYXIS_DIR/catppuccin-dynamic.palette"
-fi
-
-# Install brew
-if [[ ! -x /var/home/linuxbrew/.linuxbrew/bin/brew ]]; then
-  NONINTERACTIVE=1 /usr/libexec/brew-install
 fi
 
 # Handle privileged tasks


### PR DESCRIPTION
Also renames the flatpak installer to instead be a "networked tasks manager", of which Brew joins the roster.