### PR TITLE
fix(dx): do not start ollama automatically

### DIFF
--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -97,7 +97,7 @@ ollama:
     ${CUSTOM_ARGS}
 
     [Install]
-    RequiredBy=default.target
+    RequiredBy=multi-user.target
     EOF
     if [  ! -f ~/.config/containers/systemd/ollama.container ]; then
         mkdir -p ~/.config/containers/systemd


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
This changes Ollama's startup to require a user to run `systemctl --user start ollama`, rather than automatically starting on boot.