### PR TITLE
feat: add cryfs to bluefin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -60,7 +60,7 @@
 				"zsh"
 			],
 			"silverblue": [
-				"simple-scan",
+				"cryfs",
 				"gnome-shell-extension-appindicator",
 				"gnome-shell-extension-blur-my-shell",
 				"gnome-shell-extension-caffeine",
@@ -69,25 +69,25 @@
 				"gnome-shell-extension-logo-menu",
 				"gnome-shell-extension-search-light",
 				"gnome-shell-extension-tailscale-gnome-qs",
-				"libgda-sqlite",
 				"libgda",
+				"libgda-sqlite",
 				"libratbag-ratbagd",
 				"nautilus-gsconnect",
 				"nautilus-open-any-terminal",
 				"openssh-askpass",
+				"simple-scan",
 				"yaru-theme",
-				"zenity",
-				"cryfs"
+				"zenity"
 			],
 			"kinoite": [
-				"skanpage",
-				"libadwaita-qt5",
-				"libadwaita-qt6",
 				"kde-runtime-docs",
 				"kdenetwork-filesharing",
 				"kdeplasma-addons",
 				"kdialog",
-				"plasma-wallpapers-dynamic"
+				"libadwaita-qt5",
+				"libadwaita-qt6",
+				"plasma-wallpapers-dynamic",
+				"skanpage"
 			],
 			"dx": [
 				"adobe-source-code-pro-fonts",

--- a/packages.json
+++ b/packages.json
@@ -76,7 +76,8 @@
 				"nautilus-open-any-terminal",
 				"openssh-askpass",
 				"yaru-theme",
-				"zenity"
+				"zenity",
+				"cryfs"
 			],
 			"kinoite": [
 				"skanpage",


### PR DESCRIPTION
This commit makes [io.github.mpobaschnig.Vaults](https://flathub.org/apps/io.github.mpobaschnig.Vaults) functional. Although cryfs can be installed by the user through brew or a distrobox, Vaults won't detect it. It must be installed directly onto the system to be detected by Vaults. Of the four months I've used Bluefin, this is the only package I've been stuck with layering.

Why provide support for Vaults? KDE Plasma contains a built-in feature called vaults that allows for the creation of locally encrypted containers. This can offer a second layer of encryption beyond LUKS or allow you to create encrypted containers on an otherwise unencrypted file system. This feature was added in Plasma 5.11.

Vaults provides support for that feature on Gnome, helping bring feature parity between the two desktop environments.

This commit only adds cryfs to Bluefin because it's already included in KDE Plasma as a backend for its own vault feature. Yep, this means that Aurora already has it! No need to add it again.