### PR TITLE
feat: Restore power profile switcher on framework

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -255,6 +255,22 @@ configure-vfio ACTION="":
       sudo /usr/libexec/bluefin-dx-kvmfr-setup
     fi
 
+# Change automatic power profile switching behavior
+configure-auto-power-profile ACTION="help":
+    #!/usr/bin/bash
+    source /usr/lib/ujust/ujust.sh
+    OPTION={{ ACTION }}
+    if [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust configure-auto-power-profile <option>"
+      echo "  Use 'enable' to allow automatic power profile switching based on power state
+      echo "  Use 'disable' to prevent automatic power profile switching based on power state
+      exit 0
+    elif [[ "${OPTION,,}" =~ enable ]]; then
+      gnome-extensions enable auto-power-profile@dmy3k.github.io
+    elif [[ "${OPTION,,}" =~ disable ]]; then
+      gnome-extensions disable auto-power-profile@dmy3k.github.io
+    fi
+
 # Install system flatpaks for rebasers
 [private]
 install-system-flatpaks:

--- a/packages.json
+++ b/packages.json
@@ -50,7 +50,7 @@
 				"gnome-shell-extension-gsconnect",
 				"gnome-shell-extension-logo-menu",
 				"gnome-shell-extension-search-light",
-				"gnome-shell-extension-power-profile-switcher",
+				"gnome-shell-extension-auto-power-profile",
 				"libgda-sqlite",
 				"libgda",
 				"libratbag-ratbagd",

--- a/system_files/shared/usr/libexec/ublue-user-setup
+++ b/system_files/shared/usr/libexec/ublue-user-setup
@@ -44,6 +44,8 @@ fi
 
 if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
   if [[ ! -f "$UBLUE_CONFIG_DIR/framework-initialized" ]]; then
+    echo 'Enabling automatic power profile extension'
+    ujust configure-auto-power-profile enable
     echo 'Setting Framework logo menu'
     dconf write /org/gnome/shell/extensions/Logo-menu/symbolic-icon true
     dconf write /org/gnome/shell/extensions/Logo-menu/menu-button-icon-image 31

--- a/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
@@ -142,6 +142,8 @@ default-profile-uuid='2871e8027773ae74d6c87a5f659bbc74'
 [org/gnome/Ptyxis/Profiles/2871e8027773ae74d6c87a5f659bbc74]
 palette='catppuccin-dynamic'
 
-[org/gnome/shell/extensions/power-profile-switcher]
+[org/gnome/shell/extensions/auto-power-profile]
 ac='balanced'
 bat='power-saver'
+notify=true
+lapmode=true


### PR DESCRIPTION
Adds `ujust configure-auto-power-profile <option>` command
Switches to new version of power profile switcher modified with notifications when the profile is changed.