### PR TITLE
fix(just): remove configure-shell

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -82,33 +82,6 @@ devmode:
         fi
     fi
 
-alias shell := configure-shell
-
-# Switch to a different shell
-configure-shell ACTION="":
-    #!/bin/bash
-    source /usr/lib/ujust/ujust.sh
-    CURRENT_SHELL="$(cat /etc/passwd | grep ":$UID:" | cut '-d:' '-f7')"
-    OPTION={{ ACTION }}
-    if [ "$OPTION" == "help" ]; then
-      echo "Usage: ujust shell <option>"
-      echo "  <option>: Specify the quick option to skip the prompt"
-      echo "  Use 'fish' to select fish"
-      echo "  Use 'zsh' to select zsh"
-      echo "  Use 'bash' to select bash"
-      exit 0
-    elif [ "$OPTION" == "" ]; then
-      echo "${bold}Shell configuration${normal}"
-      echo "${USER}'s shell is currently ${CURRENT_SHELL}"
-      OPTION=$(Choose "fish" "zsh" "bash")
-    fi
-    if [ -z "$OPTION" ]; then
-      exit 0
-    else
-      sudo usermod $USER --shell /usr/bin/$OPTION 
-      printf "${USER}'s shell is now %s.\n" "$(cat /etc/passwd | grep ":$UID:" | cut '-d:' '-f7')"
-    fi
-
 alias gnome-vrr := toggle-gnome-vrr
 
 # Enable or Disable Gnome-VRR


### PR DESCRIPTION
We should have removed this a long time ago: 

Supported instructions: https://docs.projectbluefin.io/administration#changing-the-default-terminal-shell

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.

-->
