### PR TITLE
feat: enable web_ui

### DIFF
--- a/.github/workflows/reusable-build-iso.yml
+++ b/.github/workflows/reusable-build-iso.yml
@@ -156,6 +156,7 @@ jobs:
           enable_cache_skopeo: "false"
           flatpak_remote_refs_dir: ${{ steps.generate-flatpak-dir-shortname.outputs.flatpak-dir-shortname }}
           enable_flatpak_dependencies: "false"
+          web_ui: "true"
 
       - name: Move ISOs to Upload Directory
         id: upload-directory
@@ -168,7 +169,7 @@ jobs:
           echo "iso-upload-dir=${ISO_UPLOAD_DIR}" >> $GITHUB_OUTPUT
 
       - name: Upload ISOs and Checksum to Job Artifacts
-        if: github.ref_name == 'testing'
+        #if: github.ref_name == 'testing'
         #if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
DO NOT MERGE THIS PR UNTIL ALL BLOCKERS HAVE BEEN FIXED.

Current Blockers for using the Web UI:

- [ ] Kickstart Post Scripts currently do not run after installation
- [ ] Issues with how disks are managed (if we can hide advanced partitioning options, this would allow us to get around this)
