### PR TITLE
feat: Add back xwayland video bridge to all images

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -38,8 +38,9 @@
 				"tmux",
 				"usbmuxd",
 				"wireguard-tools",
-				"xprop",
 				"wl-clipboard", 
+				"xprop",
+				"xwaylandvideobridge",
 				"zsh"
 			],
 			"silverblue": [


### PR DESCRIPTION
I'm unsure why we removed xwaylandvideobridge from Bluefin.

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
