### PR TITLE
fix: limited linesize to 78 characters to accomodate 80x24 terminal 

### DIFF
--- a/system_files/shared/usr/libexec/ublue-motd
+++ b/system_files/shared/usr/libexec/ublue-motd
@@ -24,5 +24,5 @@ if [[ -f "$TIP_FILE" ]]; then
 
 	TIP_ESCAPED=$(escape "$TIP")
 
-	sed -e "s/%IMAGE_NAME%/$IMAGE_NAME_ESCAPED/g" -e "s/%IMAGE_TAG%/$IMAGE_TAG_ESCAPED/g" -e "s/%TIP%/$TIP_ESCAPED/g" /usr/share/ublue-os/motd/bluefin.md | tr '~' '\n' | /usr/bin/glow -s auto -
+	sed -e "s/%IMAGE_NAME%/$IMAGE_NAME_ESCAPED/g" -e "s/%IMAGE_TAG%/$IMAGE_TAG_ESCAPED/g" -e "s/%TIP%/$TIP_ESCAPED/g" /usr/share/ublue-os/motd/bluefin.md | tr '~' '\n' | /usr/bin/glow -s auto -w 78 -
 fi


### PR DESCRIPTION
reason this is needed is becuase while yes standard width is 80 as its set in default config it doesnt take into account what appers to be 2 character indent it has at which point it breaks anything thats 80 characters in size like the table it renders

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.

-->
