### PR TITLE
fix: port clash between InvokeAI and Cockpit

### DIFF
--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -214,7 +214,7 @@ invokeai:
     ContainerName=invokeai
     AutoUpdate=registry
     Environment=INVOKEAI_ROOT=/var/lib/invokeai
-    PublishPort=9090:9090
+    PublishPort=9091:9090
     Volume=invokeai.volume:/var/lib/invokeai
     SecurityLabelDisable=true
     ${CUSTOM_ARGS}
@@ -237,4 +237,4 @@ invokeai:
     fi
     systemctl --user daemon-reload
     systemctl --user start invokeai.service
-    echo "InvokeAI container started. You can access it at http://localhost:9090"
+    echo "InvokeAI container started. You can access it at http://localhost:9091"


### PR DESCRIPTION
Changes the InvokeAI port to use 9091 on the host since Cockpit Web Server also uses 9090.

This will not update existing systemd units, but maybe in future we can introduce a `--force` flag to overwrite existing units