### PR TITLE
chore: Add aurora to boot menu

### DIFF
--- a/boot_menu.yml
+++ b/boot_menu.yml
@@ -13,4 +13,17 @@ ublue_variants:
     flavors:
       - label: bluefin-nvidia
         info: Bluefin
-        
+  - label: ublue-os/aurora
+    ks: /kickstart/ublue-os.ks
+    flavors:
+      - label: aurora
+        info: Aurora
+  - label: ublue-os/aurora-nvidia
+    ks: /kickstart/ublue-os-nvidia.ks
+    subvariants:
+      - label: latest driver
+      - label: 470xx driver
+        suffix: -470
+    flavors:
+      - label: aurora-nvidia
+        info: Aurora


### PR DESCRIPTION
Defines boot menu entries for aurora in boot_menu.yml

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
