### PR TITLE
fix: remove scx-scheds

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -198,8 +198,7 @@
 	"40": {
 		"include": {
 			"all": [
-				"ptyxis",
-				"scx-scheds"
+				"ptyxis"
 			],
 			"silverblue": [],
 			"dx": []


### PR DESCRIPTION
Vanilla kernel doesn't support this, we'll get it in 6.12.

Part of #1717 

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
