### PR TITLE
feat(gnome): increase check-alive-timeout

### DIFF
--- a/system_files/silverblue/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/etc/dconf/db/local.d/01-ublue
@@ -93,6 +93,7 @@ sort-directories-first=true
 
 [org/gnome/mutter]
 experimental-features=['scale-monitor-framebuffer']
+check-alive-timeout=20000
 
 [org/gnome/software]
 allow-updates=false

--- a/system_files/silverblue/etc/dconf/db/local.d/01-ublue
+++ b/system_files/silverblue/etc/dconf/db/local.d/01-ublue
@@ -93,7 +93,7 @@ sort-directories-first=true
 
 [org/gnome/mutter]
 experimental-features=['scale-monitor-framebuffer']
-check-alive-timeout=20000
+check-alive-timeout=uint32 20000
 
 [org/gnome/software]
 allow-updates=false


### PR DESCRIPTION
This will supress the application crash dialog to a more reasonable time (20s instead of 5s)

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.

-->
