### PR TITLE
fix: enable incus-startup service

### DIFF
--- a/system_files/dx/usr/libexec/bluefin-incus
+++ b/system_files/dx/usr/libexec/bluefin-incus
@@ -58,6 +58,7 @@ sudo systemctl enable --now incus-workaround.service
 sudo systemctl enable --now lxcfs
 sudo systemctl enable --now incus.socket
 sudo systemctl start incus.service
+sudo systemctl enable incus-startup
 
 # run incus admin init
 echo ""


### PR DESCRIPTION
This change enables the incus-startup service which will start containers that were running at system shutdown, and start containers marked to start at boot.

It was overlooked previously.