### PR TITLE
fix: update warning formatting

### DIFF
--- a/system_files/shared/usr/libexec/check-sb-key.sh
+++ b/system_files/shared/usr/libexec/check-sb-key.sh
@@ -18,7 +18,7 @@ if [ $SB_ENABLED -ne 0 ]; then
 fi
 
 if mokutil --test-key "$KEY_DER_FILE"; then 
-    echo "**WARNING**: $WARNING_MSG" > $KEY_WARN_FILE
+    echo "$WARNING_MSG" > $KEY_WARN_FILE
 else
     [ -e $KEY_WARN_FILE ] && rm $KEY_WARN_FILE
 fi

--- a/system_files/shared/usr/libexec/ublue-motd
+++ b/system_files/shared/usr/libexec/ublue-motd
@@ -27,7 +27,7 @@ if [[ -f "$TIP_FILE" ]]; then
 fi
 
 KEY_WARN_FILE="/run/user-motd-sbkey-warn.md"
-[ -e $KEY_WARN_FILE ] && KEY_WARN="$(cat $KEY_WARN_FILE)"
+[ -e $KEY_WARN_FILE ] && KEY_WARN="**WARNING**: $(cat $KEY_WARN_FILE)"
 KEY_WARN_ESCAPED=$(escape "$KEY_WARN")
 
 sed -e "s/%IMAGE_NAME%/$IMAGE_NAME_ESCAPED/g" \


### PR DESCRIPTION
- remove warning prefix from message file
- add warning prefix to motd script

this change is a small fix to remove the redundant "WARNING" prefix for the GUI notification that bothered me

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.

-->
