### PR TITLE
fix(bluefin-tools): Don't explicitly start ollama after creating service

### DIFF
--- a/just/bluefin-tools.just
+++ b/just/bluefin-tools.just
@@ -133,7 +133,6 @@ ollama ACTION="help":
     fi
 
     systemctl --user daemon-reload
-    systemctl --user start ollama.service || echo "Error starting ollama Quadlet."
     echo "Please install the ollama cli via \`brew install ollama\`"
         exit 0
     fi
@@ -170,7 +169,6 @@ ollama ACTION="help":
         echo "open-webui container already exists, skipping..."
     fi
     systemctl --user daemon-reload
-    systemctl --user start ollama-web.service
     echo "Ollama Web UI container started. You can access it at http://localhost:8080"
     elif [[ "${OPTION,,}" == "remove" ]]; then
         echo "Removing ollama container"


### PR DESCRIPTION
Running daemon-reload is sufficient. Confirmed both ollama and ollama-web services load afterwards

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.

-->
