### PR TITLE
chore: attempt to fix rechunker complaint of multiple kernels

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -401,7 +401,7 @@ jobs:
 
       - name: Rechunk Image
         id: rechunk
-        if: inputs.rechunk == true && github.event_name != 'pull_request'
+        if: inputs.rechunk == true
         uses: hhd-dev/rechunk@v0.8.6
         with:
           rechunk: ghcr.io/hhd-dev/rechunk:v0.8.6

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -401,7 +401,7 @@ jobs:
 
       - name: Rechunk Image
         id: rechunk
-        if: inputs.rechunk == true
+        if: inputs.rechunk == true && ( github.event_name == 'pull_request' && ( matrix.image_flavor == 'main' || matrix.image_flavor == 'nvidia' ) || github.event_name != 'pull_request' )
         uses: hhd-dev/rechunk@v0.8.6
         with:
           rechunk: ghcr.io/hhd-dev/rechunk:v0.8.6

--- a/build_files/cache_kernel.sh
+++ b/build_files/cache_kernel.sh
@@ -3,8 +3,10 @@
 set -eoux pipefail
 
 if [[ -n "${NVIDIA_TYPE:-}" ]]; then
-    rpm-ostree override remove \
-        kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra
+    for pkg in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra
+    do
+        rpm --erase $pkg --nodeps
+    done
 
     rpm-ostree install \
         /tmp/kernel-rpms/kernel-[0-9]*.rpm \


### PR DESCRIPTION
PR #1722 passed all build checks, but after merging, we saw that for latest, where we use the stock upstream kernel, but with our added signature, rechunker complains of multiple kernels in /usr/lib/modules

Also, the method which was being used to remove the old kernel packages does not run when building locally on a Fedora host. So trying a different approach.

See: https://github.com/ublue-os/bluefin/actions/runs/11205608165/job/31145333321#step:23:233

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
