### PR TITLE
fix(just): remove fleekbrew alias

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -10,13 +10,6 @@
 # fix-       = apply fix/patch/workaround for something
 # foo        = no verb is used for shortcuts or something deemed important enough to use a super memorable name
 
-alias brew-fleek := install-brew-fleek
-
-# Install "fleek" set of packages for brew | none, low, default, high
-install-brew-fleek level="high":
-    #!/usr/bin/env bash
-    curl --proto '=https' --tlsv1.2 -sSf -L https://brew.getfleek.dev/s/fleek | bash -s -- {{ level }}
-
 alias cockpit := setup-cockpit
 
 # Enable Cockpit for web-based system management | https://cockpit-project.org/


### PR DESCRIPTION
`bluefin-cli` will do this by default, but not implemented yet so I'm just staging this here for now.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
