### PR TITLE
chore: update to handle the negativo17-only main image

### DIFF
--- a/build_files/copr-repos-dx.sh
+++ b/build_files/copr-repos-dx.sh
@@ -20,8 +20,3 @@ curl -Lo /etc/yum.repos.d/atim-ubuntu-fonts-fedora-"${FEDORA_MAJOR_VERSION}".rep
 
 # Kvmfr module
 curl -Lo /etc/yum.repos.d/hikariknight-looking-glass-kvmfr-fedora-"${FEDORA_MAJOR_VERSION}".repo https://copr.fedorainfracloud.org/coprs/hikariknight/looking-glass-kvmfr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/hikariknight-looking-glass-kvmfr-fedora-"${FEDORA_MAJOR_VERSION}".repo
-
-# Renenable RPMFusion
-sed -i '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/rpmfusion-{,non}free.repo
-sed -i '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/rpmfusion-{,non}free-updates.repo
-sed -i '0,/enabled=0/s//enabled=1/' /etc/yum.repos.d/rpmfusion-{,non}free-updates-testing.repo

--- a/build_files/install-akmods.sh
+++ b/build_files/install-akmods.sh
@@ -24,11 +24,13 @@ rpm-ostree install \
     # /tmp/akmods-rpms/kmods/*framework-laptop*.rpm
 
 # rpmfusion dependent kmods
-rpm-ostree install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+rpm-ostree install \
+    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm \
+    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm
 rpm-ostree install \
     broadcom-wl /tmp/akmods/kmods/*wl*.rpm \
     v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
-rpm-ostree uninstall rpmfusion-free-release
+rpm-ostree uninstall rpmfusion-free-release rpmfusion-nonfree-release
 
 # ZFS for gts/stable
 if [[ ${AKMODS_FLAVOR} =~ "coreos" ]]; then

--- a/build_files/install-akmods.sh
+++ b/build_files/install-akmods.sh
@@ -15,18 +15,20 @@ if [[ "${NVIDIA_TYPE}" == "nvidia" ]]; then
     rm -f /usr/share/vulkan/icd.d/nouveau_icd.*.json
 fi
 
-curl -Lo /etc/yum.repos.d/negativo17-fedora-multimedia.repo https://negativo17.org/repos/fedora-multimedia.repo
 sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 
 # Everyone
 rpm-ostree install \
     /tmp/akmods/kmods/*xone*.rpm \
-    /tmp/akmods/kmods/*openrazer*.rpm \
-    /tmp/akmods/kmods/*wl*.rpm \
-    /tmp/akmods/kmods/*v4l2loopback*.rpm
+    /tmp/akmods/kmods/*openrazer*.rpm
     # /tmp/akmods-rpms/kmods/*framework-laptop*.rpm
 
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+# rpmfusion dependent kmods
+rpm-ostree install https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm
+rpm-ostree install \
+    broadcom-wl /tmp/akmods/kmods/*wl*.rpm \
+    v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
+rpm-ostree uninstall rpmfusion-free-release
 
 # ZFS for gts/stable
 if [[ ${AKMODS_FLAVOR} =~ "coreos" ]]; then


### PR DESCRIPTION
Now that main and hwe images are only providing negativo17, not rpmfusion, the 2 rpmfusion dependent akmods need some extra support, but other areas using rpmfusion can be cleaned up.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
