### PR TITLE
chore(ci): prevent pinning build-container-installer action digest

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,6 +16,13 @@
       "automerge": true,
       "matchManagers": ["dockerfile"],
       "matchUpdateTypes": ["digest"]
+    },
+    {
+      // Do not pin digest for jasonn3/build-container-installer GitHub Action since Docker
+      // images are not tagged with the commit sha
+      "matchUpdateTypes": ["pin", "digest", "pinDigest"],
+      "matchPackageNames": ["jasonn3/build-container-installer"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
The build-container-installer Docker images are not tagged with the commit sha (working on it).
For now, we can only use the tag names.