### PR TITLE
feat: hide all windows (show desktop) via Super+D

### DIFF
--- a/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -40,6 +40,7 @@ num-workspaces=4
 titlebar-font="Inter Bold 12"
 
 [org.gnome.desktop.wm.keybindings]
+show-desktop=['<Super>d']
 switch-applications=['<Super>Tab']
 switch-applications-backward=['<Shift><Super>Tab']
 switch-windows=['<Alt>Tab']


### PR DESCRIPTION
Upstream issue proposing this (years ago) is found here: https://gitlab.gnome.org/GNOME/gsettings-desktop-schemas/-/issues/24

Justification to not set the shortcut by default by GNOME dev (Ubuntu has that default) is:

> The original purpose of that shortcut was to provide quick access to desktop icons (in fact, the internal shortcut name is show-desktop). As we no longer have those, the shortcut is no longer useful to most users.

Main counter-argument is: Being able to hide all windows (and showing one of Bluefin's beautiful wallpapers 🦕 or whatever) *is* already a use case.

GNOME dev counters that with

> Sure, and nobody is planning to remove the shortcut. But it's not a strong argument for a default shortcut, given that someone who installs and configures conky can also assign a shortcut.

Now I just wanted to see if anyone is against setting this by default in Bluefin.