### PR TITLE
fix: just dx-group append group entry from /usr/lib/group

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -126,11 +126,25 @@ ptyxis-transparency opacity="0.95":
 
 # Configure docker,incus-admin,lxd,libvirt container manager permissions
 dx-group:
+    #!/usr/bin/env bash
+    append_group() {
+    local group_name="$1"
+    if ! grep -q "^$group_name:" /etc/group; then
+      echo "Appending $group_name to /etc/group"
+      grep "^$group_name:" /usr/lib/group | sudo tee -a /etc/group > /dev/null
+    fi
+    }
+
+    append_group docker
+    append_group incus-admin
+    append_group lxd
+    append_group libvirt
+
     sudo usermod -aG docker $USER
     sudo usermod -aG incus-admin $USER
     sudo usermod -aG lxd $USER
     sudo usermod -aG libvirt $USER
-    @echo "Logout to use docker, incus-admin, lxd, libvirt"
+    echo "Logout to use docker, incus-admin, lxd, libvirt"
 
 # Configure system to use vfio and kvmfr
 configure-vfio ACTION="":

--- a/system_files/dx/usr/libexec/bluefin-dx-groups
+++ b/system_files/dx/usr/libexec/bluefin-dx-groups
@@ -11,7 +11,21 @@ if [[ -f $GROUP_SETUP_VER_FILE && "$GROUP_SETUP_VER" = "$GROUP_SETUP_VER_RAN" ]]
   exit 0
 fi
 
+# Function to append a group entry to /etc/group
+append_group() {
+  local group_name="$1"
+  if ! grep -q "^$group_name:" /etc/group; then
+    echo "Appending $group_name to /etc/group"
+    grep "^$group_name:" /usr/lib/group | tee -a /etc/group > /dev/null
+  fi
+}
+
 # Setup Groups
+append_group docker
+append_group incus-admin
+append_group lxd
+append_group libvirt
+
 wheelarray=($(getent group wheel | cut -d ":" -f 4 | tr  ',' '\n'))
 for user in $wheelarray
 do


### PR DESCRIPTION
just dx-group would not add group to user. with this pr it checks if the group exists in `/etc/group`, and if not it appends from /usr/lib/group
