### PR TITLE
feat: deprecate toolbox

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -181,7 +181,8 @@
 				"podman-docker"
 			],
 			"silverblue": [
-				"gnome-terminal-nautilus"
+				"gnome-terminal-nautilus",
+				"toolbox"
 			],
 			"dx": []
 		}


### PR DESCRIPTION
40 only, 39/gts remains unchanged

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
