### PR TITLE
fix: ujust ollama

### DIFF
--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -56,8 +56,6 @@ ollama:
             ;;
     esac
 
-    mkdir -p "$HOME/.ollama"
-
     read -r -d '' QUADLET <<-EOF
     [Unit]
     Description=The Ollama container
@@ -68,6 +66,8 @@ ollama:
     TimeoutStartSec=60
     # Ensure there's a userland podman.sock
     ExecStartPre=/bin/systemctl --user enable podman.socket
+    # Ensure that the dir exists
+    ExecStartPre=-mkdir -p %h/.ollama
 
     [Container]
     ContainerName=ollama

--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -56,6 +56,8 @@ ollama:
             ;;
     esac
 
+    mkdir -p "$HOME/.ollama"
+
     read -r -d '' QUADLET <<-EOF
     [Unit]
     Description=The Ollama container


### PR DESCRIPTION
From a fresh install with NVIDIA the systemd user service fails to start due to the `$HOME/.ollama/` dir not being present. Error message below:


```bash
Apr 19 13:48:46 desktop systemd[6775]: Starting ollama.service - The Ollama container...
░░ Subject: A start job for unit UNIT has begun execution
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
░░ 
░░ A start job for unit UNIT has begun execution.
░░ 
░░ The job identifier is 2686.
Apr 19 13:48:46 desktop ollama[57764]: Error: statfs /var/home/storopoli/.ollama: no such file or directory
Apr 19 13:48:46 desktop podman[57764]: 2024-04-19 13:48:46.644839296 -0300 -03 m=+0.017979759 image pull 6ffa7903c2d4b1a8c90be45edf1c3931>
Apr 19 13:48:46 desktop systemd[6775]: ollama.service: Main process exited, code=exited, status=125/n/a
░░ Subject: Unit process exited
░░ Defined-By: systemd
░░ Support: https://lists.freedesktop.org/mailman/listinfo/systemd-devel
```

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
