### PR TITLE
feat: remove bluefin-cli shortcut

### DIFF
--- a/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/usr/etc/dconf/db/local.d/01-ublue
@@ -73,11 +73,6 @@ binding='<Control><Shift>Escape'
 command="flatpak run io.missioncenter.MissionCenter"
 name='mission-center'
 
-[org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3]
-binding='<Control><Alt>Return'
-command='/usr/libexec/distrobox-quadlet-ptyxis.sh bluefin-cli'
-name='Bluefin Ptyxis'
-
 [org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4]
 binding='<Control><Alt>f'
 command='/usr/libexec/distrobox-quadlet-ptyxis.sh fedora-toolbox'


### PR DESCRIPTION
Let's free this back up, the bluefin-cli experience via brew is better.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
