### PR TITLE
fix: update gnome-vrr copr

### DIFF
--- a/build_files/base/copr-repos.sh
+++ b/build_files/base/copr-repos.sh
@@ -10,15 +10,17 @@ curl -Lo /etc/yum.repos.d/ublue-os-bling-fedora-"${FEDORA_MAJOR_VERSION}".repo h
 
 # 39 Ptyxis
 if [ "${FEDORA_MAJOR_VERSION}" -eq "39" ]; then
-    curl -Lo /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo https://copr.fedorainfracloud.org/coprs/kylegospo/gnome-vrr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/kylegospo-gnome-vrr-fedora-"${FEDORA_MAJOR_VERSION}".repo
-    rpm-ostree override replace --experimental --from repo=copr:copr.fedorainfracloud.org:kylegospo:gnome-vrr mutter mutter-common gnome-control-center gnome-control-center-filesystem
-    rm -f /etc/yum.repos.d/_copr_kylegospo-gnome-vrr.repo
     rpm-ostree override replace \
     --experimental \
     --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
         gtk4 \
         vte291 \
-        libadwaita
+        libadwaita \
+        gnome-vrr \ 
+        mutter \
+        mutter-common \
+        gnome-control-center \
+        gnome-control-center-filesystem 
     rpm-ostree install ptyxis
 fi
 

--- a/build_files/base/copr-repos.sh
+++ b/build_files/base/copr-repos.sh
@@ -16,7 +16,6 @@ if [ "${FEDORA_MAJOR_VERSION}" -eq "39" ]; then
         gtk4 \
         vte291 \
         libadwaita \
-        gnome-vrr \ 
         mutter \
         mutter-common \
         gnome-control-center \


### PR DESCRIPTION
This COPR went away, everything is in ublue-staging now

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
