### PR TITLE
fix: match bazzite's vrr/fractional scaling options

### DIFF
--- a/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -76,7 +76,7 @@ sort-directories-first=true
 sort-directories-first=true
 
 [org.gnome.mutter]
-experimental-features=['scale-monitor-framebuffer', 'xwayland-native-scaling']
+experimental-features=['variable-refresh-rate', 'scale-monitor-framebuffer', 'xwayland-native-scaling']
 check-alive-timeout=uint32 20000
 
 [org.gnome.software]


### PR DESCRIPTION
Seems to be working in bazzite so let's just match their setting:

Attempts to fix #1843 