### PR TITLE
fix: source systemd-dx.sh from build-dx.sh script

### DIFF
--- a/build_files/dx/build-dx.sh
+++ b/build_files/dx/build-dx.sh
@@ -11,5 +11,6 @@ sysctl -p
 . /tmp/build/image-info.sh
 . /tmp/build/fetch-install-dx.sh
 . /tmp/build/workarounds.sh
+. /tmp/build/systemd-dx.sh
 . /tmp/build/branding-dx.sh
 . /tmp/build/cleanup-dx.sh


### PR DESCRIPTION
I feel this file should be sourced (and therefore executed) from the build-dx.sh file.  This is why we have no Podman or Docker sockets enabled in DX.