### PR TITLE
chore: packages.json: Remove kdeplasma-addons (already included)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,6 @@
 
 ## Thank you for contributing to the Universal Blue project!
 
-Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.
+Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.
 
 -->

--- a/packages.json
+++ b/packages.json
@@ -72,7 +72,6 @@
 				"libadwaita-qt6",
 				"kde-runtime-docs",
 				"kdenetwork-filesharing",
-				"kdeplasma-addons",
 				"plasma-wallpapers-dynamic"
 			],
 			"dx": [


### PR DESCRIPTION
chore: packages.json: Remove kdeplasma-addons (already included)

This package has been included for a long time in Kinoite and is
unlikely to go away so there is no particular need to list it here.

Fixes: https://github.com/ublue-os/bluefin/pull/1135

---

chore: Fix link to contributor's guide in PR template