### PR TITLE
fix(Aurora): Change the default values for the wobbly windows desktop effect

### DIFF
--- a/system_files/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kwinrc
+++ b/system_files/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kwinrc
@@ -3,11 +3,11 @@ InputMethod[$e]=/usr/share/applications/com.github.maliit.keyboard.desktop
 VirtualKeyboardEnabled=true
 
 [Effect-wobblywindows]
-AdvancedMode=true
-Drag=97
-MoveFactor=25
-Stiffness=7
-WobblynessLevel=4
+AdvancedMode=false
+Drag=80
+MoveFactor=10
+Stiffness=15
+WobblynessLevel=0
 
 [Plugins]
 blurEnabled=true


### PR DESCRIPTION
The default values for the wobbly windows desktop effect are kind of annoying. This changes this to more reasonable values.
