### PR TITLE
feat: seasonal variation in sunrise/sunset times for seasonal Bluefin backgrounds

### DIFF
--- a/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-autumn-dynamic.xml
+++ b/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-autumn-dynamic.xml
@@ -4,13 +4,13 @@
                 <month>1</month>
                 <day>1</day>
                 <hour>6</hour>
-                <minute>0</minute>
+                <minute>30</minute>
                 <second>0</second>
         </starttime>
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_AutumnDay_Post.webp</file>
-                <duration>36000.0</duration>
+                <duration>34200.0</duration>
         </static>
 
         <transition type="overlay">
@@ -21,7 +21,7 @@
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_AutumnNight_Post.webp</file>
-                <duration>36000.0</duration>
+                <duration>37800.0</duration>
         </static>
 
         <transition type="overlay">

--- a/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-spring-dynamic.xml
+++ b/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-spring-dynamic.xml
@@ -10,7 +10,7 @@
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_SpringDay_Post.webp</file>
-                <duration>36000.0</duration>
+                <duration>37800.0</duration>
         </static>
 
         <transition type="overlay">
@@ -21,7 +21,7 @@
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_SpringNight_Post.webp</file>
-                <duration>36000.0</duration>
+                <duration>34200.0</duration>
         </static>
 
         <transition type="overlay">

--- a/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-summer-dynamic.xml
+++ b/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-summer-dynamic.xml
@@ -10,7 +10,7 @@
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_SummerDay_Post.webp</file>
-                <duration>44100.0</duration>
+                <duration>45000.0</duration>
         </static>
 
         <transition type="overlay">
@@ -21,7 +21,7 @@
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_SummerNight_Post.webp</file>
-                <duration>27900.0</duration>
+                <duration>27000.0</duration>
         </static>
 
         <transition type="overlay">

--- a/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-summer-dynamic.xml
+++ b/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-summer-dynamic.xml
@@ -3,14 +3,14 @@
                 <year>2018</year>
                 <month>1</month>
                 <day>1</day>
-                <hour>6</hour>
-                <minute>0</minute>
+                <hour>4</hour>
+                <minute>45</minute>
                 <second>0</second>
         </starttime>
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_SummerDay_Post.webp</file>
-                <duration>36000.0</duration>
+                <duration>44100.0</duration>
         </static>
 
         <transition type="overlay">
@@ -21,7 +21,7 @@
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_SummerNight_Post.webp</file>
-                <duration>36000.0</duration>
+                <duration>27900.0</duration>
         </static>
 
         <transition type="overlay">

--- a/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-summer-dynamic.xml
+++ b/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-summer-dynamic.xml
@@ -3,14 +3,14 @@
                 <year>2018</year>
                 <month>1</month>
                 <day>1</day>
-                <hour>4</hour>
+                <hour>5</hour>
                 <minute>45</minute>
                 <second>0</second>
         </starttime>
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_SummerDay_Post.webp</file>
-                <duration>45000.0</duration>
+                <duration>41400.0</duration>
         </static>
 
         <transition type="overlay">
@@ -21,7 +21,7 @@
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_SummerNight_Post.webp</file>
-                <duration>27000.0</duration>
+                <duration>30600.0</duration>
         </static>
 
         <transition type="overlay">

--- a/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-winter-dynamic.xml
+++ b/system_files/silverblue/usr/share/backgrounds/bluefin/bluefin-winter-dynamic.xml
@@ -4,7 +4,7 @@
                 <month>1</month>
                 <day>1</day>
                 <hour>6</hour>
-                <minute>0</minute>
+                <minute>15</minute>
                 <second>0</second>
         </starttime>
 
@@ -14,18 +14,18 @@
         </static>
 
         <transition type="overlay">
-                <duration>7200.0</duration>
+                <duration>1800.0</duration>
                 <from>/usr/share/backgrounds/bluefin/WallPaper_WinterDay_Post.webp</from>
                 <to>/usr/share/backgrounds/bluefin/WallPaper_WinterNight_Post.webp</to>
         </transition>
 
         <static>
                 <file>/usr/share/backgrounds/bluefin/WallPaper_WinterNight_Post.webp</file>
-                <duration>36000.0</duration>
+                <duration>46800.0</duration>
         </static>
 
         <transition type="overlay">
-                <duration>7200.0</duration>
+                <duration>1800.0</duration>
                 <from>/usr/share/backgrounds/bluefin/WallPaper_WinterNight_Post.webp</from>
                 <to>/usr/share/backgrounds/bluefin/WallPaper_WinterDay_Post.webp</to>
         </transition>


### PR DESCRIPTION
This PR changes the time at which the sun rises and sets in the seasonal Bluefin backgrounds to more closely match the variation in sunrise/sunset timing seen in real life. Daytime has a longer duration during summer and a shorter duration during winter.

Because the timing of sunsets and sunrises is dependent upon various factors, such as latitude and the specific date, choosing the exact time for the sunset and sunrise to begin for each background required some consideration.

Bluefin's seasonal backgrounds are inspired by the appearance of seasons in temperate, mid-latitude regions; for that reason, I chose to use the timings commonly experienced in mid-latitudes of around 40 - 45°. I averaged out the sunrise/sunset timing for each season to work around the variation within seasons. And to accommodate for how some mid-latitude regions implement daylight savings time, I chose a compromise for spring and summer that should feel close enough regardless of whether a specific location uses DST.

Overall, the timing of sunrises and sunsets in the seasonal Bluefin backgrounds should be much closer to the real-life timing for all regions which experience temperate seasons. 