### PR TITLE
fix(dx,just): copy dx groups to /etc/group before usermod

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -126,6 +126,7 @@ ptyxis-transparency opacity="0.95":
 
 # Configure docker,incus-admin,lxd,libvirt container manager permissions
 dx-group:
+    cat /usr/lib/group | grep 'docker:\|incus-admin:\|lxd:\|libvirt:' | sudo tee -a /etc/group >/dev/null
     sudo usermod -aG docker $USER
     sudo usermod -aG incus-admin $USER
     sudo usermod -aG lxd $USER

--- a/system_files/dx/usr/lib/systemd/system/bluefin-dx-groups.service
+++ b/system_files/dx/usr/lib/systemd/system/bluefin-dx-groups.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Add wheel members to docker,incus-admin, and lxd groups
+Description=Add wheel members to docker, incus-admin, libvirt, and lxd groups
 
 [Service]
 Type=oneshot

--- a/system_files/dx/usr/libexec/bluefin-dx-groups
+++ b/system_files/dx/usr/libexec/bluefin-dx-groups
@@ -11,6 +11,9 @@ if [[ -f $GROUP_SETUP_VER_FILE && "$GROUP_SETUP_VER" = "$GROUP_SETUP_VER_RAN" ]]
   exit 0
 fi
 
+# Copy relevant groups from /usr/lib/group to /etc/group so they can have users added
+cat /usr/lib/group | grep 'docker:\|incus-admin:\|lxd:\|libvirt:' | tee -a /etc/group >/dev/null
+
 # Setup Groups
 wheelarray=($(getent group wheel | cut -d ":" -f 4 | tr  ',' '\n'))
 for user in $wheelarray


### PR DESCRIPTION
I just installed bluefin-dx on my framework laptop for the first time and found that my user account was not in the expected groups for docker, incus-admin, libvirt, and lxd.

I tried running `$ ujust dx-group` manually with no change to my user groups after logout or restart.

I found the groups were only defined in `/usr/lib/group` which cannot be modified.

This PR copies the groups from `/usr/lib/group` to `/etc/group` before the `usermod` commands are run.

I believe this relates to #1755
