### PR TITLE
feat(motd): add link to feedback survey

### DIFF
--- a/system_files/silverblue/usr/share/ublue-os/motd/bluefin.md
+++ b/system_files/silverblue/usr/share/ublue-os/motd/bluefin.md
@@ -13,3 +13,4 @@
 - 󰊤 [Issues](https://issues.projectbluefin.io)
 - 󰈙 [Documentation](http://docs.projectbluefin.io/)
 - 󰊌 [Discuss](https://community.projectbluefin.io/)
+- 󰊌 [Leave Feedback](https://feedback.projectbluefin.io)


### PR DESCRIPTION
We have https://feedback.projectbluefin.io set up to accept anonymous feedback via a form, this adds a link to the MOTD. 
