### PR TITLE
chore(ci): disable asus gts builds

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -44,14 +44,10 @@ jobs:
         fedora_version:
           - ${{ inputs.fedora_version }}
         exclude:
-          - fedora_version: 38
+          - fedora_version: 39
             image_flavor: asus
-          - fedora_version: 38
+          - fedora_version: 39
             image_flavor: asus-nvidia
-          - fedora_version: 38
-            image_flavor: surface
-          - fedora_version: 38
-            image_flavor: surface-nvidia
 
     steps:
       - name: Checkout


### PR DESCRIPTION
asus-linux only supports latest anyway, we've been pointing people off of these, we just never shut them off.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
