### PR TITLE
fix(ci): Don't sign kernel on PR

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Check just syntax
         uses: ublue-os/just-action@v1
-      
+
       - name: Generate tags
         id: generate-tags
         shell: bash
@@ -229,6 +229,7 @@ jobs:
 
       - name: Sign kernel
         uses: ublue-os/kernel-signer@v0.2.3
+        if: github.event_name != 'pull_request'
         with:
           image: ${{ steps.build_image.outputs.image }}
           default-tag: ${{ env.DEFAULT_TAG }}


### PR DESCRIPTION
Secrets can't be used out of org causing PRs to fail

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
