### PR TITLE
feat(framework): Stop enabling power-profile-switcher in ublue-user-setup

### DIFF
--- a/system_files/shared/usr/libexec/ublue-user-setup
+++ b/system_files/shared/usr/libexec/ublue-user-setup
@@ -44,8 +44,6 @@ fi
 
 if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
   if [[ ! -f "$UBLUE_CONFIG_DIR/framework-initialized" ]]; then
-    echo 'Enabling automatic power profile extension'
-    gnome-extensions enable power-profile-switcher@eliapasquali.github.io
     echo 'Setting Framework logo menu'
     dconf write /org/gnome/shell/extensions/Logo-menu/symbolic-icon true
     dconf write /org/gnome/shell/extensions/Logo-menu/menu-button-icon-image 31


### PR DESCRIPTION
power-profile-switcher is a good extension to install, but it's not a great default to start with; see the attached issue.

Remove enabling the switcher during user setup.

Fixes #1276

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
