### PR TITLE
chore: Use Containers folder by default

### DIFF
--- a/system_files/silverblue/usr/etc/dconf/db/local.d/02-bluefin-folders
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/02-bluefin-folders
@@ -1,5 +1,5 @@
 [org/gnome/desktop/app-folders]
-folder-children=['Games', 'GamingUtilities', 'Utilities', 'Distrobox', 'Wine', 'YaST', 'Pardus']
+folder-children=['Games', 'GamingUtilities', 'Utilities', 'Containers', 'Wine', 'YaST', 'Pardus']
 
 [org/gnome/desktop/app-folders/folders/GamingUtilities]
 apps=['protontricks.desktop', 'discover_overlay_configure.desktop', 'com.vysp3r.ProtonPlus.desktop', 'io.github.benjamimgois.goverlay.desktop', 'com.gerbilsoft.rom-properties.rp-config.desktop', 'input-remapper-gtk.desktop', 'steamos-nested-desktop.desktop']


### PR DESCRIPTION
Corrects issue in app-folders dconf entry

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
