### PR TITLE
fix(aurora): update KDE settings homepage link

### DIFF
--- a/system_files/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kcm-about-distrorc
+++ b/system_files/kinoite/usr/share/kde-settings/kde-profile/default/xdg/kcm-about-distrorc
@@ -1,5 +1,5 @@
 [General]
 LogoPath=/usr/share/pixmaps/system-logo.png
 Name=Aurora
-Website=https//getaurora.dev
+Website=https://getaurora.dev
 Variant=Aurora


### PR DESCRIPTION
Resolves #1653 

The current link is invalid, since it is missing the colon in the protocol name.
