### PR TITLE
chore(ci): build stable tag weekly on tuesdays

### DIFF
--- a/.github/workflows/build-coreos-aurora.yml
+++ b/.github/workflows/build-coreos-aurora.yml
@@ -15,7 +15,7 @@ on:
       - '**.md'
       - 'system_files/bluefin/**'
   schedule:
-    - cron: '41 5 * * *'  # 5:41 UTC everyday
+    - cron: '41 5 * * 2'  # 5:41 UTC every Tuesday
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-coreos-bluefin.yml
+++ b/.github/workflows/build-coreos-bluefin.yml
@@ -15,7 +15,7 @@ on:
       - '**.md'
       - 'system_files/kinoite/**'
   schedule:
-    - cron: '41 5 * * *'  # 5:41 UTC everyday
+    - cron: '41 5 * * 2'  # 5:41 UTC every Tuesday
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Build on every Tuesday via the cron. Note that the end devices will still check every day, so when we're pushing out new builds users will still get those fresh.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
