### PR TITLE
chore(ci): replace vanilla kernels not asus/surface

### DIFF
--- a/build_files/cache_kernel.sh
+++ b/build_files/cache_kernel.sh
@@ -2,12 +2,14 @@
 
 set -eoux pipefail
 
-for pkg in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra
-do
-    rpm --erase $pkg --nodeps
-done
+if [[ "${AKMODS_FLAVOR}" == "main" || "${AKMODS_FLAVOR}" =~ "coreos-" ]]; then
+    for pkg in kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra
+    do
+        rpm --erase $pkg --nodeps
+    done
 
-rpm-ostree install \
-    /tmp/kernel-rpms/kernel-[0-9]*.rpm \
-    /tmp/kernel-rpms/kernel-core-*.rpm \
-    /tmp/kernel-rpms/kernel-modules-*.rpm
+    rpm-ostree install \
+        /tmp/kernel-rpms/kernel-[0-9]*.rpm \
+        /tmp/kernel-rpms/kernel-core-*.rpm \
+        /tmp/kernel-rpms/kernel-modules-*.rpm
+fi


### PR DESCRIPTION
Fixes bug in #1752 which ignored the fact that asus/surface images in Bluefin are sourced from the HWE images, thus they already have their expected kernels.

I do think this end state is a bit nicer though as it is easier to grok that this script only works on specific akmods flavors rather than the nvidia_type which didn't seem to have a clear correlation to replacing the kernel.

I apologize for the noise and confusion on this topic tonight.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
