### PR TITLE
feat: Add Borgbackup on the image for both Aurora and Bluefin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5,6 +5,7 @@
 				"adcli",
 				"bash-color-prompt",
 				"bcache-tools",
+				"borgbackup",
 				"bootc",
 				"evtest",
 				"epson-inkjet-printer-escpr",


### PR DESCRIPTION
This PR adds borgbackup to the image to address this issue: https://github.com/ublue-os/bluefin/issues/1778
Forum Thread: https://universal-blue.discourse.group/t/borgbackup-via-homebrew-not-working-great/4495