### PR TITLE
feat: ollama ujust script, some additions for removal verbs for the ollama and open-webui containers.

### DIFF
--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -26,141 +26,182 @@ tensorflow:
     podman run -it -p 8888:8888 docker.io/tensorflow/tensorflow:latest-jupyter  # Start Jupyter server
 
 # Setup a local Ollama instance in a container. Detect hardware, offer a choice if needed.
-ollama:
+install-ollama ACTION="":
     #!/usr/bin/env bash
-    echo 'Detecting Hardware...'
-    echo
-    GPU_CHOICES=("Nvidia (CUDA)" "AMD (ROCm)" "CPU (slow)")
-    DETECTED_OPTIONS=()
-    # Detect nvidia drivers
-    if which nvidia-smi > /dev/null 2>&1; then
-        DETECTED_OPTIONS+=("${GPU_CHOICES[0]}")
+    OPTION={{ ACTION }}
+    if [ "$OPTION" == "help" ]; then
+    if [ "$OPTION" == "help" ]; then
+      echo "Usage: ujust install-ollama <option>"
+      echo "  <option>: Specify the quick option to skip the prompt"
+      echo "  Use 'install' to Install ollama container"
+      echo "  Use 'install-open-webui' to Install open-webui container"
+      echo "  Use 'remove-ollama' to remove the ollama container"
+      echo "  Use 'remove-open-webui' to remove the open-webui container and persisten volume"
+      exit 0
+    elif [ "$OPTION" == "" ]; then
+      echo "${bold}ollama setup and configuration${normal}"
+      echo "CDEmu is $CDEMU_STATE"
+      OPTION=$(Choose "Install" "Install Open-Webui" "Remove ollama" "Remove open-Webui")
     fi
-    # Detect AMD hardware
-    if lspci | grep ' VGA ' | grep -sq AMD; then
-        DETECTED_OPTIONS+=("${GPU_CHOICES[1]}")
+    if [[ "${OPTION,,}" == "install" ]]; then
+        echo 'Detecting Hardware...'
+        echo
+        GPU_CHOICES=("Nvidia (CUDA)" "AMD (ROCm)" "CPU (slow)")
+        DETECTED_OPTIONS=()
+        # Detect nvidia drivers
+        if which nvidia-smi > /dev/null 2>&1; then
+            DETECTED_OPTIONS+=("${GPU_CHOICES[0]}")
+        fi
+        # Detect AMD hardware
+        if lspci | grep ' VGA ' | grep -sq AMD; then
+            DETECTED_OPTIONS+=("${GPU_CHOICES[1]}")
+        fi
+        # Nothing detected, ask the user
+        if [ ${#DETECTED_OPTIONS[@]} -eq 0 ]; then
+            GPU_SELECTION=$(printf '%s\n' "${GPU_CHOICES[@]}" | gum choose --select-if-one --header "Select the type of graphics card you want to use")
+        else
+            GPU_SELECTION=$(printf '%s\n' "${DETECTED_OPTIONS[@]}" | gum choose --select-if-one --header "Select the type of graphics card you want to use")
+        fi
+        echo "Selected ${GPU_SELECTION}!"
+        case "$GPU_SELECTION" in
+            "Nvidia (CUDA)")
+                IMAGE=latest
+                CUSTOM_ARGS="AddDevice=nvidia.com/gpu=all"
+                ;;
+
+            "AMD (ROCm)")
+                IMAGE=rocm
+                read -r -d '' CUSTOM_ARGS <<-'EOF'
+        AddDevice=/dev/dri
+        AddDevice=/dev/kfd
+        EOF
+                ;;
+            *)
+                IMAGE=latest
+                CUSTOM_ARGS=""
+                ;;
+        esac
+
+        read -r -d '' QUADLET <<-EOF
+        [Unit]
+        Description=The Ollama container
+        After=local-fs.target
+
+        [Service]
+        Restart=always
+        TimeoutStartSec=60
+        # Ensure there's a userland podman.sock
+        ExecStartPre=/bin/systemctl --user enable podman.socket
+        # Ensure that the dir exists
+        ExecStartPre=-mkdir -p %h/.ollama
+
+        [Container]
+        ContainerName=ollama
+        PublishPort=11434:11434
+        RemapUsers=keep-id
+        RunInit=yes
+        NoNewPrivileges=no
+        Network=ollama.network
+        Volume=%h/.ollama:/.ollama
+        PodmanArgs=--userns=keep-id
+        PodmanArgs=--group-add=keep-groups
+        PodmanArgs=--ulimit=host
+        PodmanArgs=--security-opt=label=disable
+        PodmanArgs=--cgroupns=host
+
+        Image=docker.io/ollama/ollama:${IMAGE}
+        ${CUSTOM_ARGS}
+
+        [Install]
+        RequiredBy=multi-user.target
+        EOF
+        if [  ! -f ~/.config/containers/systemd/ollama.container ]; then
+            mkdir -p ~/.config/containers/systemd
+            echo "${QUADLET}" > ~/.config/containers/systemd/ollama.container
+        else
+            echo "Ollama container already exists, skipping..."
+        fi
+
+        read -r -d '' QUADLET_NETWORK <<-EOF
+        [Network]
+        NetworkName=ollama
+        EOF
+        if [  ! -f ~/.config/containers/systemd/ollama.network ]; then
+            mkdir -p ~/.config/containers/systemd
+            echo "${QUADLET_NETWORK}" > ~/.config/containers/systemd/ollama.network
+        else
+            echo "Ollama network already exists, skipping..."
+        fi
+
+        systemctl --user daemon-reload
+        systemctl --user start ollama.service || echo "Error starting Ollama Quadlet."
+        echo "Please install the ollama cli via \`brew install ollama\`"
     fi
-    # Nothing detected, ask the user
-    if [ ${#DETECTED_OPTIONS[@]} -eq 0 ]; then
-        GPU_SELECTION=$(printf '%s\n' "${GPU_CHOICES[@]}" | gum choose --select-if-one --header "Select the type of graphics card you want to use")
-    else
-        GPU_SELECTION=$(printf '%s\n' "${DETECTED_OPTIONS[@]}" | gum choose --select-if-one --header "Select the type of graphics card you want to use")
+    if [[ "${OPTION,,}" == "install-open-webui" ]]; then
+        # Setup a local Open WebUI in a container
+        #!/usr/bin/env bash
+
+        read -r -d '' QUADLET <<-EOF
+        [Unit]
+        Description=An Ollama WebUI container
+        After=network-online.target ollama.service
+        Requires=ollama.service
+
+        [Container]
+        Image=ghcr.io/open-webui/open-webui:latest
+        AutoUpdate=registry
+        ContainerName=ollama-web
+        Environment=OLLAMA_BASE_URL=http://ollama:11434
+        Environment=WEBUI_SECRET_KEY=abc123
+        Environment=DEFAULT_USER_ROLE=admin
+        Volume=open-webui:/app/backend/data
+        # Open WebUI does not allow access without a user account, nor does it allow
+        # account creation via environment variables.
+        Environment=ENABLE_SIGNUP=true
+        PublishPort=8080:8080
+        Network=ollama.network
+
+        [Service]
+        TimeoutStartSec=900
+
+        [Install]
+        WantedBy=multi-user.target
+        EOF
+        if [  ! -f ~/.config/containers/systemd/ollama-web.container ]; then
+            mkdir -p ~/.config/containers/systemd
+            echo "${QUADLET}" > ~/.config/containers/systemd/ollama-web.container
+        else
+            echo "Open WebUI container already exists, skipping..."
+        fi
+        systemctl --user daemon-reload
+        systemctl --user start ollama-web.service
+        echo "Open Web UI container started. You can access it at http://localhost:8080"
     fi
-    echo "Selected ${GPU_SELECTION}!"
-    case "$GPU_SELECTION" in
-        "Nvidia (CUDA)")
-            IMAGE=latest
-            CUSTOM_ARGS="AddDevice=nvidia.com/gpu=all"
-            ;;
-
-        "AMD (ROCm)")
-            IMAGE=rocm
-            read -r -d '' CUSTOM_ARGS <<-'EOF'
-    AddDevice=/dev/dri
-    AddDevice=/dev/kfd
-    EOF
-            ;;
-        *)
-            IMAGE=latest
-            CUSTOM_ARGS=""
-            ;;
-    esac
-
-    read -r -d '' QUADLET <<-EOF
-    [Unit]
-    Description=The Ollama container
-    After=local-fs.target
-
-    [Service]
-    Restart=always
-    TimeoutStartSec=60
-    # Ensure there's a userland podman.sock
-    ExecStartPre=/bin/systemctl --user enable podman.socket
-    # Ensure that the dir exists
-    ExecStartPre=-mkdir -p %h/.ollama
-
-    [Container]
-    ContainerName=ollama
-    PublishPort=11434:11434
-    RemapUsers=keep-id
-    RunInit=yes
-    NoNewPrivileges=no
-    Network=ollama.network
-    Volume=%h/.ollama:/.ollama
-    PodmanArgs=--userns=keep-id
-    PodmanArgs=--group-add=keep-groups
-    PodmanArgs=--ulimit=host
-    PodmanArgs=--security-opt=label=disable
-    PodmanArgs=--cgroupns=host
-
-    Image=docker.io/ollama/ollama:${IMAGE}
-    ${CUSTOM_ARGS}
-
-    [Install]
-    RequiredBy=multi-user.target
-    EOF
-    if [  ! -f ~/.config/containers/systemd/ollama.container ]; then
-        mkdir -p ~/.config/containers/systemd
-        echo "${QUADLET}" > ~/.config/containers/systemd/ollama.container
-    else
-        echo "Ollama container already exists, skipping..."
+    if [[ "${OPTION,,}" == "remove-ollama" ]]; then
+        echo "Removing ollama container"
+        if [ "$(systemctl is-enabled ollama.service)" == "enabled" ]; then
+            echo "stopping Ollama Quadlet"
+            systemctl --user stop ollama.service || echo "Error stopping Ollama Quadlet."
+            rm ~/.config/containers/systemd/ollama.container
+            rm ~/.config/containers/systemd/ollama.network
+            systemctl --user daemon-reload
+            echo "Ollama Quadlet removed"
+        fi
+        echo "ollama quadlet not enabled, nothing to do"
     fi
-
-    read -r -d '' QUADLET_NETWORK <<-EOF
-    [Network]
-    NetworkName=ollama
-    EOF
-    if [  ! -f ~/.config/containers/systemd/ollama.network ]; then
-        mkdir -p ~/.config/containers/systemd
-        echo "${QUADLET_NETWORK}" > ~/.config/containers/systemd/ollama.network
-    else
-        echo "Ollama network already exists, skipping..."
+    if [[ "${OPTION,,}" == "remove-open-webui" ]]; then
+        echo "Removing open-webui container"
+        if [ "$(systemctl is-enabled ollama-web.service)" == "enabled" ]; then
+            echo "stopping open-webui Quadlet"
+            systemctl --user stop ollama-web.service || echo "Error stopping Open-webui Quadlet."
+            rm ~/.config/containers/systemd/ollama-web.container
+            echo "removing open-webui persistent volume"
+            podman volume rm open-webui
+            systemctl --user daemon-reload
+            echo "open-webui Quadlet removed"
+        fi
+        echo "open-webui quadlet not enabled, nothing to do"
     fi
-
-    systemctl --user daemon-reload
-    systemctl --user start ollama.service || echo "Error starting Ollama Quadlet."
-    echo "Please install the ollama cli via \`brew install ollama\`"
-
-# Setup a local Ollama WebUI in a container
-ollama-web: ollama
-    #!/usr/bin/env bash
-
-    read -r -d '' QUADLET <<-EOF
-    [Unit]
-    Description=An Ollama WebUI container
-    After=network-online.target ollama.service
-    Requires=ollama.service
-
-    [Container]
-    Image=ghcr.io/open-webui/open-webui:latest
-    AutoUpdate=registry
-    ContainerName=ollama-web
-    Environment=OLLAMA_BASE_URL=http://ollama:11434
-    Environment=WEBUI_SECRET_KEY=abc123
-    Environment=DEFAULT_USER_ROLE=admin
-    Volume=open-webui:/app/backend/data
-    # Open WebUI does not allow access without a user account, nor does it allow
-    # account creation via environment variables.
-    Environment=ENABLE_SIGNUP=true
-    PublishPort=8080:8080
-    Network=ollama.network
-
-    [Service]
-    TimeoutStartSec=900
-
-    [Install]
-    WantedBy=multi-user.target
-    EOF
-    if [  ! -f ~/.config/containers/systemd/ollama-web.container ]; then
-        mkdir -p ~/.config/containers/systemd
-        echo "${QUADLET}" > ~/.config/containers/systemd/ollama-web.container
-    else
-        echo "Ollama WebUI container already exists, skipping..."
-    fi
-    systemctl --user daemon-reload
-    systemctl --user start ollama-web.service
-    echo "Ollama Web UI container started. You can access it at http://localhost:8080"
-
 # Setup InvokeAI in a container
 invokeai:
     #!/usr/bin/env bash

--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -193,6 +193,7 @@ ollama ACTION="":
         systemctl --user daemon-reload
         echo "open-webui Quadlet removed"
     fi
+
 invokeai:
     #!/usr/bin/env bash
     echo 'Detecting Hardware...'

--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -26,183 +26,173 @@ tensorflow:
     podman run -it -p 8888:8888 docker.io/tensorflow/tensorflow:latest-jupyter  # Start Jupyter server
 
 # Setup a local Ollama instance in a container. Detect hardware, offer a choice if needed.
-install-ollama ACTION="":
+ollama ACTION="":
     #!/usr/bin/env bash
     OPTION={{ ACTION }}
     if [ "$OPTION" == "help" ]; then
-    if [ "$OPTION" == "help" ]; then
-      echo "Usage: ujust install-ollama <option>"
+      echo "Usage: ujust ollama <option>"
       echo "  <option>: Specify the quick option to skip the prompt"
       echo "  Use 'install' to Install ollama container"
       echo "  Use 'install-open-webui' to Install open-webui container"
-      echo "  Use 'remove-ollama' to remove the ollama container"
-      echo "  Use 'remove-open-webui' to remove the open-webui container and persisten volume"
+      echo "  Use 'remove' to remove the ollama container"
+      echo "  Use 'remove-open-webui' to remove the open-webui container and persistent volume"
       exit 0
-    elif [ "$OPTION" == "" ]; then
-      echo "${bold}ollama setup and configuration${normal}"
-      echo "CDEmu is $CDEMU_STATE"
-      OPTION=$(Choose "Install" "Install Open-Webui" "Remove ollama" "Remove open-Webui")
+    #elif [ "$OPTION" == "" ]; then
+    #  echo "${bold}ollama setup and configuration${normal}"
+    #  #OPTION=$(Choose "install" "install-open-webui" "remove" "remove-open-webui")
     fi
-    if [[ "${OPTION,,}" == "install" ]]; then
-        echo 'Detecting Hardware...'
-        echo
-        GPU_CHOICES=("Nvidia (CUDA)" "AMD (ROCm)" "CPU (slow)")
-        DETECTED_OPTIONS=()
-        # Detect nvidia drivers
-        if which nvidia-smi > /dev/null 2>&1; then
-            DETECTED_OPTIONS+=("${GPU_CHOICES[0]}")
-        fi
-        # Detect AMD hardware
-        if lspci | grep ' VGA ' | grep -sq AMD; then
-            DETECTED_OPTIONS+=("${GPU_CHOICES[1]}")
-        fi
-        # Nothing detected, ask the user
-        if [ ${#DETECTED_OPTIONS[@]} -eq 0 ]; then
-            GPU_SELECTION=$(printf '%s\n' "${GPU_CHOICES[@]}" | gum choose --select-if-one --header "Select the type of graphics card you want to use")
-        else
-            GPU_SELECTION=$(printf '%s\n' "${DETECTED_OPTIONS[@]}" | gum choose --select-if-one --header "Select the type of graphics card you want to use")
-        fi
-        echo "Selected ${GPU_SELECTION}!"
-        case "$GPU_SELECTION" in
-            "Nvidia (CUDA)")
-                IMAGE=latest
-                CUSTOM_ARGS="AddDevice=nvidia.com/gpu=all"
-                ;;
+    if [ "${OPTION}" == "install" ]; then
+        #!/usr/bin/env bash
+    echo 'Detecting Hardware...'
+    echo
+    GPU_CHOICES=("Nvidia (CUDA)" "AMD (ROCm)" "CPU (slow)")
+    DETECTED_OPTIONS=()
+    # Detect nvidia drivers
+    if which nvidia-smi > /dev/null 2>&1; then
+        DETECTED_OPTIONS+=("${GPU_CHOICES[0]}")
+    fi
+    # Detect AMD hardware
+    if lspci | grep ' VGA ' | grep -sq AMD; then
+        DETECTED_OPTIONS+=("${GPU_CHOICES[1]}")
+    fi
+    # Nothing detected, ask the user
+    if [ ${#DETECTED_OPTIONS[@]} -eq 0 ]; then
+        GPU_SELECTION=$(printf '%s\n' "${GPU_CHOICES[@]}" | gum choose --select-if-one --header "Select the type of graphics card you want to use")
+    else
+        GPU_SELECTION=$(printf '%s\n' "${DETECTED_OPTIONS[@]}" | gum choose --select-if-one --header "Select the type of graphics card you want to use")
+    fi
+    echo "Selected ${GPU_SELECTION}!"
+    case "$GPU_SELECTION" in
+        "Nvidia (CUDA)")
+            IMAGE=latest
+            CUSTOM_ARGS="AddDevice=nvidia.com/gpu=all"
+            ;;
 
-            "AMD (ROCm)")
-                IMAGE=rocm
-                read -r -d '' CUSTOM_ARGS <<-'EOF'
-        AddDevice=/dev/dri
-        AddDevice=/dev/kfd
-        EOF
-                ;;
-            *)
-                IMAGE=latest
-                CUSTOM_ARGS=""
-                ;;
-        esac
+        "AMD (ROCm)")
+            IMAGE=rocm
+            read -r -d '' CUSTOM_ARGS <<-'EOF'
+    AddDevice=/dev/dri
+    AddDevice=/dev/kfd
+    EOF
+            ;;
+        *)
+            IMAGE=latest
+            CUSTOM_ARGS=""
+            ;;
+    esac
 
-        read -r -d '' QUADLET <<-EOF
-        [Unit]
-        Description=The Ollama container
-        After=local-fs.target
+    read -r -d '' QUADLET <<-EOF
+    [Unit]
+    Description=The Ollama container
+    After=local-fs.target
 
-        [Service]
-        Restart=always
-        TimeoutStartSec=60
-        # Ensure there's a userland podman.sock
-        ExecStartPre=/bin/systemctl --user enable podman.socket
-        # Ensure that the dir exists
-        ExecStartPre=-mkdir -p %h/.ollama
+    [Service]
+    Restart=always
+    TimeoutStartSec=60
+    # Ensure there's a userland podman.sock
+    ExecStartPre=/bin/systemctl --user enable podman.socket
+    # Ensure that the dir exists
+    ExecStartPre=-mkdir -p %h/.ollama
 
-        [Container]
-        ContainerName=ollama
-        PublishPort=11434:11434
-        RemapUsers=keep-id
-        RunInit=yes
-        NoNewPrivileges=no
-        Network=ollama.network
-        Volume=%h/.ollama:/.ollama
-        PodmanArgs=--userns=keep-id
-        PodmanArgs=--group-add=keep-groups
-        PodmanArgs=--ulimit=host
-        PodmanArgs=--security-opt=label=disable
-        PodmanArgs=--cgroupns=host
+    [Container]
+    ContainerName=ollama
+    PublishPort=11434:11434
+    RemapUsers=keep-id
+    RunInit=yes
+    NoNewPrivileges=no
+    Network=ollama.network
+    Volume=%h/.ollama:/.ollama
+    PodmanArgs=--userns=keep-id
+    PodmanArgs=--group-add=keep-groups
+    PodmanArgs=--ulimit=host
+    PodmanArgs=--security-opt=label=disable
+    PodmanArgs=--cgroupns=host
 
-        Image=docker.io/ollama/ollama:${IMAGE}
-        ${CUSTOM_ARGS}
+    Image=docker.io/ollama/ollama:${IMAGE}
+    ${CUSTOM_ARGS}
 
-        [Install]
-        RequiredBy=multi-user.target
-        EOF
-        if [  ! -f ~/.config/containers/systemd/ollama.container ]; then
-            mkdir -p ~/.config/containers/systemd
-            echo "${QUADLET}" > ~/.config/containers/systemd/ollama.container
-        else
-            echo "Ollama container already exists, skipping..."
-        fi
+    [Install]
+    RequiredBy=multi-user.target
+    EOF
+    if [  ! -f ~/.config/containers/systemd/ollama.container ]; then
+        mkdir -p ~/.config/containers/systemd
+        echo "${QUADLET}" > ~/.config/containers/systemd/ollama.container
+    else
+        echo "ollama container already exists, skipping..."
+    fi
 
-        read -r -d '' QUADLET_NETWORK <<-EOF
-        [Network]
-        NetworkName=ollama
-        EOF
-        if [  ! -f ~/.config/containers/systemd/ollama.network ]; then
-            mkdir -p ~/.config/containers/systemd
-            echo "${QUADLET_NETWORK}" > ~/.config/containers/systemd/ollama.network
-        else
-            echo "Ollama network already exists, skipping..."
-        fi
+    read -r -d '' QUADLET_NETWORK <<-EOF
+    [Network]
+    NetworkName=ollama
+    EOF
+    if [  ! -f ~/.config/containers/systemd/ollama.network ]; then
+        mkdir -p ~/.config/containers/systemd
+        echo "${QUADLET_NETWORK}" > ~/.config/containers/systemd/ollama.network
+    else
+        echo "ollama network already exists, skipping..."
+    fi
 
-        systemctl --user daemon-reload
-        systemctl --user start ollama.service || echo "Error starting Ollama Quadlet."
-        echo "Please install the ollama cli via \`brew install ollama\`"
+    systemctl --user daemon-reload
+    systemctl --user start ollama.service || echo "Error starting ollama Quadlet."
+    echo "Please install the ollama cli via \`brew install ollama\`"
+        exit 0
     fi
     if [[ "${OPTION,,}" == "install-open-webui" ]]; then
-        # Setup a local Open WebUI in a container
-        #!/usr/bin/env bash
+    #!/usr/bin/env bash
 
-        read -r -d '' QUADLET <<-EOF
-        [Unit]
-        Description=An Ollama WebUI container
-        After=network-online.target ollama.service
-        Requires=ollama.service
+    read -r -d '' QUADLET <<-EOF
+    [Unit]
+    Description=An Ollama WebUI container
+    After=network-online.target ollama.service
+    Requires=ollama.service
 
-        [Container]
-        Image=ghcr.io/open-webui/open-webui:latest
-        AutoUpdate=registry
-        ContainerName=ollama-web
-        Environment=OLLAMA_BASE_URL=http://ollama:11434
-        Environment=WEBUI_SECRET_KEY=abc123
-        Environment=DEFAULT_USER_ROLE=admin
-        Volume=open-webui:/app/backend/data
-        # Open WebUI does not allow access without a user account, nor does it allow
-        # account creation via environment variables.
-        Environment=ENABLE_SIGNUP=true
-        PublishPort=8080:8080
-        Network=ollama.network
+    [Container]
+    Image=ghcr.io/open-webui/open-webui:latest
+    AutoUpdate=registry
+    ContainerName=ollama-web
+    Environment=OLLAMA_BASE_URL=http://ollama:11434
+    Environment=WEBUI_SECRET_KEY=abc123
+    Environment=DEFAULT_USER_ROLE=admin
+    Volume=open-webui:/app/backend/data
+    # Open WebUI does not allow access without a user account, nor does it allow
+    # account creation via environment variables.
+    Environment=ENABLE_SIGNUP=true
+    PublishPort=8080:8080
+    Network=ollama.network
 
-        [Service]
-        TimeoutStartSec=900
+    [Service]
+    TimeoutStartSec=900
 
-        [Install]
-        WantedBy=multi-user.target
-        EOF
-        if [  ! -f ~/.config/containers/systemd/ollama-web.container ]; then
-            mkdir -p ~/.config/containers/systemd
-            echo "${QUADLET}" > ~/.config/containers/systemd/ollama-web.container
-        else
-            echo "Open WebUI container already exists, skipping..."
-        fi
-        systemctl --user daemon-reload
-        systemctl --user start ollama-web.service
-        echo "Open Web UI container started. You can access it at http://localhost:8080"
+    [Install]
+    WantedBy=multi-user.target
+    EOF
+    if [  ! -f ~/.config/containers/systemd/ollama-web.container ]; then
+        mkdir -p ~/.config/containers/systemd
+        echo "${QUADLET}" > ~/.config/containers/systemd/ollama-web.container
+    else
+        echo "open-webui container already exists, skipping..."
     fi
-    if [[ "${OPTION,,}" == "remove-ollama" ]]; then
+    systemctl --user daemon-reload
+    systemctl --user start ollama-web.service
+    echo "Ollama Web UI container started. You can access it at http://localhost:8080"
+    elif [[ "${OPTION,,}" == "remove" ]]; then
         echo "Removing ollama container"
-        if [ "$(systemctl is-enabled ollama.service)" == "enabled" ]; then
-            echo "stopping Ollama Quadlet"
-            systemctl --user stop ollama.service || echo "Error stopping Ollama Quadlet."
-            rm ~/.config/containers/systemd/ollama.container
-            rm ~/.config/containers/systemd/ollama.network
-            systemctl --user daemon-reload
-            echo "Ollama Quadlet removed"
-        fi
-        echo "ollama quadlet not enabled, nothing to do"
-    fi
-    if [[ "${OPTION,,}" == "remove-open-webui" ]]; then
+        echo "stopping ollama Quadlet"
+        systemctl --user stop ollama.service || echo "Error stopping ollama Quadlet."
+        rm ~/.config/containers/systemd/ollama.container || echo "Error removing ollama container"
+        rm ~/.config/containers/systemd/ollama.network || echo "Error removing ollama network"
+        systemctl --user daemon-reload
+        echo "ollama Quadlet removed"
+    elif [[ "${OPTION,,}" == "remove-open-webui" ]]; then
         echo "Removing open-webui container"
-        if [ "$(systemctl is-enabled ollama-web.service)" == "enabled" ]; then
-            echo "stopping open-webui Quadlet"
-            systemctl --user stop ollama-web.service || echo "Error stopping Open-webui Quadlet."
-            rm ~/.config/containers/systemd/ollama-web.container
-            echo "removing open-webui persistent volume"
-            podman volume rm open-webui
-            systemctl --user daemon-reload
-            echo "open-webui Quadlet removed"
-        fi
-        echo "open-webui quadlet not enabled, nothing to do"
+        echo "stopping open-webui Quadlet"
+        systemctl --user stop ollama-web.service || echo "Error stopping open-webui Quadlet."
+        rm ~/.config/containers/systemd/ollama-web.container
+        echo "removing open-webui persistent volume"
+        podman volume rm open-webui > /dev/null
+        systemctl --user daemon-reload
+        echo "open-webui Quadlet removed"
     fi
-# Setup InvokeAI in a container
 invokeai:
     #!/usr/bin/env bash
     echo 'Detecting Hardware...'


### PR DESCRIPTION
this is a first step on adding some actions to the ujust for ollama before potentially standardising this in bazzite too with another PR to bring "bazzite-tools.just" over. I've been using this, but i've seen others with the same opinion as me that i'd like to be able to mostly atomically clean up after it, as bazzite machines are often everything devices (so people are picky about things using their resources) I also can imagine a situation where in bazzite, people will want to tinker with this, but then remove and clear up afterwards because of the nature of the machine, and the users themselves are likely not as tech savvy as say aurora or bluefin people.
The script is a frankenstein now, but works in my test environment, backwards and forwards as necessary. I'm not sure what the established design conventions are for remove- verbs and how people expect it to work, but it's got an included "ollama help" to move things along. 

I'm sure this will help dozens of people ;) 
