### PR TITLE
Fix broken path in brew setup script for fish

### DIFF
--- a/system_files/shared/usr/share/fish/vendor_conf.d/brew.fish
+++ b/system_files/shared/usr/share/fish/vendor_conf.d/brew.fish
@@ -4,7 +4,7 @@ if status --is-interactive
     if [ -d /home/linuxbrew/.linuxbrew ]
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         if [ -w /home/linuxbrew/.linuxbrew ]
-            if  [ ! -L (brew --prefix)/share/fish/vendor_completions.d/brew ]
+            if  [ ! -L (brew --prefix)/share/fish/vendor_completions.d/brew.fish ]
                 brew completions link > /dev/null
             end
         end


### PR DESCRIPTION
The extension was missing from the filepath, which led to the completions script running on every shell startup because the `brew` symlink never exists. 

That completion script takes nearly a second to complete, and I found this bug when I was trying to understand why fish took so long to startup.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
