### PR TITLE
fix(bluefin): add blur-my-shell to Fedora 40

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -43,6 +43,7 @@
 			],
 			"silverblue": [
 				"gnome-shell-extension-appindicator",
+				"gnome-shell-extension-blur-my-shell",
 				"gnome-shell-extension-caffeine",
 				"gnome-shell-extension-dash-to-dock",
 				"gnome-shell-extension-gsconnect",
@@ -139,7 +140,6 @@
 	"38": {
 		"include": {
 			"silverblue": [
-				"gnome-shell-extension-blur-my-shell",
 				"gnome-shell-extension-tailscale-status"
 			],
 			"dx": [
@@ -161,7 +161,6 @@
 				"input-leap"
 			],
 			"silverblue": [
-				"gnome-shell-extension-blur-my-shell",
 				"gnome-shell-extension-tailscale-gnome-qs",
 				"nautilus-open-any-terminal"
 			],


### PR DESCRIPTION
Blur my shell previously couldn't be installed on a machine with GNOME >45, but it seems Fedora have bumped the versions in their repos.
It now can be installed on F40.