### PR TITLE
chore(ci): scanning fixes and enable aurora

### DIFF
--- a/.github/workflows/build-38-bluefin.yml
+++ b/.github/workflows/build-38-bluefin.yml
@@ -24,7 +24,7 @@ jobs:
   scan:
     # Scan can still be ran when some builds fail since only successfully built
     # images will be stored in the output
-    if: github.event_name != 'pull_request' && always()
+    if: (github.event_name != 'pull_request' && github.event_name != 'merge_group') && always()
     uses: ./.github/workflows/reusable-image-scan.yml
     needs: build
     secrets: inherit

--- a/.github/workflows/build-39-aurora.yml
+++ b/.github/workflows/build-39-aurora.yml
@@ -20,3 +20,13 @@ jobs:
     with:
       brand_name: aurora
       fedora_version: 39
+
+  scan:
+    # Scan can still be ran when some builds fail since only successfully built
+    # images will be stored in the output
+    if: (github.event_name != 'pull_request' && github.event_name != 'merge_group') && always()
+    uses: ./.github/workflows/reusable-image-scan.yml
+    needs: build
+    secrets: inherit
+    with:
+      images: ${{ needs.build.outputs.images }}

--- a/.github/workflows/build-39-bluefin.yml
+++ b/.github/workflows/build-39-bluefin.yml
@@ -24,7 +24,7 @@ jobs:
   scan:
     # Scan can still be ran when some builds fail since only successfully built
     # images will be stored in the output
-    if: github.event_name != 'pull_request' && always()
+    if: (github.event_name != 'pull_request' && github.event_name != 'merge_group') && always()
     uses: ./.github/workflows/reusable-image-scan.yml
     needs: build
     secrets: inherit

--- a/.github/workflows/build-40-aurora.yml
+++ b/.github/workflows/build-40-aurora.yml
@@ -20,3 +20,13 @@ jobs:
     with:
       brand_name: aurora
       fedora_version: 40
+
+  scan:
+    # Scan can still be ran when some builds fail since only successfully built
+    # images will be stored in the output
+    if: (github.event_name != 'pull_request' && github.event_name != 'merge_group') && always()
+    uses: ./.github/workflows/reusable-image-scan.yml
+    needs: build
+    secrets: inherit
+    with:
+      images: ${{ needs.build.outputs.images }}

--- a/.github/workflows/build-40-bluefin.yml
+++ b/.github/workflows/build-40-bluefin.yml
@@ -24,7 +24,7 @@ jobs:
   scan:
     # Scan can still be ran when some builds fail since only successfully built
     # images will be stored in the output
-    if: github.event_name != 'pull_request' && always()
+    if: (github.event_name != 'pull_request' && github.event_name != 'merge_group') && always()
     uses: ./.github/workflows/reusable-image-scan.yml
     needs: build
     secrets: inherit

--- a/.github/workflows/reusable-image-scan.yml
+++ b/.github/workflows/reusable-image-scan.yml
@@ -23,6 +23,7 @@ jobs:
   scan-image:
     needs: generate-matrix
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Enables SBOM and scanning for Aurora.
Adds a timeout to the SBOM actions.
Do not run SBOM generation in merge_group.