### PR TITLE
chore(ci): Enable a CoreOS Kernel Workflow

### DIFF
--- a/.github/workflows/build-coreos-bluefin.yml
+++ b/.github/workflows/build-coreos-bluefin.yml
@@ -1,0 +1,19 @@
+name: bluefin CoreOS Kernel
+on:
+  merge_group:
+  pull_request:
+    branches:
+      - testing
+    paths-ignore:
+      - '**.md'
+      - 'system_files/kinoite/**'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      brand_name: bluefin
+      fedora_version: coreos


### PR DESCRIPTION
Workflow needs to be defined in main before it can run on testing branch.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
