### PR TITLE
fix: turn off audible bell in the terminal

### DIFF
--- a/usr/etc/dconf/db/local.d/01-ublue
+++ b/usr/etc/dconf/db/local.d/01-ublue
@@ -124,6 +124,7 @@ show-boxbuddy=true
 interface-style='system'
 restore-session=false
 restore-window-size=false
+audible-bell=false
 profile-uuids=['2871e8027773ae74d6c87a5f659bbc74']
 default-profile-uuid='2871e8027773ae74d6c87a5f659bbc74'
 


### PR DESCRIPTION
I am embarrassed that we didn't turn this off on day 1.

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
