### PR TITLE
chore(ci): enable rechunker for stable and gts

### DIFF
--- a/.github/workflows/build-beta-aurora.yml
+++ b/.github/workflows/build-beta-aurora.yml
@@ -26,3 +26,5 @@ jobs:
     with:
       brand_name: aurora
       fedora_version: beta
+      rechunk: true
+

--- a/.github/workflows/build-beta-bluefin.yml
+++ b/.github/workflows/build-beta-bluefin.yml
@@ -26,3 +26,5 @@ jobs:
     with:
       brand_name: bluefin
       fedora_version: beta
+      rechunk: true
+

--- a/.github/workflows/build-coreos-aurora.yml
+++ b/.github/workflows/build-coreos-aurora.yml
@@ -19,3 +19,5 @@ jobs:
     with:
       brand_name: aurora
       fedora_version: stable
+      rechunk: true
+

--- a/.github/workflows/build-coreos-bluefin.yml
+++ b/.github/workflows/build-coreos-bluefin.yml
@@ -19,3 +19,5 @@ jobs:
     with:
       brand_name: bluefin
       fedora_version: stable
+      rechunk: true
+

--- a/.github/workflows/build-gts-bluefin.yml
+++ b/.github/workflows/build-gts-bluefin.yml
@@ -19,3 +19,5 @@ jobs:
     with:
       brand_name: bluefin
       fedora_version: gts
+      rechunk: true
+


### PR DESCRIPTION
Let's merge this on Wednesday, 2 October, after gts/stable go out, then it'll just go off for the next set. I think it'll be fine but I'd like to kick the tyres on :latest for this one for a week.
