### PR TITLE
feat(just): add update-ng shortcut

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -272,3 +272,9 @@ install-system-flatpaks:
 # Configure grub bootmenu visibility
 configure-grub:
     /usr/libexec/configure-grub.sh
+
+update-ng:
+    echo "Note: This command doesn't work if you have locally layered packages" 
+    sudo bootc upgrade
+    flatpak update -y
+    brew upgrade


### PR DESCRIPTION
This is to test using bootc upgrade in lieu of rpm-ostree

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
