### PR TITLE
fix(nvidia): pin Nvidia drivers to 555

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Verify Nvidia
         uses: EyeCantCU/cosign-action/verify@58722a084c82190b57863002d494c91eabbe9e79 # v0.3.0
         with:
-          containers: akmods-nvidia:${{ env.AKMODS_FLAVOR}}-${{ env.fedora_version }}
+          containers: akmods-nvidia:${{ env.AKMODS_FLAVOR}}-${{ env.fedora_version }}-20240806
 
       - name: Verify ZFS
         uses: EyeCantCU/cosign-action/verify@58722a084c82190b57863002d494c91eabbe9e79 # v0.3.0
@@ -315,7 +315,7 @@ jobs:
             # we can retry on that unfortunately common failure case
             podman pull ${{ env.IMAGE_REGISTRY }}/${{ env.BASE_IMAGE_NAME }}-${{ env.image_flavor }}:${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods:${{ env.AKMODS_FLAVOR }}-${{ env.fedora_version }}
-            podman pull ${{ env.IMAGE_REGISTRY }}/akmods-nvidia:${{ env.AKMODS_FLAVOR }}-${{ env.fedora_version }}
+            podman pull ${{ env.IMAGE_REGISTRY }}/akmods-nvidia:${{ env.AKMODS_FLAVOR }}-${{ env.fedora_version }}-20240806
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods-zfs:coreos-stable-${{ env.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/${{ env.AKMODS_FLAVOR }}-kernel:${{ env.kernel_release }}
 

--- a/Containerfile
+++ b/Containerfile
@@ -12,7 +12,8 @@ ARG UBLUE_IMAGE_TAG="${UBLUE_IMAGE_TAG:-latest}"
 # FROM's for Mounting
 ARG KMOD_SOURCE_COMMON="ghcr.io/ublue-os/akmods:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}"
 ARG ZFS_CACHE="ghcr.io/ublue-os/akmods-zfs:coreos-stable-${FEDORA_MAJOR_VERSION}"
-ARG NVIDIA_CACHE="ghcr.io/ublue-os/akmods-nvidia:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}"
+# Pin the NVIDIA images to the last build of the 555 driver due to issues with monitor freezing on the newer 560 drivers
+ARG NVIDIA_CACHE="ghcr.io/ublue-os/akmods-nvidia-20240806:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}"
 ARG KERNEL_CACHE="ghcr.io/ublue-os/${AKMODS_FLAVOR}-kernel:${KERNEL}"
 FROM ${KMOD_SOURCE_COMMON} AS akmods
 FROM ${ZFS_CACHE} AS zfs_cache

--- a/Containerfile
+++ b/Containerfile
@@ -13,7 +13,7 @@ ARG UBLUE_IMAGE_TAG="${UBLUE_IMAGE_TAG:-latest}"
 ARG KMOD_SOURCE_COMMON="ghcr.io/ublue-os/akmods:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}"
 ARG ZFS_CACHE="ghcr.io/ublue-os/akmods-zfs:coreos-stable-${FEDORA_MAJOR_VERSION}"
 # Pin the NVIDIA images to the last build of the 555 driver due to issues with monitor freezing on the newer 560 drivers
-ARG NVIDIA_CACHE="ghcr.io/ublue-os/akmods-nvidia-20240806:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}"
+ARG NVIDIA_CACHE="ghcr.io/ublue-os/akmods-nvidia:${AKMODS_FLAVOR}-${FEDORA_MAJOR_VERSION}-20240806"
 ARG KERNEL_CACHE="ghcr.io/ublue-os/${AKMODS_FLAVOR}-kernel:${KERNEL}"
 FROM ${KMOD_SOURCE_COMMON} AS akmods
 FROM ${ZFS_CACHE} AS zfs_cache


### PR DESCRIPTION
We have been experiencing multiple freezes with the newly released Nvidia 560 drivers, so we will pin to 555 while we investigate.