### PR TITLE
chore(ci): TEMPORARY hack to build surface again

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -76,10 +76,10 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
             /tmp/akmods-rpms/kmods/*xone*.rpm \
             /tmp/akmods-rpms/kmods/*openrazer*.rpm \
             /tmp/akmods-rpms/kmods/*wl*.rpm; \
-        if grep -qv "surface" <<< "${AKMODS_FLAVOR}"; then \
-            rpm-ostree install \
-                /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
-        ; fi && \
+    ; fi && \
+    if [[ "${FEDORA_MAJOR_VERSION}" -ge "39" ]] && grep -qv "surface" <<< "${AKMODS_FLAVOR}"; then \
+        rpm-ostree install \
+            /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
     ; fi && \
     if grep -qv "asus" <<< "${AKMODS_FLAVOR}"; then \
         rpm-ostree install \

--- a/Containerfile
+++ b/Containerfile
@@ -75,12 +75,15 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
             /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
             /tmp/akmods-rpms/kmods/*xone*.rpm \
             /tmp/akmods-rpms/kmods/*openrazer*.rpm \
-            /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
             /tmp/akmods-rpms/kmods/*wl*.rpm \
     ; fi && \
     if grep -qv "asus" <<< "${AKMODS_FLAVOR}"; then \
         rpm-ostree install \
             /tmp/akmods-rpms/kmods/*evdi*.rpm \
+    ; fi && \
+    if grep -qv "surface" <<< "${AKMODS_FLAVOR}"; then \
+        rpm-ostree install \
+            /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
     ; fi && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo && \
     wget https://copr.fedorainfracloud.org/coprs/che/nerd-fonts/repo/fedora-"${FEDORA_MAJOR_VERSION}"/che-nerd-fonts-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/_copr_che-nerd-fonts-"${FEDORA_MAJOR_VERSION}".repo

--- a/Containerfile
+++ b/Containerfile
@@ -75,7 +75,7 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
             /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
             /tmp/akmods-rpms/kmods/*xone*.rpm \
             /tmp/akmods-rpms/kmods/*openrazer*.rpm \
-            /tmp/akmods-rpms/kmods/*wl*.rpm && \
+            /tmp/akmods-rpms/kmods/*wl*.rpm; \
         if grep -qv "surface" <<< "${AKMODS_FLAVOR}"; then \
             rpm-ostree install \
                 /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \

--- a/Containerfile
+++ b/Containerfile
@@ -76,14 +76,14 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
             /tmp/akmods-rpms/kmods/*xone*.rpm \
             /tmp/akmods-rpms/kmods/*openrazer*.rpm \
             /tmp/akmods-rpms/kmods/*wl*.rpm \
+        if grep -qv "surface" <<< "${AKMODS_FLAVOR}"; then \
+            rpm-ostree install \
+                /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
+        ; fi && \
     ; fi && \
     if grep -qv "asus" <<< "${AKMODS_FLAVOR}"; then \
         rpm-ostree install \
             /tmp/akmods-rpms/kmods/*evdi*.rpm \
-    ; fi && \
-    if grep -qv "surface" <<< "${AKMODS_FLAVOR}"; then \
-        rpm-ostree install \
-            /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
     ; fi && \
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo && \
     wget https://copr.fedorainfracloud.org/coprs/che/nerd-fonts/repo/fedora-"${FEDORA_MAJOR_VERSION}"/che-nerd-fonts-fedora-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/_copr_che-nerd-fonts-"${FEDORA_MAJOR_VERSION}".repo

--- a/Containerfile
+++ b/Containerfile
@@ -75,7 +75,7 @@ RUN sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
             /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
             /tmp/akmods-rpms/kmods/*xone*.rpm \
             /tmp/akmods-rpms/kmods/*openrazer*.rpm \
-            /tmp/akmods-rpms/kmods/*wl*.rpm \
+            /tmp/akmods-rpms/kmods/*wl*.rpm && \
         if grep -qv "surface" <<< "${AKMODS_FLAVOR}"; then \
             rpm-ostree install \
                 /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \

--- a/install-akmods.sh
+++ b/install-akmods.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+wget https://negativo17.org/repos/fedora-multimedia.repo -O /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+if [[ "${FEDORA_MAJOR_VERSION}" -ge "39" ]]; then
+    rpm-ostree install \
+        /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
+        /tmp/akmods-rpms/kmods/*xone*.rpm \
+        /tmp/akmods-rpms/kmods/*openrazer*.rpm \
+        /tmp/akmods-rpms/kmods/*wl*.rpm
+    if grep -qv "surface" <<< "${AKMODS_FLAVOR}"; then
+        rpm-ostree install \
+            /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm
+    fi
+fi
+if grep -qv "asus" <<< "${AKMODS_FLAVOR}"; then
+    rpm-ostree install \
+        /tmp/akmods-rpms/kmods/*evdi*.rpm
+fi
+sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo


### PR DESCRIPTION
For some reason, the v4l2loopback kmod is not building on the current surface kernel (6.8.1) (even though it IS building for main 6.8.1).

This blocks installation of the kmod in question, so at least images are built.
