### PR TITLE
feat: enable stable-daily channel

### DIFF
--- a/.github/workflows/build-coreos-aurora.yml
+++ b/.github/workflows/build-coreos-aurora.yml
@@ -8,7 +8,7 @@ on:
       - '**.md'
       - 'system_files/silverblue/**'
   schedule:
-    - cron: '41 5 * * 2'  # 5:41 UTC every Tuesday
+    - cron: '41 5 * * *'  # 5:41 UTC everyday
   workflow_dispatch:
 
 jobs:
@@ -20,4 +20,5 @@ jobs:
       brand_name: aurora
       fedora_version: stable
       rechunk: true
+      weekly_tag_day: Tuesday
 

--- a/.github/workflows/build-coreos-bluefin.yml
+++ b/.github/workflows/build-coreos-bluefin.yml
@@ -8,7 +8,7 @@ on:
       - '**.md'
       - 'system_files/kinoite/**'
   schedule:
-    - cron: '41 5 * * 2'  # 5:41 UTC every Tuesday
+    - cron: '41 5 * * *'  # 5:41 UTC everyday
   workflow_dispatch:
 
 jobs:
@@ -20,4 +20,5 @@ jobs:
       brand_name: bluefin
       fedora_version: stable
       rechunk: true
+      weekly_tag_day: Tuesday
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -15,6 +15,11 @@ on:
         required: false
         type: boolean
         default: false
+      weekly_tag_day:
+        description: "Tag stable weekly on for example 'Tuesday'"
+        required: false
+        type: string
+        default: Tuesday
     outputs:
       images:
         description: "An array of images built and pushed to the registry"
@@ -237,7 +242,15 @@ jobs:
           fi
 
           if [[ ${{ matrix.fedora_version }} == "stable" ]]; then
-            BUILD_TAGS=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${TIMESTAMP}")
+            BUILD_TAGS=("${FEDORA_VERSION}-daily" "${FEDORA_VERSION}-daily-${TIMESTAMP}")
+            if [[ ${{ github.event_name }} == "schedule" ]]; then
+              TODAY="$(date +%A)"
+              if [[ "${TODAY}" == "${{ inputs.weekly_tag_day }}" ]]; then
+                BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${TIMESTAMP}")
+              fi
+            else
+              BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${TIMESTAMP}")
+            fi
           else
             BUILD_TAGS=("${{ env.fedora_version }}" "${{ env.fedora_version }}-${TIMESTAMP}")
           fi
@@ -267,7 +280,7 @@ jobs:
                   BUILD_TAGS+=("gts")
                   echo "DEFAULT_TAG=gts" >> $GITHUB_ENV
             elif [[ "$IS_COREOS" == "true" ]]; then
-                  echo "DEFAULT_TAG=stable" >> $GITHUB_ENV
+                  echo "DEFAULT_TAG=stable-daily" >> $GITHUB_ENV
             fi
           fi
 


### PR DESCRIPTION
I really liked the idea of having a daily build of the stable channel as of talked in https://github.com/ublue-os/bluefin/issues/1736. So I tried my best to implement this feature.

Changes made:

- Aurora & Bluefin stable workflow now scheduled to build everyday and let you specify a "weekly_tag_day".
- If the workflow is not run via schedule, tag with stable and stable-daily.
- If the workflow is run via schedule and matches the weekly_tag_day, tag with stable and stable-daily.
- If the workflow is run via schedule but not matches the weekly_tag_day, tag with stable-daily.

Hope this is the correct implementation, thanks for this awesome project.