### PR TITLE
feat(ci): Build stable weekly on the same day as gts

### DIFF
--- a/.github/workflows/build-coreos-aurora.yml
+++ b/.github/workflows/build-coreos-aurora.yml
@@ -8,7 +8,7 @@ on:
       - '**.md'
       - 'system_files/silverblue/**'
   schedule:
-    - cron: '41 5 * * *'  # 5:41 UTC everyday
+    - cron: '45 5 * * *'  # 5:41 UTC everyday
   workflow_dispatch:
 
 jobs:
@@ -20,5 +20,5 @@ jobs:
       brand_name: aurora
       fedora_version: stable
       rechunk: true
-      weekly_tag_day: Tuesday
+      weekly_tag_day: Sunday
 

--- a/.github/workflows/build-coreos-bluefin.yml
+++ b/.github/workflows/build-coreos-bluefin.yml
@@ -8,7 +8,7 @@ on:
       - '**.md'
       - 'system_files/kinoite/**'
   schedule:
-    - cron: '41 5 * * *'  # 5:41 UTC everyday
+    - cron: '45 5 * * *'  # 5:41 UTC everyday
   workflow_dispatch:
 
 jobs:
@@ -20,5 +20,5 @@ jobs:
       brand_name: bluefin
       fedora_version: stable
       rechunk: true
-      weekly_tag_day: Tuesday
+      weekly_tag_day: Sunday
 


### PR DESCRIPTION
This puts the weeklies the same as GTS, sunday nights. Also added an extra 4m to the cron so that the gts builds populate the build queue first. 