### PR TITLE
feat: disable ollama-web quadlet auth

### DIFF
--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -152,11 +152,8 @@ ollama ACTION="help":
     ContainerName=ollama-web
     Environment=OLLAMA_BASE_URL=http://ollama:11434
     Environment=WEBUI_SECRET_KEY=abc123
-    Environment=DEFAULT_USER_ROLE=admin
+    Environment=WEBUI_AUTH=false
     Volume=open-webui:/app/backend/data
-    # Open WebUI does not allow access without a user account, nor does it allow
-    # account creation via environment variables.
-    Environment=ENABLE_SIGNUP=true
     PublishPort=8080:8080
     Network=ollama.network
 


### PR DESCRIPTION
The ollama-web container now does not require auth to be used.  This change disables authentication in the Ollama Web container.

This is safe because the configuration does not expose the web server to other machines on the network