### PR TITLE
fix(ci): Update reusable-image-scan.yml to use lowercase registry name

### DIFF
--- a/.github/workflows/reusable-image-scan.yml
+++ b/.github/workflows/reusable-image-scan.yml
@@ -41,9 +41,15 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
           syft version
 
+      - name: Lowercase Registry
+        id: registry_case
+        uses: ASzc/change-string-case-action@v6
+        with:
+          string: ${{ matrix.image }}
+
       - name: Generate SBOM
         env:
-          IMAGE: ${{ matrix.image }}
+          IMAGE: ${{ steps.registry_case.outputs.lowercase }}
         run: |
           syft ${IMAGE} \
             --output cyclonedx-json=sbom.json \
@@ -60,7 +66,7 @@ jobs:
       - name: Generate artifact name
         id: artifact-name
         env:
-          IMAGE: ${{ matrix.image }}
+          IMAGE: ${{ steps.registry_case.outputs.lowercase }}
         run: |
           echo "name=$(echo ${IMAGE} | awk -F'/' '{print $NF}' | sed 's/:/-/g')" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
I was just having an issue with the image scan part of the github build actions. I was able to pinpoint the issue down to my github username having capital letters based on this error. 
```
   - unable to parse registry reference="ghcr.io/APoorDev/aurora-asus@sha256:707967fb1d91da42774b8756c50c9df974919d1a84dd879ba7063c08aae99328": could not parse reference: ghcr.io/APoorDev/aurora-asus@sha256:707967fb1d91da42774b8756c50c9df974919d1a84dd879ba7063c08aae99328
```
 I just stole the fix you all use in the reusable-build.yml and it was able to fix this error. Let me know if there is anything you would like changed or if I did something wrong!

P.S. 
Awesome project, Ive been having a lot of fun messing with and learning github actions!