### PR TITLE
fix: exclude Syft ELF package cataloger

### DIFF
--- a/.github/syft.yml
+++ b/.github/syft.yml
@@ -3,3 +3,9 @@ exclude:
   - '/sysroot/ostree/repo/objects/**'
   - '/usr/share/icons/**'
   - '/usr/share/doc/**'
+
+# There's a known issue with the previous releases where ELF cataloger uses far
+# too much memory, causing crashes.  Current recommendation is to disable this
+# until the Anchore team have investigated and rolled out a fix
+select-catalogers:
+  - '-elf-package'


### PR DESCRIPTION
There's a known issue with the previous releases where ELF cataloger uses far
too much memory, causing crashes.  Current recommendation is to disable this
until the Anchore team have investigated and rolled out a fix