### PR TITLE
fix: change switch-input-source keybinding

### DIFF
--- a/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
@@ -35,6 +35,7 @@ switch-applications-backward = ['<Shift><Super>Tab']
 switch-windows = ['<Alt>Tab']
 switch-windows-backward = ['<Shift><Alt>Tab']
 switch-input-source = ['<Shift><Super>Space']
+switch-input-source-backwards = []
 
 [org/gnome/desktop/peripherals/touchpad]
 tap-to-click=true

--- a/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
@@ -34,6 +34,7 @@ switch-applications = ['<Super>Tab']
 switch-applications-backward = ['<Shift><Super>Tab']
 switch-windows = ['<Alt>Tab']
 switch-windows-backward = ['<Shift><Alt>Tab']
+switch-input-source = ['<Shift><Super>Space']
 
 [org/gnome/desktop/peripherals/touchpad]
 tap-to-click=true


### PR DESCRIPTION
This `<Super>Space` keybinding should be used for the Search Light extension since it matches Alfred (MacOS).  
This PR is untested, and I will not be around to test it until tomorrow.
