### PR TITLE
feat(dx): add virt-v2v

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -156,6 +156,7 @@
 				"umoci",
 				"virt-manager",
 				"virt-viewer",
+				"virt-v2v",
 				"ydotool"
 			]
 		},


### PR DESCRIPTION
People who have OVFs, etc. and other VM formats have no way to convert those to KVM-usable images, so adding this.

https://github.com/libguestfs/virt-v2v

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
