### PR TITLE
feat: ublue-rollback-helper - add stable-daily to targets

### DIFF
--- a/system_files/shared/usr/bin/ublue-rollback-helper
+++ b/system_files/shared/usr/bin/ublue-rollback-helper
@@ -15,7 +15,7 @@ function rebase_helper(){
     base_image="ghcr.io/ublue-os/${IMAGE_NAME}"
     echo "Which Tag would you like to rebase to?"
     echo "The default selection is gts, stable is for enthusiasts, and latest is for testers"
-    choose_target=$(Choose date latest gts stable cancel)
+    choose_target=$(Choose date latest gts stable stable-daily cancel)
     if [[ "$choose_target" != "date" && "$choose_target" != "cancel" ]]; then
         rebase_target="${base_image}:${choose_target}"
     elif [[ "$choose_target" == "date" ]]; then

--- a/system_files/shared/usr/bin/ublue-rollback-helper
+++ b/system_files/shared/usr/bin/ublue-rollback-helper
@@ -14,7 +14,7 @@ function list_tags(){
 function rebase_helper(){
     base_image="ghcr.io/ublue-os/${IMAGE_NAME}"
     echo "Which Tag would you like to rebase to?"
-    echo "The default selection is gts, stable is for enthusiasts, and latest is for testers"
+    echo "The default selection is gts, stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers"
     choose_target=$(Choose date latest gts stable stable-daily cancel)
     if [[ "$choose_target" != "date" && "$choose_target" != "cancel" ]]; then
         rebase_target="${base_image}:${choose_target}"


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
Adding stable-daily to the rebase helper options for https://github.com/ublue-os/bluefin/issues/1782

Possibly should update the message as well. Open to suggestions here. Below is one option although seems a little verbose.

`The default selection is gts, stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers`

Example from running it locally (rebasing from stable -> stable-daily)
```
./ublue-rollback-helper 
Choose your action.
Which Tag would you like to rebase to?
The default selection is gts, stable is for enthusiasts, and latest is for testers
Rebase Target is ghcr.io/ublue-os/bluefin-dx:stable-daily
Confirm Rebase
Pulling manifest: ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-dx:stable-daily
Importing: ostree-image-signed:docker://ghcr.io/ublue-os/bluefin-dx:stable-daily (digest: sha256:0d10f41a01a735797519b1c1fbe0b8a0fdfb6a3a7c11484b430e02b4bd114616)
ostree chunk layers already present: 61
ostree chunk layers needed: 11 (1.1 GB)
Fetching ostree chunk sha256:4439bd3dede3 (112.1 MB)... done
Fetching ostree chunk sha256:446cf5d07acb (144.9 MB)... done
Fetching ostree chunk sha256:966fe64c459e (150.7 MB)... done
Fetching ostree chunk sha256:e6f475c8082a (86.8 MB)... done
Fetching ostree chunk sha256:ac6738ab5132 (85.9 MB)... done
Fetching ostree chunk sha256:54a3cfab19f3 (39.4 MB)... done
Fetching ostree chunk sha256:62d6370aaaf7 (71.3 MB)... done
Fetching ostree chunk sha256:32518619f02c (63.1 MB)... done
Fetching ostree chunk sha256:d4f607332a2c (35.6 MB)... done
Fetching ostree chunk sha256:373785233ae9 (339.8 MB)... done
Fetching ostree chunk sha256:131e2a709fa6 (9.6 MB)... done
Staging deployment... done
Freed: 937.3 MB (pkgcache branches: 0)
Upgraded:
  devpod v0.5.20-1.fc40 -> v0.5.21-1.fc40
  kcli 99.0.0.git.202410142227.e28a501-0.fc40 -> 99.0.0.git.202410161200.72a798d-0.fc40
  kernel-tools 6.10.12-200.fc40 -> 6.11.3-200.fc40
  kernel-tools-libs 6.10.12-200.fc40 -> 6.11.3-200.fc40
  libgsf 1.14.51-4.fc40 -> 1.14.53-1.fc40
  libopenmpt 0.7.8-1.fc40 -> 0.7.10-1.fc40
  tailscale 1.76.0-1 -> 1.76.1-1
Changes queued for next boot. Run "systemctl reboot" to start a reboot
```
