### PR TITLE
fix: Add user flathub repo if --user flatpaks are found

### DIFF
--- a/usr/libexec/ublue-flatpak-manager
+++ b/usr/libexec/ublue-flatpak-manager
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 # Script Version
-VER=1
+VER=2
 VER_FILE="${XDG_DATA_HOME:-$HOME/.local/share}/ublue/flatpak_manager_version"
 VER_RAN=$(cat $VER_FILE)
 
@@ -11,6 +11,14 @@ mkdir -p "$(dirname "$VER_FILE")" || exit 1
 if [[ -f $VER_FILE && $VER = $VER_RAN ]]; then
 	echo "Flatpak manager v$VER has already ran. Exiting..."
 	exit 0
+fi
+
+# Install User Flatpak Repo if user has flatpaks installed from that repo
+USER_FLATPAKS=$(flatpak list --user)
+
+if [[ -n "$USER_FLATPAKS" ]]; then
+    flatpak remote-add --if-not-exists --user flathub /usr/etc/flatpak/remotes.d/flathub.flatpakrepo
+	flatpak remote-modify --user --enable --prio=2 flathub
 fi
 
 # Use until yafti rework is done


### PR DESCRIPTION
User reported in Discord that they were unable to update their flatpak apps after the recent changes to the user flatpak service. This change seeks to add the --user flathub repo only if user flatpaks are found.

**BLOCKER:**
I need additional testing with the service file which requires me to set up a local registry to rebase from. When doing manual testing in a VM, it will add it to the users home directory, not sure what the service will do, I want to test that.
