### PR TITLE
feat: Allow just to turn off transparency for terminals

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -142,7 +142,7 @@ ptyxis-transparency opacity="0.95":
     set -euxo pipefail
     if [[ -n "$(echo "{{ opacity }}" | grep -v '^[.0-9]*$')" ]]; then
       printf "Value must be numeric: %s.\n" "{{ opacity }}"
-    elif [[ $(echo "0<{{ opacity }} && 1>{{ opacity }}" | bc -q) -eq 1 ]]; then
+    elif [[ $(echo "0<{{ opacity }} && 1>={{ opacity }}" | bc -q) -eq 1 ]]; then
       raw="$(gsettings get org.gnome.Ptyxis profile-uuids)"
       uuids="$(sed -En 's|[^0-9a-z]*||g; s|([0-9a-z]{32})|\1\n|gp' <<<${raw})"
       for i in ${uuids}; do
@@ -150,7 +150,7 @@ ptyxis-transparency opacity="0.95":
         gsettings set "${location}" opacity "{{ opacity }}"; done
       printf "Ptyxis opacity is now %s.\n" "{{ opacity }}"
     else
-      printf "Value must be between 0 and 1: %s.\n" "{{ opacity }}"
+      printf "Value must be greater than 0 and less than or equal to 1: %s.\n" "{{ opacity }}"
     fi
 
 # Configure docker,incus-admin,lxd,libvirt container manager permissions


### PR DESCRIPTION
<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
This change allows the `ptyxis-transparency` recipe to set Ptyxis' opacity to values in the range (0-1]. The current recipe doesn't allow the user to spacify 1.0 as an opacity value, so transparency can't be completely turned off