### PR TITLE
refactor: use akmods-zfs for ZFS install

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   build_container:
     name: image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     continue-on-error: false
     outputs:
       image_full: ${{ steps.generate-outputs.outputs.image }}
@@ -318,6 +318,37 @@ jobs:
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-nvidia:${{ env.AKMODS_FLAVOR }}-${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-zfs:coreos-stable-${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/${{ env.AKMODS_FLAVOR }}-kernel:${{ env.kernel_release }}
+
+      # buildah on ubuntu-22.04 builder is pretty dated and the version on
+      # ubuntu-24.04 misbehaves when using heredocs in Containerfiles
+      # (as of 2024-07-12)
+      # this wrapper script mimics toolbx/distrobox behaviour for buildah which
+      # is invoked by redhat-actions/buildah-build@v2
+      - name: Install wrapper script for containerized buildah
+        id: fix-gh-buildah
+        shell: bash
+        run: |
+          cat > /usr/local/bin/buildah <<'EOF'
+            #!/bin/sh
+            set -eux
+            # get local graphroot at runtime
+            GRAPH_ROOT="$(/usr/bin/buildah info | jq -r '.store.GraphRoot')"
+            exec podman run --rm \
+              --privileged \
+              --net=host \
+              --cgroups=disabled \
+              --runtime=crun \
+              --runtime-flag=cgroup-manager=disabled \
+              --security-opt=label=disable \
+              --security-opt=seccomp=unconfined \
+              --device=/dev/fuse:rw \
+              -v /home/runner:/home/runner \
+              -v "$GRAPH_ROOT":/var/lib/containers/storage \
+              -v "$(pwd):"/builder \
+              -w /builder \
+              quay.io/buildah/stable:v1 buildah "$@"
+          EOF
+          chmod +x /usr/local/bin/buildah
 
       # Build image using Buildah action
       - name: Build Image

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -163,6 +163,11 @@ jobs:
         with:
           containers: akmods-nvidia:${{ env.AKMODS_FLAVOR}}-${{ env.fedora_version }}
 
+      - name: Verify ZFS
+        uses: EyeCantCU/cosign-action/verify@58722a084c82190b57863002d494c91eabbe9e79 # v0.3.0
+        with:
+          containers: akmods-zfs:coreos-stable-${{ env.fedora_version }}
+
       - name: Verify Kernel Cache
         uses: EyeCantCU/cosign-action/verify@58722a084c82190b57863002d494c91eabbe9e79 # v0.3.0
         with:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   build_container:
     name: image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: false
     outputs:
       image_full: ${{ steps.generate-outputs.outputs.image }}
@@ -311,6 +311,7 @@ jobs:
             podman pull ${{ env.IMAGE_REGISTRY }}/${{ env.BASE_IMAGE_NAME }}-${{ env.image_flavor }}:${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods:${{ env.AKMODS_FLAVOR }}-${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-nvidia:${{ env.AKMODS_FLAVOR }}-${{ env.fedora_version }}
+            podman pull ${{ env.IMAGE_REGISTRY }}/akmods-zfs:coreos-stable-${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/${{ env.AKMODS_FLAVOR }}-kernel:${{ env.kernel_release }}
 
       # Build image using Buildah action

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -319,36 +319,19 @@ jobs:
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-zfs:coreos-stable-${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/${{ env.AKMODS_FLAVOR }}-kernel:${{ env.kernel_release }}
 
-      # buildah on ubuntu-22.04 builder is pretty dated and the version on
-      # ubuntu-24.04 misbehaves when using heredocs in Containerfiles
-      # (as of 2024-07-12)
-      # this wrapper script mimics toolbx/distrobox behaviour for buildah which
-      # is invoked by redhat-actions/buildah-build@v2
-      - name: Install wrapper script for containerized buildah
-        id: fix-gh-buildah
+      # Update Podman
+      # use podman build from OBS to get newer features
+      # from https://askubuntu.com/questions/1414446/whats-the-recommended-way-of-installing-podman-4-in-ubuntu-22-04
+      - name: Setup Podman
         shell: bash
         run: |
-          cat > /usr/local/bin/buildah <<'EOF'
-            #!/bin/sh
-            set -eux
-            # get local graphroot at runtime
-            GRAPH_ROOT="$(/usr/bin/buildah info | jq -r '.store.GraphRoot')"
-            exec podman run --rm \
-              --privileged \
-              --net=host \
-              --cgroups=disabled \
-              --runtime=crun \
-              --runtime-flag=cgroup-manager=disabled \
-              --security-opt=label=disable \
-              --security-opt=seccomp=unconfined \
-              --device=/dev/fuse:rw \
-              -v /home/runner:/home/runner \
-              -v "$GRAPH_ROOT":/var/lib/containers/storage \
-              -v "$(pwd):"/builder \
-              -w /builder \
-              quay.io/buildah/stable:v1 buildah "$@"
-          EOF
-          chmod +x /usr/local/bin/buildah
+          ubuntu_version='22.04'
+          key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
+          sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
+          echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel-kubic-libcontainers-unstable.list
+          curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+          sudo apt-get update
+          sudo apt-get install -y podman
 
       # Build image using Buildah action
       - name: Build Image

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   build_container:
     name: image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: false
     outputs:
       image_full: ${{ steps.generate-outputs.outputs.image }}
@@ -318,20 +318,6 @@ jobs:
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-nvidia:${{ env.AKMODS_FLAVOR }}-${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-zfs:coreos-stable-${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/${{ env.AKMODS_FLAVOR }}-kernel:${{ env.kernel_release }}
-
-      # Update Podman
-      # use podman build from OBS to get newer features
-      # from https://askubuntu.com/questions/1414446/whats-the-recommended-way-of-installing-podman-4-in-ubuntu-22-04
-      - name: Setup Podman
-        shell: bash
-        run: |
-          ubuntu_version='22.04'
-          key_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}/Release.key"
-          sources_url="https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_${ubuntu_version}"
-          echo "deb $sources_url/ /" | sudo tee /etc/apt/sources.list.d/devel-kubic-libcontainers-unstable.list
-          curl -fsSL $key_url | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y podman
 
       # Build image using Buildah action
       - name: Build Image

--- a/Containerfile
+++ b/Containerfile
@@ -11,9 +11,11 @@ ARG UBLUE_IMAGE_TAG="${UBLUE_IMAGE_TAG:-latest}"
 
 # FROM's for copying
 ARG KMOD_SOURCE_COMMON="ghcr.io/ublue-os/akmods:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}"
+ARG ZFS_CACHE="ghcr.io/ublue-os/akmods-zfs:coreos-stable-${FEDORA_MAJOR_VERSION}"
 ARG NVIDIA_CACHE="ghcr.io/ublue-os/akmods-nvidia:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}"
 ARG KERNEL_CACHE="ghcr.io/ublue-os/${AKMODS_FLAVOR}-kernel:${KERNEL}"
 FROM ${KMOD_SOURCE_COMMON} AS akmods
+FROM ${ZFS_CACHE} AS zfs_cache
 FROM ${NVIDIA_CACHE} AS nvidia_cache
 FROM ${KERNEL_CACHE} AS kernel_cache
 
@@ -39,16 +41,21 @@ COPY packages.json /tmp/packages.json
 # Copy ublue-update.toml to tmp first, to avoid being overwritten.
 COPY /system_files/shared/usr/etc/ublue-update/ublue-update.toml /tmp/ublue-update.toml
 # COPY ublue kmods, add needed negativo17 repo and then immediately disable due to incompatibility with RPMFusion
-COPY --from=akmods /rpms /tmp/akmods-rpms
-COPY --from=nvidia_cache /rpms /tmp/akmods-rpms
-COPY --from=kernel_cache /tmp/rpms /tmp/kernel-rpms
+# COPY --from=akmods /rpms /tmp/akmods-rpms
+# COPY --from=nvidia_cache /rpms /tmp/akmods-rpms
+# COPY --from=kernel_cache /tmp/rpms /tmp/kernel-rpms
 
 # Build, cleanup, commit.
-RUN rpm-ostree cliwrap install-to-root / && \
+RUN --mount=type=bind,from=akmods,source=/rpms,target=/tmp/akmods,rw \
+    --mount=type=bind,from=nvidia_cache,source=/rpms,target=/tmp/akmods-rpms,rw \
+    --mount=type=bind,from=kernel_cache,source=/tmp/rpms,target=/tmp/kernel-rpms,rw \
+    --mount=type=bind,from=zfs_cache,source=/rpms,target=/tmp/akmods-zfs,rw \
+    rpm-ostree cliwrap install-to-root / && \
     mkdir -p /var/lib/alternatives && \
     bash -c ". /tmp/build/build-base.sh"  && \
     mv /var/lib/alternatives /staged-alternatives && \
-    rm -rf /tmp/* /var/* && \
+    rm -rf /tmp/* || true && \
+    rm -rf /var/* || true && \
     ostree container commit && \
     mkdir -p /var/lib && mv /staged-alternatives /var/lib/alternatives && \
     mkdir -p /var/tmp && \
@@ -73,14 +80,16 @@ COPY system_files/dx /
 COPY packages.json /tmp/packages.json
 
 # Copy akmods from ublue
-COPY --from=akmods /rpms /tmp/akmods-rpms
+# COPY --from=akmods /rpms /tmp/akmods-rpms
 
 # Build, Clean-up, Commit
-RUN mkdir -p /var/lib/alternatives && \
+RUN --mount=type=bind,from=akmods,source=/rpms,target=/tmp/akmods,rw \
+    mkdir -p /var/lib/alternatives && \
     bash -c ". /tmp/build/build-dx.sh"  && \
     fc-cache --system-only --really-force --verbose && \
     mv /var/lib/alternatives /staged-alternatives && \
-    rm -rf /tmp/* /var/* && \
+    rm -rf /tmp/* || true && \
+    rm -rf /var/* || true && \
     ostree container commit && \
     mkdir -p /var/lib && mv /staged-alternatives /var/lib/alternatives && \
     mkdir -p /var/tmp && \

--- a/Containerfile
+++ b/Containerfile
@@ -46,10 +46,10 @@ COPY /system_files/shared/usr/etc/ublue-update/ublue-update.toml /tmp/ublue-upda
 # COPY --from=kernel_cache /tmp/rpms /tmp/kernel-rpms
 
 # Build, cleanup, commit.
-RUN --mount=type=bind,from=akmods,source=/rpms,target=/tmp/akmods,rw \
-    --mount=type=bind,from=nvidia_cache,source=/rpms,target=/tmp/akmods-rpms,rw \
-    --mount=type=bind,from=kernel_cache,source=/tmp/rpms,target=/tmp/kernel-rpms,rw \
-    --mount=type=bind,from=zfs_cache,source=/rpms,target=/tmp/akmods-zfs,rw \
+RUN --mount=type=bind,from=akmods,source=/rpms,target=/tmp/akmods \
+    --mount=type=bind,from=nvidia_cache,source=/rpms,target=/tmp/akmods-rpms \
+    --mount=type=bind,from=kernel_cache,source=/tmp/rpms,target=/tmp/kernel-rpms \
+    --mount=type=bind,from=zfs_cache,source=/rpms,target=/tmp/akmods-zfs \
     rpm-ostree cliwrap install-to-root / && \
     mkdir -p /var/lib/alternatives && \
     bash -c ". /tmp/build/build-base.sh"  && \
@@ -83,7 +83,7 @@ COPY packages.json /tmp/packages.json
 # COPY --from=akmods /rpms /tmp/akmods-rpms
 
 # Build, Clean-up, Commit
-RUN --mount=type=bind,from=akmods,source=/rpms,target=/tmp/akmods,rw \
+RUN --mount=type=bind,from=akmods,source=/rpms,target=/tmp/akmods \
     mkdir -p /var/lib/alternatives && \
     bash -c ". /tmp/build/build-dx.sh"  && \
     fc-cache --system-only --really-force --verbose && \

--- a/build_files/base/install-akmods.sh
+++ b/build_files/base/install-akmods.sh
@@ -20,28 +20,24 @@ sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 
 # Everyone
 rpm-ostree install \
-    /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
-    /tmp/akmods-rpms/kmods/*xone*.rpm \
-    /tmp/akmods-rpms/kmods/*openrazer*.rpm \
-    /tmp/akmods-rpms/kmods/*wl*.rpm \
-    /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm
+    /tmp/akmods/kmods/*xpadneo*.rpm \
+    /tmp/akmods/kmods/*xone*.rpm \
+    /tmp/akmods/kmods/*openrazer*.rpm \
+    /tmp/akmods/kmods/*wl*.rpm \
+    /tmp/akmods/kmods/*v4l2loopback*.rpm
     # /tmp/akmods-rpms/kmods/*framework-laptop*.rpm
 
 # All but Asus
 if grep -qv "asus" <<< "${AKMODS_FLAVOR}"; then
     rpm-ostree install \
-        /tmp/akmods-rpms/kmods/*evdi*.rpm
+        /tmp/akmods/kmods/*evdi*.rpm
 fi
 
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 
 # ZFS for gts/stable
 if [[ ${AKMODS_FLAVOR} =~ "coreos" ]]; then
-    podman create --name akmods-zfs ghcr.io/ublue-os/akmods-zfs:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}
-    podman export akmods-zfs > /tmp/akmods-zfs.tar
-    tar -xvf /tmp/akmods-zfs.tar -C /tmp
-    podman rm -f akmods-zfs
-    rpm-ostree install pv /tmp/akmods-zfs/zfs/*.rpm
+    rpm-ostree install pv /tmp/akmods-zfs/kmods/zfs/*.rpm
     depmod -a -v "${KERNEL}"
     echo "zfs" > /usr/lib/modules-load.d/zfs.conf
 fi

--- a/build_files/base/install-akmods.sh
+++ b/build_files/base/install-akmods.sh
@@ -37,8 +37,11 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.r
 
 # ZFS for gts/stable
 if [[ ${AKMODS_FLAVOR} =~ "coreos" ]]; then
-    rpm-ostree install /tmp/akmods-rpms/kmods/zfs/*.rpm \
-                       pv
+    podman create --name akmods-zfs ghcr.io/ublue-os/akmods-zfs:coreos-stable-${FEDORA_VERSION}
+    podman export akmods-zfs > /tmp/akmods-zfs.tar
+    tar -xvf /tmp/akmods-zfs.tar -C /tmp
+    podman rm -f akmods-zfs
+    rpm-ostree install pv /tmp/akmods-zfs/zfs/*.rpm
     depmod -a -v "${KERNEL}"
     echo "zfs" > /usr/lib/modules-load.d/zfs.conf
 fi

--- a/build_files/base/install-akmods.sh
+++ b/build_files/base/install-akmods.sh
@@ -37,7 +37,7 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.r
 
 # ZFS for gts/stable
 if [[ ${AKMODS_FLAVOR} =~ "coreos" ]]; then
-    podman create --name akmods-zfs ghcr.io/ublue-os/akmods-zfs:coreos-stable-${FEDORA_MAJOR_VERSION}
+    podman create --name akmods-zfs ghcr.io/ublue-os/akmods-zfs:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}
     podman export akmods-zfs > /tmp/akmods-zfs.tar
     tar -xvf /tmp/akmods-zfs.tar -C /tmp
     podman rm -f akmods-zfs

--- a/build_files/base/install-akmods.sh
+++ b/build_files/base/install-akmods.sh
@@ -37,7 +37,7 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.r
 
 # ZFS for gts/stable
 if [[ ${AKMODS_FLAVOR} =~ "coreos" ]]; then
-    podman create --name akmods-zfs ghcr.io/ublue-os/akmods-zfs:coreos-stable-${FEDORA_VERSION}
+    podman create --name akmods-zfs ghcr.io/ublue-os/akmods-zfs:coreos-stable-${FEDORA_MAJOR_VERSION}
     podman export akmods-zfs > /tmp/akmods-zfs.tar
     tar -xvf /tmp/akmods-zfs.tar -C /tmp
     podman rm -f akmods-zfs

--- a/build_files/dx/install-akmods-dx.sh
+++ b/build_files/dx/install-akmods-dx.sh
@@ -5,5 +5,5 @@ set -ouex pipefail
 sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 if [[ "${FEDORA_MAJOR_VERSION}" -ge "39" ]]; then
     rpm-ostree install \
-        /tmp/akmods-rpms/kmods/*kvmfr*.rpm
+        /tmp/akmods/kmods/*kvmfr*.rpm
 fi

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -18,15 +18,15 @@ version=$3
 
 # Get Fedora Version and Kernel Info
 if [[ "${version}" == "stable" ]]; then
-    KERNEL_RELEASE=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:stable | jq -r '.Labels["ostree.linux"] | split(".x86_64")[0]')
+    KERNEL_RELEASE=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:stable | jq -r '.Labels["ostree.linux"]')
     fedora_version=$(echo "$KERNEL_RELEASE" | grep -oP 'fc\K[0-9]+')
 elif [[ ${version} == "gts" ]]; then
-    coreos_kernel_release=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:stable | jq -r '.Labels["ostree.linux"] | split(".x86_64")[0]')
+    coreos_kernel_release=$(skopeo inspect docker://quay.io/fedora/fedora-coreos:stable | jq -r '.Labels["ostree.linux"]')
     major_minor_patch=$(echo "$coreos_kernel_release" | cut -d '-' -f 1)
     coreos_fedora_version=$(echo "$coreos_kernel_release" | grep -oP 'fc\K[0-9]+')
-    KERNEL_RELEASE="${major_minor_patch}-200.fc$(("$coreos_fedora_version" - 1))"
+    KERNEL_RELEASE="${major_minor_patch}-200.fc$(("$coreos_fedora_version" - 1)).$(uname -m)"
 else
-    KERNEL_RELEASE=$(skopeo inspect docker://ghcr.io/ublue-os/silverblue-main:"${version}" | jq -r '.Labels["ostree.linux"] | split(".x86_64")[0]')
+    KERNEL_RELEASE=$(skopeo inspect docker://ghcr.io/ublue-os/silverblue-main:"${version}" | jq -r '.Labels["ostree.linux"]')
 fi
 
 fedora_version=$(echo "$KERNEL_RELEASE" | grep -oP 'fc\K[0-9]+')
@@ -40,7 +40,7 @@ akmods_flavor=main
 if [[ "${version}" == "gts" || \
     "${version}" == "stable" ]]; then
     nvidia_type="main"
-    akmods_flavor=coreos
+    akmods_flavor=coreos-stable
 fi
 
 


### PR DESCRIPTION
This should install ZFS from the new `akmods-zfs` image (rather than akmods common image) and do so without a wasted copy layer.

Blocked by: https://github.com/ublue-os/akmods/pull/217