### PR TITLE
fix: fastfetch don't include directory as option

### DIFF
--- a/system_files/silverblue/usr/etc/profile.d/bluefin-fastfetch.sh
+++ b/system_files/silverblue/usr/etc/profile.d/bluefin-fastfetch.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-BLUEFIN_FETCH_LOGO="$(find /usr/share/ublue-os/bluefin-logos/symbols/ | shuf -n 1 )"
+BLUEFIN_FETCH_LOGO="$(/usr/bin/find /usr/share/ublue-os/bluefin-logos/symbols/* | /usr/bin/shuf -n 1 )"
 
 alias fastfetch='/usr/bin/fastfetch --logo ${BLUEFIN_FETCH_LOGO}  -c /usr/share/ublue-os/ublue-os.jsonc'


### PR DESCRIPTION
Using find on a directory returns the directory as well as contents. Don't do that.

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
