### PR TITLE
feat: add skanpage and simple-scan

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -44,6 +44,7 @@
 				"zsh"
 			],
 			"silverblue": [
+				"simple-scan",
 				"gnome-shell-extension-appindicator",
 				"gnome-shell-extension-blur-my-shell",
 				"gnome-shell-extension-caffeine",
@@ -59,6 +60,7 @@
 				"yaru-theme"
 			],
 			"kinoite": [
+				"skanpage",
 				"libadwaita-qt5",
 				"libadwaita-qt6",
 				"kde-runtime-docs",


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->

This PR adds the scanning apps skanpage for Aurora and simple-scan for Bluefin. Reason for layering directly is so the apps can access the drivers that are installed on the host system. 