### PR TITLE
fix: change working dir to `/tmp` for `stress-ng` in `ujust benchmark`

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -13,7 +13,7 @@
 # Run a one minute system benchmark
 benchmark:
     echo 'Running a 1 minute benchmark ...'
-    stress-ng --matrix 0 -t 1m --times
+    cd /tmp && stress-ng --matrix 0 -t 1m --times
 
 # Configure Bluefin-CLI Terminal Experience
 bluefin-cli:


### PR DESCRIPTION
Change the working dir to `/tmp` for `stress-ng` in `ujust benchmark` to prevent read/write permission error as in https://github.com/ublue-os/bluefin/issues/1036

Note: setting `--temp-path` in `stress-ng` is not sufficient because `stress-ng` will continue to use the current directory for I/O tests.