### PR TITLE
chore(ci): always replace kernel packages

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -116,7 +116,6 @@ jobs:
           elif [[ "${{ matrix.image_flavor }}" == "main" && \
                   "${{ matrix.fedora_version }}" != "beta" ]]; then
                echo "image_flavor=${{ matrix.image_flavor }}" >> $GITHUB_ENV
-               echo "nvidia_type=main" >> $GITHUB_ENV
           else
              echo "image_flavor=${{ matrix.image_flavor }}" >> $GITHUB_ENV
           fi

--- a/build_files/cache_kernel.sh
+++ b/build_files/cache_kernel.sh
@@ -2,14 +2,12 @@
 
 set -eoux pipefail
 
-if [[ -n "${NVIDIA_TYPE:-}" ]]; then
-    for pkg in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra
-    do
-        rpm --erase $pkg --nodeps
-    done
+for pkg in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra
+do
+    rpm --erase $pkg --nodeps
+done
 
-    rpm-ostree install \
-        /tmp/kernel-rpms/kernel-[0-9]*.rpm \
-        /tmp/kernel-rpms/kernel-core-*.rpm \
-        /tmp/kernel-rpms/kernel-modules-*.rpm
-fi
+rpm-ostree install \
+    /tmp/kernel-rpms/kernel-[0-9]*.rpm \
+    /tmp/kernel-rpms/kernel-core-*.rpm \
+    /tmp/kernel-rpms/kernel-modules-*.rpm

--- a/build_files/install-akmods.sh
+++ b/build_files/install-akmods.sh
@@ -2,11 +2,6 @@
 
 set -ouex pipefail
 
-# if [[ -n "${NVIDIA_TYPE:-}" ]]; then
-#     curl -L -o /etc/yum.repos.d/fedora-coreos-pool.repo \
-#         https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-coreos-pool.repo
-# fi
-
 # Nvidia for gts/stable - nvidia
 if [[ "${NVIDIA_TYPE}" == "nvidia" ]]; then
     curl -Lo /tmp/nvidia-install.sh https://raw.githubusercontent.com/ublue-os/hwe/main/nvidia-install.sh && \


### PR DESCRIPTION
This simplifies the logic around installing cached kernels by always doing it. This means that "vanilla"/"main" images will have the true vanilla kernel replaced by essentially the same package, but the repackaged version which we have signed in addition to the Fedora signature.

This fixes a bug introduced in #1722 where accidentally stopped installing the cached kernels for asus/surface images.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
