### PR TITLE
feat(just): add switch-channel shortcut

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -276,6 +276,7 @@ rebase-helper:
     @/usr/bin/ublue-rollback-helper
 
 alias rollback-helper := rebase-helper
+alias switch-channel := rebase-helper
 
 update-ng:
     echo "Note: This command doesn't work if you have locally layered packages" 


### PR DESCRIPTION
Since this will eventually do a bootc switch and all the verbs upstream are switch I'm adding this as an alias for the rebase-helper. 

"channels" for gts, stable, etc make sense as a word so aligning all this up.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.

-->
