### PR TITLE
chore: remove v4l2 module for asus

### DIFF
--- a/build_files/base/install-akmods.sh
+++ b/build_files/base/install-akmods.sh
@@ -10,7 +10,7 @@ if [[ "${FEDORA_MAJOR_VERSION}" -ge "39" ]]; then
         /tmp/akmods-rpms/kmods/*xone*.rpm \
         /tmp/akmods-rpms/kmods/*openrazer*.rpm \
         /tmp/akmods-rpms/kmods/*wl*.rpm
-    if grep -qv "surface" <<< "${AKMODS_FLAVOR}"; then
+    if grep -Eqv "(surface|asus)" <<< "${AKMODS_FLAVOR}"; then
         rpm-ostree install \
             /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm
     fi


### PR DESCRIPTION
v4l2loopback module has not built for the asus kernel since ~25 March.
<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
