### PR TITLE
refactor(ci): stable-daily tagging

### DIFF
--- a/.github/workflows/build-coreos-aurora-daily.yml
+++ b/.github/workflows/build-coreos-aurora-daily.yml
@@ -1,0 +1,16 @@
+name: Aurora Stable Daily
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      brand_name: aurora
+      fedora_version: stable
+      rechunk: true
+      build_stable_daily: true
+      build_stable_weekly: false
+

--- a/.github/workflows/build-coreos-aurora-weekly.yml
+++ b/.github/workflows/build-coreos-aurora-weekly.yml
@@ -1,0 +1,16 @@
+name: Aurora Stable Weekly
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      brand_name: aurora
+      fedora_version: stable
+      rechunk: true
+      build_stable_daily: false
+      build_stable_weekly: true
+

--- a/.github/workflows/build-coreos-bluefin-daily.yml
+++ b/.github/workflows/build-coreos-bluefin-daily.yml
@@ -1,0 +1,17 @@
+name: Bluefin Stable Daily
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      brand_name: bluefin
+      fedora_version: stable
+      rechunk: true
+      build_stable_daily: true
+      build_stable_weekly: false
+
+

--- a/.github/workflows/build-coreos-bluefin-weekly.yml
+++ b/.github/workflows/build-coreos-bluefin-weekly.yml
@@ -1,0 +1,16 @@
+name: Bluefin Stable Weekly
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    with:
+      brand_name: bluefin
+      fedora_version: stable
+      rechunk: true
+      build_stable_daily: false
+      build_stable_weekly: true
+

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -20,6 +20,16 @@ on:
         required: false
         type: string
         default: Tuesday
+      build_stable_daily:
+        description: "Build with 'stable-daily' tag"
+        required: false
+        type: boolean
+        default: true
+      build_stable_weekly:
+        description: "Build with 'stable' tag"
+        required: false
+        type: boolean
+        default: true
     outputs:
       images:
         description: "An array of images built and pushed to the registry"
@@ -251,6 +261,10 @@ jobs:
             if [[ ${{ github.event_name }} == "schedule" ]] && \
                [[ "${{ inputs.weekly_tag_day }}" != "${TODAY}" ]]; then
               BUILD_TAGS+=("stable-daily" "stable-daily-${TIMESTAMP}")
+            elif [[ ${{ inputs.build_stable_daily }} == "false" ]]; then
+              BUILD_TAGS+=("stable" "stable-${TIMESTAMP}")
+            elif [[ ${{ inputs.build_stable_weekly }} == "false" ]]; then
+              BUILD_TAGS+=("stable-daily" "stable-daily-${TIMESTAMP}")
             else
               BUILD_TAGS+=("stable" "stable-${TIMESTAMP}")
               BUILD_TAGS+=("stable-daily" "stable-daily-${TIMESTAMP}")
@@ -290,7 +304,11 @@ jobs:
                   BUILD_TAGS+=("beta")
                   echo "DEFAULT_TAG=beta" >> $GITHUB_ENV
             elif [[ "$IS_COREOS" == "true" ]]; then
-                  echo "DEFAULT_TAG=stable-daily" >> $GITHUB_ENV
+                  if [[ ${{ inputs.build_stable_daily }} == "true" ]]; then
+                    echo "DEFAULT_TAG=stable-daily" >> $GITHUB_ENV
+                  else
+                    echo "DEFAULT_TAG=stable" >> $GITHUB_ENV
+                  fi
             fi
           fi
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -246,15 +246,14 @@ jobs:
               COMMIT_TAGS+=("${SHA_SHORT}")
           fi
 
+          TODAY="$(date +%A)"
           if [[ ${{ matrix.fedora_version }} == "stable" ]]; then
-            BUILD_TAGS=("${FEDORA_VERSION}-daily" "${FEDORA_VERSION}-daily-${TIMESTAMP}")
-            if [[ ${{ github.event_name }} == "schedule" ]]; then
-              TODAY="$(date +%A)"
-              if [[ "${TODAY}" == "${{ inputs.weekly_tag_day }}" ]]; then
-                BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${TIMESTAMP}")
-              fi
+            if [[ ${{ github.event_name }} == "schedule" ]] && \
+               [[ "${{ inputs.weekly_tag_day }}" != "${TODAY}" ]]; then
+              BUILD_TAGS+=("stable-daily" "stable-daily-${TIMESTAMP}")
             else
-              BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${TIMESTAMP}")
+              BUILD_TAGS+=("stable" "stable-${TIMESTAMP}")
+              BUILD_TAGS+=("stable-daily" "stable-daily-${TIMESTAMP}")
             fi
           else
             BUILD_TAGS=("${{ env.fedora_version }}" "${{ env.fedora_version }}-${TIMESTAMP}")


### PR DESCRIPTION
I have refactored the stable-daily tagging logic to make it much more readable. I hope M2 is happier with this code.
Reference: https://github.com/ublue-os/bluefin/issues/1804

Psuedo logic:
```
if triggered by schedule and its not weekly_tag_day; then
    tag with stable-daily
else
    tag with stable stable-daily
fi
```
In the code, I used the explicit term `stable` instead of `${FEDORA_VERSION}` to improve readability. I chose this because we are already in stable logic, so this would always be `stable`. If you prefer `${FEDORA_VERSION}` I can, of course, put that back in.

Manual triggered run will produce: stable, stable-daily
Schedule triggered run on weekly_tag_day: stable, stable-daily
Schedule triggered run on non weekly_tag_days: stable-daily

On top of this I made changes that will allow you to manually build stable or stable-daily only by pushing a button.
Introduces the following workflows.

- Aurora Stable Daily - (builds aurora:stable-daily)
- Aurora Stable Weekly - (builds aurora:stable)
- Bluefin Stable Daily - (builds bluefin:stable-daily)
- Bluefin Stable Weekly - (builds bluefin:stable)

To make this possible I updated the above pseudo logic like so:
```
if triggered by schedule and its not weekly_tag_day; then
    tag with stable-daily
else if build_stable_weekly is false; then 
    tag with stable-daily
else if build_stable_daily is false; then 
    tag with stable
else
    tag with stable stable-daily
fi
```

`build_stable_weekly` and `build_stable_daily` are both set to `true` by default inn the `reusable-build.yml` and are toggled via the new workflow files.