### PR TITLE
fix: update search-light default appearance

### DIFF
--- a/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
@@ -124,7 +124,12 @@ show-boxbuddy=true
 
 [org/gnome/shell/extensions/search-light]
 shortcut-search=['<Super>space']
-
+scale-width=0.10
+scale-height=0.15
+border-thickness=1
+border-radius=1.65
+border-color=(0.23, 0.23, 0.23, 1.0)
+background-color=(0.0, 0.0, 0.0, 0.8)
 
 [org/gnome/Ptyxis]
 interface-style='system'


### PR DESCRIPTION
I found the default search light a little hard to read in some scenarios, so this PR darkens the background, rounds the edges to look more gnome-like and adds a very thin border.

Unfortunately blur was moved to the testing package since it caused a few bugs, so we are unable to use that.  

Updates Search Light's default appearance from:
![image](https://github.com/ublue-os/bluefin/assets/46304672/b6ff3d3f-cbcb-4512-a00d-78bf821849ce)

To:
![image](https://github.com/ublue-os/bluefin/assets/46304672/524dc23c-f153-423c-9e72-cbb7fc8d5690)
