### PR TITLE
style: Standardize FromAsCasing in dockerfile

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,8 +13,8 @@ ARG UBLUE_IMAGE_TAG="${UBLUE_IMAGE_TAG:-latest}"
 ARG KMOD_SOURCE_COMMON="ghcr.io/ublue-os/akmods:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}"
 ARG COREOS_KMODS="ghcr.io/ublue-os/ucore-kmods:stable"
 ARG COREOS_NVIDIA="ghcr.io/ublue-os/akmods-nvidia:coreos-${FEDORA_MAJOR_VERSION}"
-FROM ${KMOD_SOURCE_COMMON} as akmods
-FROM ${COREOS_NVIDIA} as coreos_nvidia
+FROM ${KMOD_SOURCE_COMMON} AS akmods
+FROM ${COREOS_NVIDIA} AS coreos_nvidia
 
 ## bluefin image section
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS base


### PR DESCRIPTION
Standardized the [FromAsCasing](https://docs.docker.com/reference/build-checks/from-as-casing/) to match style recommendations and satisfy a build check. This will remove the build check's warning from the build process log.