### PR TITLE
fix: add missing backup flatpaks dejadup and pika

### DIFF
--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -13,3 +13,5 @@ app/io.github.dvlv.boxbuddyrs/x86_64/stable
 app/io.github.flattool.Warehouse/x86_64/stable
 app/org.fedoraproject.MediaWriter/x86_64/stable
 app/io.missioncenter.MissionCenter/x86_64/stable
+app/org.gnome.DejaDup/x86_64/stable
+app/org.gnome.World.PikaBackup/x86_64/stable

--- a/bluefin_flatpaks/flatpaks
+++ b/bluefin_flatpaks/flatpaks
@@ -10,6 +10,7 @@ app/org.gnome.Characters/x86_64/stable
 app/org.gnome.clocks/x86_64/stable
 app/org.gnome.Connections/x86_64/stable
 app/org.gnome.Contacts/x86_64/stable
+app/org.gnome.DejaDup/x86_64/stable
 app/org.gnome.Evince/x86_64/stable
 app/com.mattjakeman.ExtensionManager/x86_64/stable
 app/org.gnome.font-viewer/x86_64/stable
@@ -17,6 +18,7 @@ app/org.gnome.Logs/x86_64/stable
 app/org.gnome.Loupe/x86_64/stable
 app/org.gnome.Maps/x86_64/stable
 app/org.gnome.NautilusPreviewer/x86_64/stable
+app/org.gnome.World.PikaBackup/x86_64/stable
 app/org.gnome.TextEditor/x86_64/stable
 app/org.gnome.Weather/x86_64/stable
 app/io.missioncenter.MissionCenter/x86_64/stable


### PR DESCRIPTION
Add missing deja dup flatpak. Additionally add PikaBackup for Borg backup

<!---

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
