### PR TITLE
chore(ci): remove SBOM and scanning workflows

### DIFF
--- a/.github/workflows/build-39-aurora.yml
+++ b/.github/workflows/build-39-aurora.yml
@@ -20,13 +20,3 @@ jobs:
     with:
       brand_name: aurora
       fedora_version: 39
-
-  scan:
-    # Scan can still be ran when some builds fail since only successfully built
-    # images will be stored in the output
-    if: (github.event_name != 'pull_request' && github.event_name != 'merge_group') && always()
-    uses: ./.github/workflows/reusable-image-scan.yml
-    needs: build
-    secrets: inherit
-    with:
-      images: ${{ needs.build.outputs.images }}

--- a/.github/workflows/build-39-bluefin.yml
+++ b/.github/workflows/build-39-bluefin.yml
@@ -26,13 +26,3 @@ jobs:
     with:
       brand_name: bluefin
       fedora_version: 39
-
-  scan:
-    # Scan can still be ran when some builds fail since only successfully built
-    # images will be stored in the output
-    if: (github.event_name != 'pull_request' && github.event_name != 'merge_group') && always()
-    uses: ./.github/workflows/reusable-image-scan.yml
-    needs: build
-    secrets: inherit
-    with:
-      images: ${{ needs.build.outputs.images }}

--- a/.github/workflows/build-40-aurora.yml
+++ b/.github/workflows/build-40-aurora.yml
@@ -26,13 +26,3 @@ jobs:
     with:
       brand_name: aurora
       fedora_version: 40
-
-  scan:
-    # Scan can still be ran when some builds fail since only successfully built
-    # images will be stored in the output
-    if: (github.event_name != 'pull_request' && github.event_name != 'merge_group') && always()
-    uses: ./.github/workflows/reusable-image-scan.yml
-    needs: build
-    secrets: inherit
-    with:
-      images: ${{ needs.build.outputs.images }}

--- a/.github/workflows/build-40-bluefin.yml
+++ b/.github/workflows/build-40-bluefin.yml
@@ -26,13 +26,3 @@ jobs:
     with:
       brand_name: bluefin
       fedora_version: 40
-
-  scan:
-    # Scan can still be ran when some builds fail since only successfully built
-    # images will be stored in the output
-    if: (github.event_name != 'pull_request' && github.event_name != 'merge_group') && always()
-    uses: ./.github/workflows/reusable-image-scan.yml
-    needs: build
-    secrets: inherit
-    with:
-      images: ${{ needs.build.outputs.images }}


### PR DESCRIPTION
These workflows sounded good in theory, but in reality they are too flakey and take far longer than I would have hoped to complete.  

I feel they are getting in the way more than they are helping.  Maybe later I will make them a workflow we trigger on an individual image manually (maybe put in ublue-os/main), but running every build doesn't seem useful.