### PR TITLE
feat: install flatpak-builder in dx

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -89,6 +89,7 @@
 				"docker-buildx-plugin",
 				"docker-compose-plugin",
 				"edk2-ovmf",
+				"flatpak-builder",
 				"genisoimage",
 				"google-droid-sans-mono-fonts",
 				"google-go-mono-fonts",


### PR DESCRIPTION
flatpak-builder can't easily be used in distrobox, and makes sense to have available in the developer version of a Flatpak-centric distro

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
