### PR TITLE
fix: correct ulimit nofile issue with brew

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -114,6 +114,7 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"$
     echo "Hidden=true" >> /usr/share/applications/nvtop.desktop && \
     echo "Hidden=true" >> /usr/share/applications/gnome-system-monitor.desktop && \
     rm -f /etc/yum.repos.d/_copr_che-nerd-fonts-"${FEDORA_MAJOR_VERSION}".repo && \
+    sed -i 's/#DefaultLimitNOFILE=/DefaultLimitNOFILE=4096:524288/' /etc/systemd/user.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/user.conf && \
     sed -i 's/#DefaultTimeoutStopSec.*/DefaultTimeoutStopSec=15s/' /etc/systemd/system.conf && \
     sed -i '/^PRETTY_NAME/s/Silverblue/Bluefin/' /usr/lib/os-release && \

--- a/usr/etc/security/limits.d/30-brew-limits.conf
+++ b/usr/etc/security/limits.d/30-brew-limits.conf
@@ -1,8 +1,9 @@
-#This file sets the resource limits for the users logged in via PAM.
-#It does not affect resource limits of the system services.
+#This file sets the resource limits for the users logged in via PAM,
+#more specifically, users logged in on via SSH or tty (console).
+#Limits related to terminals in Wayland/Xorg sessions depend on a
+#change to /etc/systemd/user.conf.
+#This does not affect resource limits of the system services.
 #This file overrides defaults set in /etc/security/limits.conf
 
-* hard nofile 524288
-root hard nofile 524288
-* soft nofile 524288
-root soft nofile 524288
+* soft nofile 4096
+root soft nofile 4096


### PR DESCRIPTION
`brew install texlive` was still failing with:
`Error: Too many open files @ rb_sysopen`

This sets a functional limits.conf soft nofile limit of 4096, but also sets the same default in systemd/user.conf which is required for the ulimit value to be respected in terminals running under Wayland/Xorg.

Relates: #670