### PR TITLE
feat: Add kernel signer to sign Fedora kernel with ublue's keys for secure boot

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -221,6 +221,15 @@ jobs:
           extra-args: |
             --target=${{ env.TARGET_NAME }}
 
+      - name: Sign kernel
+        uses: EyeCantCU/kernel-signer@v0.2.1
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          default-tag: ${{ env.BUILD_TAGS }}
+          privkey: ${{ secrets.AKMOD_PRIVKEY_20230518 }}
+          pubkey: /etc/pki/akmods/certs/akmods-ublue.der
+          tags: ${{ steps.build_image.outputs.tags }}
+
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12
       - name: Lowercase Registry


### PR DESCRIPTION
default-tags will need to be changed, and this relies on the next update to kernel-signer to allow us to sign without removing existing keys.