### PR TITLE
fix: change dash-to-dock running indicator to DOTS

### DIFF
--- a/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
@@ -56,6 +56,7 @@ custom-background-color=true
 customize-alphas=true
 max-alpha=0.8
 min-alpha=0.5
+running-indicator-style='DOTS'
 
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0]
 binding='<Control><Alt>t'


### PR DESCRIPTION
Fixes the issue with overlapping running indicators and icons.
This setting changes the dock from having a single dot when many apps are open to displaying a dot for each open instance of the app.

Issue:
![image](https://github.com/ublue-os/bluefin/assets/46304672/9630f41e-73b5-42c6-bf57-d46ad6fd2f73)



Workaround:

![image](https://github.com/ublue-os/bluefin/assets/46304672/b492d5e7-9a4d-4637-8ba6-2fb15256360b)
