### PR TITLE
chore: remove broken f38 builds for asus/surface

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,16 @@ jobs:
             is_latest_version: true
             is_stable_version: true
             is_gts_version: false
+        exclude:
+          - major_version: 38
+            image_flavor: asus
+          - major_version: 38
+            image_flavor: asus-nvidia
+          - major_version: 38
+            image_flavor: surface
+          - major_version: 38
+            image_flavor: surface-nvidia
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
ASUS/Surface don't have F38 upstream.