### PR TITLE
fix: update brew packages only after brew itself is fully updated

### DIFF
--- a/system_files/shared/usr/lib/systemd/system/brew-upgrade.service
+++ b/system_files/shared/usr/lib/systemd/system/brew-upgrade.service
@@ -2,6 +2,7 @@
 Description=Upgrade Brew packages
 After=local-fs.target
 After=network-online.target
+After=brew-update.service
 ConditionPathIsSymbolicLink=/home/linuxbrew/.linuxbrew/bin/brew
 
 [Service]

--- a/system_files/shared/usr/lib/systemd/system/brew-upgrade.timer
+++ b/system_files/shared/usr/lib/systemd/system/brew-upgrade.timer
@@ -3,7 +3,7 @@ Description=Timer for brew upgrade for on image brew
 Wants=network-online.target
 
 [Timer]
-OnBootSec=20min
+OnBootSec=21min
 OnUnitInactiveSec=6h
 Persistent=true
 


### PR DESCRIPTION
Currently, the updates of brew itself and brew packages are triggered at the same time. This can lead to the following error: 
```shell
Error:
Another active Homebrew update process is already in progress.
Please wait for it to finish or terminate it to continue.
```
This fixes this issue by delaying the upgrade of brew packages by one minute and adding After=brew-update.service to brew-upgrade.service