### PR TITLE
fix: disable auto power management extension by default

### DIFF
--- a/system_files/shared/usr/libexec/ublue-user-setup
+++ b/system_files/shared/usr/libexec/ublue-user-setup
@@ -45,7 +45,7 @@ fi
 if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
   if [[ ! -f "$UBLUE_CONFIG_DIR/framework-initialized" ]]; then
     echo 'Enabling automatic power profile extension'
-    ujust configure-auto-power-profile enable
+    ujust configure-auto-power-profile disable
     echo 'Setting Framework logo menu'
     dconf write /org/gnome/shell/extensions/Logo-menu/symbolic-icon true
     dconf write /org/gnome/shell/extensions/Logo-menu/menu-button-icon-image 31


### PR DESCRIPTION
This seems to cause issues on some laptops, so let's ship it but leave it off by default.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
