### PR TITLE
chore(aurora): Remove KRFB

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -40,7 +40,7 @@
 				"usbmuxd",
 				"wireguard-tools",
 				"xprop",
-				"wl-clipboard", 
+				"wl-clipboard",
 				"zsh"
 			],
 			"silverblue": [
@@ -140,6 +140,8 @@
 				"gnome-tour"
 			],
 			"kinoite": [
+				"krfb",
+				"krfb-libs",
 				"plasma-welcome"
 			],
 			"dx": []


### PR DESCRIPTION
KRFB isn't entirely reliable, and most people that would want to use a remote desktop would more than likely be better off using something like Sunshine
