### PR TITLE
fix: fix cryfs error on bluefin-gts

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -187,7 +187,9 @@
 	"39": {
 		"include": {
 			"all": [],
-			"silverblue": [],
+			"silverblue": [
+				"fmt"
+			],
 			"dx": [
 				"distrobuilder",
 				"podman-plugins"


### PR DESCRIPTION
This commit adds the fmt package to bluefin-gts which was mysteriously absent.

Resolves https://github.com/ublue-os/bluefin/issues/1798.