### PR TITLE
feat: add kwin rules for google chrome stable/unstable and flathub steam

### DIFF
--- a/system_files/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kwinrulesrc
+++ b/system_files/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kwinrulesrc
@@ -1,0 +1,21 @@
+[chrome-dev]
+Description=chrome-dev
+desktopfile=com.google.ChromeDev
+desktopfilerule=3
+wmclass=google-chrome-unstable
+wmclassmatch=1
+
+[chrome-fix]
+Description=chrome-fix
+desktopfile=com.google.Chrome
+desktopfilerule=3
+wmclass=google-chrome
+wmclassmatch=1
+
+[steam-flathub-fix]
+Description=steam-flathub-fix
+desktopfile=com.valvesoftware.Steam
+desktopfilerule=3
+wmclass=steamwebhelper SDL Application
+wmclasscomplete=true
+wmclassmatch=1


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.

-->
this pr will add default kwin rules for google chrome stable/unstable 
it will fix this issue [default wayland icons for google chrome](https://www.reddit.com/r/kde/comments/tzw738/fix_generic_wayland_icon_in_task_manager_for/) 
also fix icon issue for steam flathub on KDE 
![gambar](https://github.com/user-attachments/assets/322ac9dd-3c79-42f1-ac6f-d910d442148f)
