### PR TITLE
chore(aurora): remove the line that deletes the konsole desktop file

### DIFF
--- a/build_files/base/aurora-changes.sh
+++ b/build_files/base/aurora-changes.sh
@@ -12,5 +12,6 @@ if [[ "${BASE_IMAGE_NAME}" = "kinoite" ]]; then
     sed -i 's@Keywords=@Keywords=konsole;console;@g' /usr/share/applications/org.gnome.Ptyxis.desktop
     cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.gnome.Ptyxis.desktop
     sed -i 's@\[Desktop Action new-window\]@\[Desktop Action new-window\]\nX-KDE-Shortcuts=Ctrl+Alt+T@g' /usr/share/applications/org.gnome.Ptyxis.desktop
+    rm -f /usr/share/kglobalaccel/org.kde.konsole.desktop
     systemctl enable kde-sysmonitor-workaround.service
 fi

--- a/build_files/base/aurora-changes.sh
+++ b/build_files/base/aurora-changes.sh
@@ -12,6 +12,5 @@ if [[ "${BASE_IMAGE_NAME}" = "kinoite" ]]; then
     sed -i 's@Keywords=@Keywords=konsole;console;@g' /usr/share/applications/org.gnome.Ptyxis.desktop
     cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.gnome.Ptyxis.desktop
     sed -i 's@\[Desktop Action new-window\]@\[Desktop Action new-window\]\nX-KDE-Shortcuts=Ctrl+Alt+T@g' /usr/share/applications/org.gnome.Ptyxis.desktop
-    sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/org.kde.konsole.desktop
     systemctl enable kde-sysmonitor-workaround.service
 fi

--- a/build_files/base/aurora-changes.sh
+++ b/build_files/base/aurora-changes.sh
@@ -13,6 +13,5 @@ if [[ "${BASE_IMAGE_NAME}" = "kinoite" ]]; then
     cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.gnome.Ptyxis.desktop
     sed -i 's@\[Desktop Action new-window\]@\[Desktop Action new-window\]\nX-KDE-Shortcuts=Ctrl+Alt+T@g' /usr/share/applications/org.gnome.Ptyxis.desktop
     sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/org.kde.konsole.desktop
-    rm -f /usr/share/kglobalaccel/org.kde.konsole.desktop
     systemctl enable kde-sysmonitor-workaround.service
 fi


### PR DESCRIPTION
<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->

This PR removes the line that deletes the .desktop file from the image to leave users the choice of a terminal. Ptyxis is still the default, but users who prefer a more native-feeling KDE terminal experience, Konsole should be available to launch and choose. 