### PR TITLE
chore(just): cleanup and standardize just recipes

### DIFF
--- a/just/custom.just
+++ b/just/custom.just
@@ -156,14 +156,14 @@ jetbrains-toolbox:
 # Install and configure Incus
 incus:
     #!/usr/bin/env bash
+    source /usr/lib/ujust/ujust.sh
     CURRENT_IMAGE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"')
-
     if grep -q "bluefin-dx" <<< $CURRENT_IMAGE
     then
         echo 'Installing and configuring Incus.'
         /usr/bin/bluefin-incus
     else
-        echo "Developer mode is currently ${CURRENT_STATE}."
+        echo "Developer mode is currently ${b}${red}Disabled${n}."
         echo "Run `just devmode` to turn on Developer mode."
         exit
     fi

--- a/just/custom.just
+++ b/just/custom.just
@@ -164,7 +164,7 @@ incus:
         /usr/bin/bluefin-incus
     else
         echo "Developer mode is currently ${b}${red}Disabled${n}."
-        echo "Run `just devmode` to turn on Developer mode."
+        echo "Run \"just devmode\" to turn on Developer mode."
         exit
     fi
 


### PR DESCRIPTION
Drafting this so we can start a discussion.
Unlike the just reorg done in https://github.com/ublue-os/bazzite/pull/765
Bluefin has way less just recipes so I would like to prod and hear what the reorg needs will be and if the just files should be split up in groups like we did in bazzite.

In bazzite we focused on merging together recipes that involved the same thing under the `configure-` and `setup-` verbs.
- `configure` for things that already exist on the image
- `setup` for anything that would require installation before configuring. (we also have `install-foo` for anything that just installs without any configuration or removal steps)

shortcuts like `ujust benchmark` would stay as they are however i can merge all the `ujust zsh|fish|bash` into `ujust configure-shell` with an alias named `ujust shell`

Other than this there does not seem to be anything else to do other than just some minor cleanup and change recipes to follow the standard we decided on in https://github.com/ublue-os/config/pull/181
<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
