### PR TITLE
chore(ci): always build latest images for both varieties

### DIFF
--- a/.github/workflows/build-latest-aurora.yml
+++ b/.github/workflows/build-latest-aurora.yml
@@ -7,13 +7,11 @@ on:
       - testing
     paths-ignore:
       - '**.md'
-      - 'system_files/silverblue/**'
   push:
     branches:
       - main
     paths-ignore:
       - '**.md'
-      - 'system_files/silverblue/**'
   schedule:
     - cron: '40 4 * * *'  # 4:40 UTC everyday
   workflow_dispatch:

--- a/.github/workflows/build-latest-bluefin.yml
+++ b/.github/workflows/build-latest-bluefin.yml
@@ -7,13 +7,11 @@ on:
       - testing
     paths-ignore:
       - '**.md'
-      - 'system_files/kinoite/**'
   push:
     branches:
       - main
     paths-ignore:
       - '**.md'
-      - 'system_files/kinoite/**'
   schedule:
     - cron: '40 4 * * *'  # 4:40 UTC everyday
   workflow_dispatch:


### PR DESCRIPTION
Related to changes made in bluefin repo merge rulesets, we need to always run the "latest" build workflows for both aurora and bluefin to ensure that merge checks pass both for the pre-merge checks and the merge queue checks.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
