### PR TITLE
fix: broken scale-monitor-framebuffer

### DIFF
--- a/build_files/bluefin-changes.sh
+++ b/build_files/bluefin-changes.sh
@@ -11,9 +11,14 @@ if [[ "${BASE_IMAGE_NAME}" = "silverblue" ]]; then
         sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/org.gnome.SystemMonitor.desktop
     fi
 
-    # GNOME Terminal is replaced with Ptyxis in F41+
+    # Workarounds for versions pre F41
     if [[ "${FEDORA_MAJOR_VERSION}" -lt "41" ]]; then
+        # GNOME Terminal is replaced with Ptyxis in F41+
         sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/org.gnome.Terminal.desktop
+
+        # Remove incompatible schema modifications
+        sed -i 's@accent-color="slate"@@g' /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+        sed -i 's@'", "\''xwayland-native-scaling'\''@@g' /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
     fi
     
     # Create symlinks from old to new wallpaper names for backwards compatibility
@@ -33,7 +38,7 @@ if [[ "${BASE_IMAGE_NAME}" = "silverblue" ]]; then
     echo "Running error test for bluefin gschema override. Aborting if failed."
     # We are omitting "--strict" from the schema validation since GNOME <47 do not contain the accent-color keys.
     # We should ideally refactor this to handle multiple GNOME version schemas better
-    glib-compile-schemas /tmp/bluefin-schema-test
+    glib-compile-schemas --strict /tmp/bluefin-schema-test
     echo "Compiling gschema to include bluefin setting overrides"
     glib-compile-schemas /usr/share/glib-2.0/schemas &>/dev/null
 fi


### PR DESCRIPTION
This PR tries to fix https://github.com/ublue-os/bluefin/issues/1843

Enabled `glib-combile-schemas --strict` again and strips out incompatible schema values (pre F41) via dirty sed:
`, 'xwayland-native-scaling'` and `accent-color="slate"`

Probably there are nicer ways to do this, but it results in strict checked schemas as tested on latest, gts and beta:

```
❯ rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/befanyt/bluefin:gts
                   Digest: sha256:7b19b8a71a101a9e405b4605e0750aff4e2b2d234f3c4a46f722fdcaa3174a30
                  Version: 39.20241027.0 (2024-10-28T20:46:13Z)

❯ gsettings get org.gnome.mutter experimental-features
['scale-monitor-framebuffer']

❯ rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/befanyt/bluefin:latest
                   Digest: sha256:52c1eacb99b1b00ac9952ab64b77067629b51aba92ed78e34c40544300bbc0fa
                  Version: 40.20241027.0 (2024-10-28T20:40:52Z)

❯ gsettings get org.gnome.mutter experimental-features
['scale-monitor-framebuffer']

❯ rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-unverified-registry:ghcr.io/befanyt/bluefin:beta
                   Digest: sha256:a5df3522395ac2231e96171d922528c1b64f0b26f14345b0b98060c5f2c546f3
                  Version: 41.20241028.0 (2024-10-28T20:46:52Z)

❯ gsettings get org.gnome.mutter experimental-features
['scale-monitor-framebuffer', 'xwayland-native-scaling']
```
Instead of current behavior:
```
❯ rpm-ostree status
State: idle
AutomaticUpdates: stage; rpm-ostreed-automatic.timer: no runs since boot
Deployments:
● ostree-image-signed:docker://ghcr.io/ublue-os/bluefin:latest
                   Digest: sha256:a39aa0fe06b2b04ebe2890b963eef9277c7442c7aebf891d761c27c4a42199d2
                  Version: 40.20241027.0 (2024-10-28T21:18:19Z)

❯ gsettings get org.gnome.mutter experimental-features
@as []
```