### PR TITLE
chore(cleanup): Remove NVIDIA configuration from non-NVIDIA images

### DIFF
--- a/build_files/base/cleanup.sh
+++ b/build_files/base/cleanup.sh
@@ -2,6 +2,11 @@
 
 set -ouex pipefail
 
+if [[ "${IMAGE_FLAVOR}" =~ "nvidia" ]]; then
+  rm /usr/etc/dracut.conf.d/nvidia.conf
+  rm /usr/lib/modprobe.d/nvidia.conf
+fi
+
 rm -f /etc/yum.repos.d/tailscale.repo
 rm -f /etc/yum.repos.d/charm.repo
 rm -f /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo


### PR DESCRIPTION
Removes NVIDIA dracut and modprobe configuration from non-NVIDIA images

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
