### PR TITLE
feat: add scx-scheds

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -190,7 +190,8 @@
 	"40": {
 		"include": {
 			"all": [
-				"ptyxis"
+				"ptyxis",
+				"scx-scheds"
 			],
 			"silverblue": [],
 			"dx": []


### PR DESCRIPTION
This adds support for scx-scheds, same package in bazzite. This will only work on fsync kernels like the one in `:latest`. 

Running the tools on stock kernels is a noop so `:stable` and `:gts` are safe:

```
❯ sudo scx_bpfland 
[sudo] password for jorge: 
23:30:09 [INFO] scx_bpfland 1.0.4 x86_64-unknown-linux-gnu SMT on
Error: sched_ext_ops.dump() missing, kernel too old?
```

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.

-->
