### PR TITLE
feat: add breeze-gtk for aurora

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -69,6 +69,7 @@
 				"zenity"
 			],
 			"kinoite": [
+				"breeze-gtk",
 				"skanpage",
 				"libadwaita-qt5",
 				"libadwaita-qt6",


### PR DESCRIPTION
https://github.com/ublue-os/bluefin/issues/1596

Adds breeze-gtk package for more native theming of gtk apps on KDE Plasma.