### PR TITLE
fix: add skopeo to devcontainer's features

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,8 @@
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
 		"ghcr.io/guiyomh/features/just:0": {},
-		"ghcr.io/lukewiwa/features/shellcheck:0": {}
+		"ghcr.io/lukewiwa/features/shellcheck:0": {},
+		"ghcr.io/jsburckhardt/devcontainer-features/skopeo:1": {}
 	},
 	"onCreateCommand": {
 		"bash-completions": "sudo apt-get install -y bash-completion; echo 'source /etc/profile.d/bash_completion.sh' | sudo tee -a /etc/bash.bashrc > /dev/null",


### PR DESCRIPTION
skopeo is a dependency used in the build scripts, but it's missing from the devcontainer environment. This fixes that.