### PR TITLE
feat(ci): build manual stable-daily or weekly

### DIFF
--- a/.github/workflows/build-coreos-aurora-daily.yml
+++ b/.github/workflows/build-coreos-aurora-daily.yml
@@ -1,0 +1,16 @@
+name: Aurora Stable Daily
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      brand_name: aurora
+      fedora_version: stable
+      rechunk: true
+      build_stable_daily: true
+      build_stable_weekly: false
+

--- a/.github/workflows/build-coreos-aurora-weekly.yml
+++ b/.github/workflows/build-coreos-aurora-weekly.yml
@@ -1,0 +1,16 @@
+name: Aurora Stable Weekly
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      brand_name: aurora
+      fedora_version: stable
+      rechunk: true
+      build_stable_daily: false
+      build_stable_weekly: true
+

--- a/.github/workflows/build-coreos-bluefin-daily.yml
+++ b/.github/workflows/build-coreos-bluefin-daily.yml
@@ -1,0 +1,16 @@
+name: Bluefin Stable Daily
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      brand_name: bluefin
+      fedora_version: stable
+      rechunk: true
+      build_stable_daily: true
+      build_stable_weekly: false
+

--- a/.github/workflows/build-coreos-bluefin-weekly.yml
+++ b/.github/workflows/build-coreos-bluefin-weekly.yml
@@ -1,0 +1,16 @@
+name: Bluefin Stable Weekly
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      brand_name: bluefin
+      fedora_version: stable
+      rechunk: true
+      build_stable_daily: false
+      build_stable_weekly: true
+

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -20,6 +20,16 @@ on:
         required: false
         type: string
         default: Tuesday
+      build_stable_daily:
+        description: "Build with 'stable-daily' tag"
+        required: false
+        type: boolean
+        default: true
+      build_stable_weekly:
+        description: "Build with 'stable' tag"
+        required: false
+        type: boolean
+        default: true
     outputs:
       images:
         description: "An array of images built and pushed to the registry"
@@ -242,14 +252,18 @@ jobs:
           fi
 
           if [[ ${{ matrix.fedora_version }} == "stable" ]]; then
-            BUILD_TAGS=("${FEDORA_VERSION}-daily" "${FEDORA_VERSION}-daily-${TIMESTAMP}")
+            if [[ ${{ inputs.build_stable_daily }} == "true" ]]; then
+              BUILD_TAGS=("${FEDORA_VERSION}-daily" "${FEDORA_VERSION}-daily-${TIMESTAMP}")
+            fi
             if [[ ${{ github.event_name }} == "schedule" ]]; then
               TODAY="$(date +%A)"
               if [[ "${TODAY}" == "${{ inputs.weekly_tag_day }}" ]]; then
                 BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${TIMESTAMP}")
               fi
             else
-              BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${TIMESTAMP}")
+              if [[ ${{ inputs.build_stable_weekly }} == "true" ]]; then
+                BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${TIMESTAMP}")
+              fi
             fi
           else
             BUILD_TAGS=("${{ env.fedora_version }}" "${{ env.fedora_version }}-${TIMESTAMP}")
@@ -280,7 +294,11 @@ jobs:
                   BUILD_TAGS+=("gts")
                   echo "DEFAULT_TAG=gts" >> $GITHUB_ENV
             elif [[ "$IS_COREOS" == "true" ]]; then
-                  echo "DEFAULT_TAG=stable-daily" >> $GITHUB_ENV
+                  if [[ ${{ inputs.build_stable_daily }} == "true" ]]; then
+                    echo "DEFAULT_TAG=stable-daily" >> $GITHUB_ENV
+                  else
+                    echo "DEFAULT_TAG=stable" >> $GITHUB_ENV
+                  fi
             fi
           fi
 


### PR DESCRIPTION
Follow up on the PR https://github.com/ublue-os/bluefin/pull/1779 where the need to manually build stable and stable-daily versions was expressed.

Introduces the following workflows, which can only be triggered manually.

- Aurora Stable Daily - (builds aurora:stable-daily)
- Aurora Stable Weekly - (builds aurora:stable)
- Bluefin Stable Daily - (builds bluefin:stable-daily)
- Bluefin Stable Weekly - (builds bluefin:stable)

This also required a few changes to the reusable-build workflow. The Bluefin Stable and Aurora Stable workflows will still produce both versions when run manually, and may produce one or both when triggered by a schedule. 

P.S. I hope someone can address the ISO build part that it produces, as I definitely cannot. :sweat_smile: 
