### PR TITLE
feat: add git-credential-libsecret to DX

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -102,6 +102,7 @@
 				"edk2-ovmf",
 				"flatpak-builder",
 				"genisoimage",
+				"git-credential-libsecret",
 				"google-droid-sans-mono-fonts",
 				"google-go-mono-fonts",
 				"ibm-plex-mono-fonts",


### PR DESCRIPTION
Add git-credential-libsecret to allow storing git credentials in GNOME Keyring or KDE Wallet.
