### PR TITLE
fix: rename discourse shortcut to community

### DIFF
--- a/system_files/shared/usr/share/applications/Discourse.desktop
+++ b/system_files/shared/usr/share/applications/Discourse.desktop
@@ -4,6 +4,6 @@ NoDisplay=false
 Terminal=false
 Exec=xdg-open https://universal-blue.discourse.group/c/bluefin/
 Icon=/usr/share/ublue-os/bluefin/discourse.svg
-Name=Discourse
+Name=Community
 Comment=Universal Blue Forums
 Categories=Utility;


### PR DESCRIPTION
This is a more obvious label for the forum.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING) before submitting a pull request.

-->
