### PR TITLE
fix: remove duplicate builds on merge queue and push

### DIFF
--- a/.github/workflows/build-38-bluefin.yml
+++ b/.github/workflows/build-38-bluefin.yml
@@ -8,13 +8,6 @@ on:
     paths-ignore:
       - '**.md'
       - 'system_files/kinoite/**'
-  push:
-    branches:
-      - main
-      - testing
-    paths-ignore:
-      - '**.md'
-      - 'system_files/kinoite/**'
   schedule:
     - cron: '42 16 * * *'  # 16:42 UTC everyday
   workflow_dispatch:

--- a/.github/workflows/build-39-aurora.yml
+++ b/.github/workflows/build-39-aurora.yml
@@ -8,13 +8,6 @@ on:
     paths-ignore:
       - '**.md'
       - 'system_files/silverblue/**'
-  push:
-    branches:
-      - main
-      - testing
-    paths-ignore:
-      - '**.md'
-      - 'system_files/silverblue/**'
   schedule:
     - cron: '41 16 * * *'  # 16:41 UTC everyday
   workflow_dispatch:

--- a/.github/workflows/build-39-bluefin.yml
+++ b/.github/workflows/build-39-bluefin.yml
@@ -8,13 +8,6 @@ on:
     paths-ignore:
       - '**.md'
       - 'system_files/kinoite/**'
-  push:
-    branches:
-      - main
-      - testing
-    paths-ignore:
-      - '**.md'
-      - 'system_files/kinoite/**'
   schedule:
     - cron: '41 16 * * *'  # 16:41 UTC everyday
   workflow_dispatch:

--- a/.github/workflows/build-40-aurora.yml
+++ b/.github/workflows/build-40-aurora.yml
@@ -8,13 +8,6 @@ on:
     paths-ignore:
       - '**.md'
       - 'system_files/silverblue/**'
-  push:
-    branches:
-      - main
-      - testing
-    paths-ignore:
-      - '**.md'
-      - 'system_files/silverblue/**'
   schedule:
     - cron: '40 16 * * *'  # 16:40 UTC everyday
   workflow_dispatch:

--- a/.github/workflows/build-40-bluefin.yml
+++ b/.github/workflows/build-40-bluefin.yml
@@ -8,13 +8,6 @@ on:
     paths-ignore:
       - '**.md'
       - 'system_files/kinoite/**'
-  push:
-    branches:
-      - main
-      - testing
-    paths-ignore:
-      - '**.md'
-      - 'system_files/kinoite/**'
   schedule:
     - cron: '40 16 * * *'  # 16:40 UTC everyday
   workflow_dispatch:


### PR DESCRIPTION
We are building and pushing to GHCR when a PR is added to a merge queue (`merge_group`), and also after the PR has been successfully merged into main (`push`).

To me, this seems like we are running a build when we do not need to, and unnecessarily taking up GHA runners.

This PR removes the builds after a commit has been merged to `main` and `testing` since these are ran during merge queue.