### PR TITLE
fix: add pmcd log directory with tmpfiles.d

### DIFF
--- a/usr/lib/tmpfiles.d/pmcd.conf
+++ b/usr/lib/tmpfiles.d/pmcd.conf
@@ -1,0 +1,1 @@
+d /var/log/pcp/pmcd - - - -


### PR DESCRIPTION
noticed pmcd log directory was missing and service was failed.  Here's a tmpfiles.d fix for it.