### PR TITLE
fix: force clean font cache

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -208,5 +208,6 @@ RUN rm -f /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".rep
     rm -f /etc/yum.repos.d/docker-ce.repo && \
     rm -f /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:phracek:PyCharm.repo && \
     rm -f /etc/yum.repos.d/fedora-cisco-openh264.repo && \
+    fc-cache --system-only --really-force --verbose && \
     rm -rf /tmp/* /var/* && \
     ostree container commit


### PR DESCRIPTION
Recommendation comes from jstone so that fonts can work better in flatpaks. Doesn't hurt to add this now and we might be able to remove the special case ones earlier in this file but I'd like to see how this works first.

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
