### PR TITLE
chore: Add new documentation link to .desktop shortcut

### DIFF
--- a/system_files/shared/usr/share/applications/Documentation.desktop
+++ b/system_files/shared/usr/share/applications/Documentation.desktop
@@ -2,7 +2,7 @@
 Type=Application
 NoDisplay=false
 Terminal=false
-Exec=xdg-open https://docs.projectbluefin.io/
+Exec=xdg-open https://universal-blue.discourse.group/t/documentation/3147
 Icon=/usr/share/ublue-os/bluefin/docs.svg
 Name=Documentation
 Comment=Bluefin and Aurora documentation


### PR DESCRIPTION
>**Note**:  Aurora documentation is a work-in-progress, so this PR shouldn't be merged right away.

This is more of a proposal PR, but since Aurora has its own [documentation in development](https://docs.getaurora.dev/), then I propose a [general 'landing page'](https://universal-blue.discourse.group/t/documentation/3147) that includes links to all 3 end-user images' documentation websites.  

This isn't the best solution since it is a desktop shortcut that requires the user to select which documentation they want based on whether they're using GNOME or KDE Plasma, so if there is a better method that someone can suggest then this proposal can be shot down.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
