### PR TITLE
feat(just): enable volume and add access info for ollama-web

### DIFF
--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -138,6 +138,7 @@ ollama-web: ollama
     Environment=OLLAMA_BASE_URL=http://ollama:11434
     Environment=WEBUI_SECRET_KEY=abc123
     Environment=DEFAULT_USER_ROLE=admin
+    Volume=open-webui:/app/backend/data
     # Open WebUI does not allow access without a user account, nor does it allow
     # account creation via environment variables.
     Environment=ENABLE_SIGNUP=true
@@ -158,6 +159,7 @@ ollama-web: ollama
     fi
     systemctl --user daemon-reload
     systemctl --user start ollama-web.service
+    echo "Ollama Web UI container started. You can access it at http://localhost:8080"
 
 # Setup InvokeAI in a container
 invokeai:


### PR DESCRIPTION
Enabling volume will save user progress and account, so they wouldn't need to sign up over and over again after starting ollama-web systemd.

Also give user additional information regarding accessing Ollama Web UI. 