### PR TITLE
feat: do not attach modal dialog windows

### DIFF
--- a/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -75,6 +75,7 @@ sort-directories-first=true
 sort-directories-first=true
 
 [org.gnome.mutter]
+attach-modal-dialogs=false
 experimental-features=['scale-monitor-framebuffer', 'xwayland-native-scaling']
 check-alive-timeout=uint32 20000
 


### PR DESCRIPTION
Attaching modal dialogs [introduces serious usability problems for various apps](https://www.reddit.com/r/gnome/comments/1dbzni6/dear_gnome_devs_attach_modal_dialogs_should_be/), the reason being such apps not following GNOME designer's intentions IIUC. Anyways, I think such *separate-window* modal dialogs are mostly a non/pre-libadwaita design pattern, so modern GNOME apps won't be negatively affected—but legacy ones will (often) gain usability.