### PR TITLE
fix(40-dx): temporarily removed devpod from 40

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -71,7 +71,6 @@
 				"code",
 				"containerd.io",
 				"dbus-x11",
-				"devpod",
 				"docker-ce",
 				"docker-ce-cli",
 				"docker-buildx-plugin",
@@ -139,6 +138,7 @@
 			],
 			"dx": [
 				"distrobuilder",
+				"devpod",
 				"podman-plugins"
 			]
 		},
@@ -164,6 +164,7 @@
 			],
 			"dx": [
 				"distrobuilder",
+				"devpod",
 				"podman-plugins"
 			]
 		},


### PR DESCRIPTION
Fedora 40 dropped openssl1.1, Remove devpod temporarily.

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
