### PR TITLE
chore(ci): build on pushing to main

### DIFF
--- a/.github/workflows/build-39-bluefin.yml
+++ b/.github/workflows/build-39-bluefin.yml
@@ -8,6 +8,12 @@ on:
     paths-ignore:
       - '**.md'
       - 'system_files/kinoite/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'system_files/kinoite/**'
   schedule:
     - cron: '41 16 * * *'  # 16:41 UTC everyday
   workflow_dispatch:

--- a/.github/workflows/build-40-aurora.yml
+++ b/.github/workflows/build-40-aurora.yml
@@ -8,6 +8,12 @@ on:
     paths-ignore:
       - '**.md'
       - 'system_files/silverblue/**'
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'system_files/silverblue/**'
   schedule:
     - cron: '40 16 * * *'  # 16:40 UTC everyday
   workflow_dispatch:

--- a/.github/workflows/build-40-bluefin.yml
+++ b/.github/workflows/build-40-bluefin.yml
@@ -9,8 +9,9 @@ on:
       - '**.md'
       - 'system_files/kinoite/**'
   push:
+    branches:
       - main
-  paths-ignore:
+    paths-ignore:
       - '**.md'
       - 'system_files/kinoite/**'
   schedule:

--- a/.github/workflows/build-40-bluefin.yml
+++ b/.github/workflows/build-40-bluefin.yml
@@ -8,6 +8,11 @@ on:
     paths-ignore:
       - '**.md'
       - 'system_files/kinoite/**'
+  push:
+      - main
+  paths-ignore:
+      - '**.md'
+      - 'system_files/kinoite/**'
   schedule:
     - cron: '40 16 * * *'  # 16:40 UTC everyday
   workflow_dispatch:


### PR DESCRIPTION
This restores building after new things land in the `main` branch. Skipping `testing` (just run those by hand) and also skipping Aurora 39