### PR TITLE
docs: remove out-of-date line in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,6 @@ sudo mokutil --timeout -1
 sudo mokutil --import public_key.der
 ```
 
-#### Note
-
-If you encounter an issue with a password being recognized as incorrect, try using the `-` key on the numpad instead.
-
 ## Repobeats
 
 ![Alt](https://repobeats.axiom.co/api/embed/40b85b252bf6ea25eb90539d1adcea013ccae69a.svg "Repobeats analytics image")


### PR DESCRIPTION
The removed line was in reference to the hyphen in ublue-os. It's not relevant anymore with the new MOK password, so it can be swept right on out.