### PR TITLE
Revert "fix: change switch-input-source keybinding"

### DIFF
--- a/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
@@ -34,8 +34,6 @@ switch-applications = ['<Super>Tab']
 switch-applications-backward = ['<Shift><Super>Tab']
 switch-windows = ['<Alt>Tab']
 switch-windows-backward = ['<Shift><Alt>Tab']
-switch-input-source = ['<Shift><Super>Space']
-switch-input-source-backwards = []
 
 [org/gnome/desktop/peripherals/touchpad]
 tap-to-click=true


### PR DESCRIPTION
Reverts ublue-os/bluefin#1146

A clean install looks like normal GNOME.  Think I broke all dconf settings with this change.