### PR TITLE
feat: add specific flatpaks to dx images

### DIFF
--- a/.github/workflows/reusable-build-iso.yml
+++ b/.github/workflows/reusable-build-iso.yml
@@ -126,6 +126,10 @@ jobs:
           # Get list of refs from directory
           FLATPAK_REFS_DIR=${{ github.workspace }}/${{ steps.generate-flatpak-dir-shortname.outputs.flatpak-dir-shortname }}
           FLATPAK_REFS_DIR_LIST=$(cat ${FLATPAK_REFS_DIR}/* | tr '\n' ' ' )
+          DX_FLATPAK_REFS_DIR_LIST="$(cat dx_flatpaks/* | tr '\n' ' ' )"
+          if [[ env.IMAGE_NAME == *-dx ]]; then
+            FLATPAK_REFS_DIR_LIST="${FLATPAK_REFS_DIR_LIST} ${DX_FLATPAK_REFS_DIR_LIST}"
+          fi
           # Generate install script
           cat << EOF > ${TEMP_FLATPAK_INSTALL_DIR}/script.sh
           cat /temp_flatpak_install_dir/script.sh

--- a/.github/workflows/reusable-build-iso.yml
+++ b/.github/workflows/reusable-build-iso.yml
@@ -127,7 +127,7 @@ jobs:
           FLATPAK_REFS_DIR=${{ github.workspace }}/${{ steps.generate-flatpak-dir-shortname.outputs.flatpak-dir-shortname }}
           FLATPAK_REFS_DIR_LIST=$(cat ${FLATPAK_REFS_DIR}/* | tr '\n' ' ' )
           DX_FLATPAK_REFS_DIR_LIST="$(cat dx_flatpaks/* | tr '\n' ' ' )"
-          if [[ env.IMAGE_NAME == *-dx ]]; then
+          if [[ env.IMAGE_NAME == *"-dx"* ]]; then
             FLATPAK_REFS_DIR_LIST="${FLATPAK_REFS_DIR_LIST} ${DX_FLATPAK_REFS_DIR_LIST}"
           fi
           # Generate install script

--- a/.github/workflows/reusable-build-iso.yml
+++ b/.github/workflows/reusable-build-iso.yml
@@ -127,7 +127,7 @@ jobs:
           FLATPAK_REFS_DIR=${{ github.workspace }}/${{ steps.generate-flatpak-dir-shortname.outputs.flatpak-dir-shortname }}
           FLATPAK_REFS_DIR_LIST=$(cat ${FLATPAK_REFS_DIR}/* | tr '\n' ' ' )
           DX_FLATPAK_REFS_DIR_LIST="$(cat dx_flatpaks/* | tr '\n' ' ' )"
-          if [[ env.IMAGE_NAME == *"-dx"* ]]; then
+          if [[ ${{ env.IMAGE_NAME }} == *"-dx"* ]]; then
             FLATPAK_REFS_DIR_LIST="${FLATPAK_REFS_DIR_LIST} ${DX_FLATPAK_REFS_DIR_LIST}"
           fi
           # Generate install script

--- a/dx_flatpaks/flatpaks
+++ b/dx_flatpaks/flatpaks
@@ -1,0 +1,1 @@
+app/io.podman_desktop.PodmanDesktop/x86_64/stable


### PR DESCRIPTION
Podman Desktop is an example app that we would want to add specifically only to DX images. We can add others over time
