### PR TITLE
fix(Aurora): Configure ksshaskpass in /etc/profile.d

### DIFF
--- a/build_files/base/aurora-changes.sh
+++ b/build_files/base/aurora-changes.sh
@@ -13,5 +13,6 @@ if [[ "${BASE_IMAGE_NAME}" = "kinoite" ]]; then
     cp /usr/share/applications/org.gnome.Ptyxis.desktop /usr/share/kglobalaccel/org.gnome.Ptyxis.desktop
     sed -i 's@\[Desktop Action new-window\]@\[Desktop Action new-window\]\nX-KDE-Shortcuts=Ctrl+Alt+T@g' /usr/share/applications/org.gnome.Ptyxis.desktop
     rm -f /usr/share/kglobalaccel/org.kde.konsole.desktop
+    rm -f /usr/etc/profile.d/gnome-ssh-askpass.{csh,sh} # This shouldn't be pulled in
     systemctl enable kde-sysmonitor-workaround.service
 fi

--- a/system_files/kinoite/usr/etc/profile.d/ksshaskpass.sh
+++ b/system_files/kinoite/usr/etc/profile.d/ksshaskpass.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+SSH_ASKPASS=/usr/bin/ksshaskpass
+export SSH_ASKPASS
+
+SSH_ASKPASS_REQUIRE=prefer
+export SSH_ASKPASS_REQUIRE


### PR DESCRIPTION
Remove gnome-ssh-askpass configuration on Aurora
<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
