### PR TITLE
Fix(aurora): Broken Aurora SDDM Image and Desktop Wallpaper

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -89,6 +89,7 @@
 				"kdialog",
 				"libadwaita-qt5",
 				"libadwaita-qt6",
+				"kf6-kimageformats",
 				"plasma-wallpapers-dynamic",
 				"skanpage"
 			],


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
This PR adds a single package which doesn't get installed on the latest Fedora 41 Builds of Aurora for some reason. It is necessary to support Jpeg-XL Wallpapers.
