### PR TITLE
chore(bluefin): update GNOME application groups

### DIFF
--- a/system_files/silverblue/etc/dconf/db/local.d/02-bluefin-folders
+++ b/system_files/silverblue/etc/dconf/db/local.d/02-bluefin-folders
@@ -1,13 +1,13 @@
 [org/gnome/desktop/app-folders]
-folder-children=['Games', 'GamingUtilities', 'Utilities', 'Containers', 'Wine', 'YaST', 'Pardus']
+folder-children=['Games', 'GamingUtilities', 'Utilities', 'Virtualization', 'Wine', 'YaST', 'Pardus', 'Development', 'Productivity']
 
 [org/gnome/desktop/app-folders/folders/GamingUtilities]
-apps=['protontricks.desktop', 'discover_overlay_configure.desktop', 'com.vysp3r.ProtonPlus.desktop', 'io.github.benjamimgois.goverlay.desktop', 'com.gerbilsoft.rom-properties.rp-config.desktop', 'input-remapper-gtk.desktop', 'steamos-nested-desktop.desktop']
+apps=['protontricks.desktop', 'discover_overlay_configure.desktop', 'com.vysp3r.ProtonPlus.desktop', 'io.github.benjamimgois.goverlay.desktop', 'com.gerbilsoft.rom-properties.rp-config.desktop', 'steamos-nested-desktop.desktop']
 name='Gaming Utilities'
 translate=false
 
 [org/gnome/desktop/app-folders/folders/Utilities]
-apps=['com.github.tchx84.Flatseal.desktop', 'io.github.flattool.Warehouse.desktop', 'com.mattjakeman.ExtensionManager.desktop', 'org.gnome.tweaks.desktop', 'firewall-config.desktop', 'ca.desrt.dconf-editor.desktop', 'org.gnome.World.PikaBackup', 'input-leap.desktop', 'solaar.desktop', 'org.fedoraproject.MediaWriter.desktop']
+apps=['com.github.tchx84.Flatseal.desktop', 'io.github.flattool.Warehouse.desktop', 'com.mattjakeman.ExtensionManager.desktop', 'org.gnome.tweaks.desktop', 'firewall-config.desktop', 'ca.desrt.dconf-editor.desktop', 'org.gnome.World.PikaBackup.desktop', 'input-leap.desktop', 'solaar.desktop', 'org.fedoraproject.MediaWriter.desktop', 'input-remapper-gtk.desktop', 'org.gnome.Sysprof.desktop', 'remote-viewer.desktop']
 categories=['X-GNOME-Utilities']
 name='X-GNOME-Utilities.directory'
 translate=true
@@ -18,14 +18,24 @@ categories=['Game']
 name='Games'
 translate=false
 
-[org/gnome/desktop/app-folders/folders/Containers]
-apps=['io.github.dvlv.boxbuddyrs.desktop', 'io.podman_desktop.PodmanDesktop.desktop', 'com.github.marhkb.Pods.desktop']
+[org/gnome/desktop/app-folders/folders/Virtualization]
+apps=['io.github.dvlv.boxbuddyrs.desktop', 'io.podman_desktop.PodmanDesktop.desktop', 'com.github.marhkb.Pods.desktop', 'virt-manager.desktop']
 categories=['Distrobox']
-name='Containers'
+name='Virtualization'
 translate=false
 
 [org/gnome/desktop/app-folders/folders/Wine]
 apps=['winetricks.desktop']
 categories=['X-Wine', 'wine-wine']
 name='Wine'
+translate=false
+
+[org/gnome/desktop/app-folders/folders/Development]
+apps=['dev-pod.desktop', 'code.desktop']
+name='Development'
+translate=false
+
+[org/gnome/desktop/app-folders/folders/Productivity]
+apps=['simple-scan.desktop', 'org.gnome.Papers.desktop', 'org.gnome.Connections.desktop']
+name='Productivity'
 translate=false

--- a/system_files/silverblue/etc/dconf/db/local.d/02-bluefin-folders
+++ b/system_files/silverblue/etc/dconf/db/local.d/02-bluefin-folders
@@ -1,5 +1,5 @@
 [org/gnome/desktop/app-folders]
-folder-children=['Games', 'GamingUtilities', 'Utilities', 'Virtualization', 'Wine', 'YaST', 'Pardus', 'Development', 'Productivity']
+folder-children=['Games', 'GamingUtilities', 'Utilities', 'Containers', 'Wine', 'YaST', 'Pardus', 'Development', 'Productivity']
 
 [org/gnome/desktop/app-folders/folders/GamingUtilities]
 apps=['protontricks.desktop', 'discover_overlay_configure.desktop', 'com.vysp3r.ProtonPlus.desktop', 'io.github.benjamimgois.goverlay.desktop', 'com.gerbilsoft.rom-properties.rp-config.desktop', 'steamos-nested-desktop.desktop']
@@ -18,10 +18,10 @@ categories=['Game']
 name='Games'
 translate=false
 
-[org/gnome/desktop/app-folders/folders/Virtualization]
-apps=['io.github.dvlv.boxbuddyrs.desktop', 'io.podman_desktop.PodmanDesktop.desktop', 'com.github.marhkb.Pods.desktop', 'virt-manager.desktop']
+[org/gnome/desktop/app-folders/folders/Containers]
+apps=['io.github.dvlv.boxbuddyrs.desktop', 'com.github.marhkb.Pods.desktop']
 categories=['Distrobox']
-name='Virtualization'
+name='Containers'
 translate=false
 
 [org/gnome/desktop/app-folders/folders/Wine]
@@ -31,7 +31,7 @@ name='Wine'
 translate=false
 
 [org/gnome/desktop/app-folders/folders/Development]
-apps=['dev-pod.desktop', 'code.desktop']
+apps=['dev-pod.desktop', 'code.desktop', 'virt-manager.desktop', 'io.podman_desktop.PodmanDesktop.desktop']
 excluded-apps=['org.gnome.Sysprof.desktop']
 categories=['Development', 'IDE']
 name='Development'

--- a/system_files/silverblue/etc/dconf/db/local.d/02-bluefin-folders
+++ b/system_files/silverblue/etc/dconf/db/local.d/02-bluefin-folders
@@ -32,6 +32,8 @@ translate=false
 
 [org/gnome/desktop/app-folders/folders/Development]
 apps=['dev-pod.desktop', 'code.desktop']
+excluded-apps=['org.gnome.Sysprof.desktop']
+categories=['Development', 'IDE']
 name='Development'
 translate=false
 


### PR DESCRIPTION
Part of #1711 

Moves applications into folders.  
Moves the Pika Backup & Media Writer icons to the Utilities folder
Introduces a Development folder
Renames Containers to Virtualization and adds virt-manager
Introduces a Productivity folder

![image](https://github.com/user-attachments/assets/2352cee1-b222-408f-916f-1e9b7d78a230)

