### PR TITLE
fix: remove gnome touch extensions

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -87,14 +87,6 @@ install-jetbrains-toolbox:
     echo "Launching JetBrains Toolbox"
     ./jetbrains-toolbox-"${BUILD_VERSION}"/jetbrains-toolbox
 
-alias touch := install-touch
-
-# Install a better on-screen-keyboard and gesture improvements
-install-touch:
-    pip install --upgrade gnome-extensions-cli
-    gext install improvedosk@nick-shmyrev.dev
-    gext install gestureImprovements@gestures
-
 alias atuin := install-atuin
 
 # Add atuin


### PR DESCRIPTION
We don't need those anymore

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
