### PR TITLE
feat: add android-tools to dx images

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -68,6 +68,7 @@
 			],
 			"dx": [
 				"adobe-source-code-pro-fonts",
+				"android-tools",
 				"cascadia-code-fonts",
 				"cockpit-machines",
 				"cockpit-networkmanager",


### PR DESCRIPTION
### What does this do?

This adds `android-tools` to dx images, a <2MB rpm with no dependencies. 

### Why is this needed?

Simply installing adbe from brew is insufficient, adb itself from the system is required to be available. This package provides that for developers ootb.