### PR TITLE
fix(ci): Add ISO workflow for Bluefin for building latest

### DIFF
--- a/.github/workflows/build-bluefin-gts-iso.yml
+++ b/.github/workflows/build-bluefin-gts-iso.yml
@@ -1,0 +1,12 @@
+name: Bluefin GTS ISO Build
+on:
+  workflow_dispatch:
+
+jobs:
+  build-gts:
+    name: Bluefin GTS
+    uses: ./.github/workflows/reusable-build-iso.yml
+    secrets: inherit
+    with:
+      brand_name: bluefin
+      fedora_version: 39

--- a/.github/workflows/build-bluefin-latest-iso.yml
+++ b/.github/workflows/build-bluefin-latest-iso.yml
@@ -1,12 +1,12 @@
-name: Bluefin ISO Build
+name: Bluefin Latest ISO Build
 on:
   workflow_dispatch:
 
 jobs:
-  build-39:
-    name: Bluefin 39
+  build-latest:
+    name: Bluefin Latest
     uses: ./.github/workflows/reusable-build-iso.yml
     secrets: inherit
     with:
       brand_name: bluefin
-      fedora_version: 39
+      fedora_version: 40


### PR DESCRIPTION
We don't have a manual workflow for building latest ISOs. We will need this in order to push up newer versions of latest ISOs.
