### PR TITLE
fix: remove nonexistant libsssd_sudo package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -26,7 +26,6 @@
 				"libimobiledevice",
 				"libxcrypt-compat",
 				"libsss_autofs",
-				"libssd_sudo", 
 				"lm_sensors",
 				"make",
 				"mesa-libGLU",


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.

-->
