### PR TITLE
fix (ujust setup-cockpit): Fix PCP pmlogger permission and directories

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -51,6 +51,12 @@ setup-cockpit ACTION="":
       OPTION="Enable Cockpit"
     fi
     if [[ "${OPTION,,}" =~ ^enable ]]; then
+      echo "${green}${b}Enabling${n} pmlogger"
+      sudo mkdir /var/lib/pcp/tmp
+      sudo mkdir /var/log/pcp/pmlogger
+      sudo chown -R pcp:pcp /var/lib/pcp
+      sudo chown pcp:pcp /var/log/pcp/pmlogger
+      sudo systemctl enable --now pmlogger
       echo "${green}${b}Enabling${n} Cockpit"
       sudo systemctl enable cockpit.service
       echo "$(Urllink "http://localhost:9090" "Open Cockpit${n}") -> http://localhost:9090"


### PR DESCRIPTION
This will allow users to have graph in Cockpit metrics and history.

pmlogger service won't run without the appropriate dirs and permission, too.
![image](https://github.com/ublue-os/bluefin/assets/19387602/d780fd92-1606-47b8-876c-9e108d8de382)
