### PR TITLE
chore(ci): temporarily disable rechunk in latest

### DIFF
--- a/.github/workflows/build-latest-aurora.yml
+++ b/.github/workflows/build-latest-aurora.yml
@@ -26,4 +26,3 @@ jobs:
     with:
       brand_name: aurora
       fedora_version: latest
-      rechunk: true

--- a/.github/workflows/build-latest-bluefin.yml
+++ b/.github/workflows/build-latest-bluefin.yml
@@ -26,4 +26,3 @@ jobs:
     with:
       brand_name: bluefin
       fedora_version: latest
-      rechunk: true


### PR DESCRIPTION
The latest builds are currently failing while we're implementing the rechunk action.
This PR disables rechunks in latest (since they aren't working) to get the updates flowing again.