### PR TITLE
fix: remove switch-input-source keybinding

### DIFF
--- a/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
@@ -35,7 +35,7 @@ switch-applications-backward = ['<Shift><Super>Tab']
 switch-windows = ['<Alt>Tab']
 switch-windows-backward = ['<Shift><Alt>Tab']
 switch-input-source = ['<Shift><Super>space']
-switch-input-source-backwards = ['']
+switch-input-source-backward = ['']
 
 [org/gnome/desktop/peripherals/touchpad]
 tap-to-click=true

--- a/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
@@ -34,6 +34,8 @@ switch-applications = ['<Super>Tab']
 switch-applications-backward = ['<Shift><Super>Tab']
 switch-windows = ['<Alt>Tab']
 switch-windows-backward = ['<Shift><Alt>Tab']
+switch-input-source = ['<Shift><Super>space']
+switch-input-source-backwards = ['']
 
 [org/gnome/desktop/peripherals/touchpad]
 tap-to-click=true


### PR DESCRIPTION
This keybinding should be reserved for Search Light, so we need to unset the existing default usage of the keybind.

This is the second attempt at this, since the first attempt broke all dconf settings - restoring the system to a near stock GNOME shell.
