### PR TITLE
fix: Do not set SSH_ASKPASS_REQUIRE in Aurora

### DIFF
--- a/system_files/kinoite/usr/etc/profile.d/ksshaskpass.sh
+++ b/system_files/kinoite/usr/etc/profile.d/ksshaskpass.sh
@@ -2,6 +2,3 @@
 
 SSH_ASKPASS=/usr/bin/ksshaskpass
 export SSH_ASKPASS
-
-SSH_ASKPASS_REQUIRE=prefer
-export SSH_ASKPASS_REQUIRE


### PR DESCRIPTION
#1208

SSH_ASKPASS should only be prompted when the user does not have a terminal. Otherwise, if /usr/bin/ksshaskpass isn't available it won't fall back to the terminal for input. To trigger ksshaskpass from the cmdline, use `ssh-add < /dev/null`
<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
