### PR TITLE
feat: switch to distro ptyxis for F40

### DIFF
--- a/build_files/base/copr-repos.sh
+++ b/build_files/base/copr-repos.sh
@@ -23,11 +23,6 @@ if [ "${FEDORA_MAJOR_VERSION}" -eq "39" ]; then
     rpm-ostree install ptyxis
 fi
 
-# 40 Ptyxis
-if [ "${FEDORA_MAJOR_VERSION}" -eq "40" ]; then
-    rpm-ostree install ptyxis
-fi
-
 # Patched switcheroo
 # Add repo
 curl -Lo /etc/yum.repos.d/_copr_sentry-switcheroo-control_discrete.repo https://copr.fedorainfracloud.org/coprs/sentry/switcheroo-control_discrete/repo/fedora-"${FEDORA_MAJOR_VERSION}"/sentry-switcheroo-control_discrete-fedora-"${FEDORA_MAJOR_VERSION}".repo

--- a/packages.json
+++ b/packages.json
@@ -169,16 +169,16 @@
 		},
 		"exclude": {
 			"all": [],
-			"silverblue": [
-				
-			],
+			"silverblue": [],
 			"dx": []
 		}
 	},
 	"40": {
 		"include": {
 			"all": [],
-			"silverblue": [],
+			"silverblue": [
+				"ptyxis"
+			],
 			"dx": []
 		},
 		"exclude": {

--- a/packages.json
+++ b/packages.json
@@ -175,10 +175,10 @@
 	},
 	"40": {
 		"include": {
-			"all": [],
-			"silverblue": [
+			"all": [
 				"ptyxis"
 			],
+			"silverblue": [],
 			"dx": []
 		},
 		"exclude": {


### PR DESCRIPTION
ptyxis is in F40 now, this switches the F40 build to just grab it from Fedora. We still build a one off for F39, when that moves out of support we'll completely be on distro ptyxis. 😄 🎊 
