### PR TITLE
fix: limit the number of days in rollback-helper

### DIFF
--- a/system_files/shared/usr/bin/ublue-rollback-helper
+++ b/system_files/shared/usr/bin/ublue-rollback-helper
@@ -8,7 +8,7 @@ IMAGE_TAG=$(jq -r '."image-tag"' < $IMAGE_INFO)
 FEDORA_VERSION=$(jq -r '."fedora-version"' < $IMAGE_INFO)
 
 function list_tags(){
-    skopeo list-tags docker://ghcr.io/ublue-os/"${IMAGE_NAME}" | grep -E --color=never -- "$FEDORA_VERSION-([0-9]+)" | sort -rV
+    skopeo list-tags docker://ghcr.io/ublue-os/"${IMAGE_NAME}" | grep -E --color=never -- "$FEDORA_VERSION-([0-9]+)" | sort -rV | head -n 31
 }
 
 function rebase_helper(){


### PR DESCRIPTION
This PR introduces a limitation on the date selection in `ublue-rollback-helper`, restricting the available options to the last 31 days.

As outlined in issue https://github.com/ublue-os/bluefin/issues/1821, the current implementation allows users to select from all available dates, which currently totals around 176 options. This extensive list will 'overflow' and results in showing only old dates to the user. 

By limiting the date range to the last 31 days, we can prevent this overflow issue, ensuring that users have a manageable selection that is sufficient for pinpointing specific issues via the date picker.

<details>
<summary>Current behavior</summary>

```
Which Tag would you like to rebase to?
The default selection is gts, stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers
Warning: This will pin you to a specific version, do not forget to rebase back to a channel to resume receiving updates.
  40-20240628     
  40-20240627     
  40-20240626     
  40-20240625     
  40-20240624     
  40-20240623     
  40-20240622     
  40-20240621     
  40-20240620     
  40-20240618     
  40-20240616     
  40-20240615     
  40-20240614     
  40-20240613     
  40-20240611     
  40-20240610     
  40-20240609     
  40-20240608     
  40-20240607     
  40-20240606     
  40-20240605     
  40-20240604     
  40-20240603     
  40-20240602     
  40-20240601     
  40-20240531     
  40-20240530     
  40-20240528     
  40-20240527     
  40-20240526     
  40-20240525     
  40-20240524     
  40-20240523     
  40-20240522     
  40-20240521     
  40-20240520     
  40-20240519     
  40-20240518     
  40-20240517     
  40-20240516     
  40-20240515     
  40-20240514     
  40-20240513     
  40-20240512     
  40-20240511     
  40-20240510     
  40-20240509     
  40-20240508     
  40-20240507     
  40-20240506     
  40-20240505     
  40-20240504     
  40-20240503     
  40-20240502     
  40-20240501     
  40-20240430     
  40-20240429     
  40-20240428     
  40-20240427     
  40-20240424     
  40-20240423     
  40-20240422     
  40-20240421     
  40-20240420     
  40-20240419     
  40-20240418     
  40-20240417     
  40-20240416     
  40-20240415     
  40-20240414     
  40-20240413     
  40-20240412     
  40-20240411     
  40-20240409     
  40-20240402 
```
</details> 
<details>
<summary>New behavior</summary>

```
Which Tag would you like to rebase to?
The default selection is gts, stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers
Warning: This will pin you to a specific version, do not forget to rebase back to a channel to resume receiving updates.
Choose:                
  40-20241027     
  40-20241026     
  40-20241025     
  40-20241024     
  40-20241023     
  40-20241022     
  40-20241021     
  40-20241020     
  40-20241019     
  40-20241018     
  40-20241017     
  40-20241016     
  40-20241015     
  40-20241014     
  40-20241013     
  40-20241012     
  40-20241011     
  40-20241010     
  40-20241009     
  40-20241008     
  40-20241007     
  40-20241006     
  40-20241005     
  40-20241004     
  40-20241003     
  40-20241002     
  40-20241001     
  40-20240930     
  40-20240929     
  40-20240928     
  40-20240927  
```
</details> 