### PR TITLE
feat: make podman-machine work by default OOB

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -134,6 +134,7 @@
 				"p7zip-plugins",
 				"p7zip",
 				"podman-compose",
+				"podman-machine",
 				"podman-tui",
 				"podmansh",
 				"powerline-fonts",


### PR DESCRIPTION
This just adds `podman-machine` support for Bluefin. This fixes #1825
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
