### PR TITLE
fix: move to packaged topgrade

### DIFF
--- a/build_files/fetch-install.sh
+++ b/build_files/fetch-install.sh
@@ -12,9 +12,6 @@ echo 'eval "$(starship init bash)"' >> /etc/bashrc
 # Bash Prexec
 curl -Lo /usr/share/bash-prexec https://raw.githubusercontent.com/rcaloras/bash-preexec/master/bash-preexec.sh
 
-# Topgrade Install
-pip install --prefix=/usr topgrade
-
 # Install ublue-update -- breaks with packages.json disable staging to use bling.
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo
 rpm-ostree install ublue-update

--- a/packages.json
+++ b/packages.json
@@ -51,6 +51,7 @@
 				"stress-ng",
 				"tailscale",
 				"tmux",
+				"topgrade",
 				"usbmuxd",
 				"wireguard-tools",
 				"xprop",


### PR DESCRIPTION
Fixes #1718 

Bazzite has this in staging already so this should align us with them instead of installing from pip. 

We should test this though, I remember the upgrade to 15 causing confusion with some users, though we generally scope it down more than that compared to bazzite. 
