### PR TITLE
feat(just): add brew-command-not-found setup

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -162,14 +162,9 @@ setup-brew-not-found ACTION="":
       export BREW_COMMAND_NOT_FOUND=1
     fi
     EOF
-    pkexec tee /etc/fish/conf.d/brew-command-not-found.fish > /dev/null <<EOF
-    set HB_CNF_HANDLER "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-command-not-found/handler.fish"
-    if test -f \$HB_CNF_HANDLER
-      set BREW_COMMAND_NOT_FOUND 1
-      source \$HB_CNF_HANDLER
-    end
-    EOF
-      echo "Brew command-not-found has been ${b}${green}enabled${n}"
+        # Necessary for fish since just having a script sourcing it does not work
+        pkexec ln -sf "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-command-not-found/handler.fish" /etc/fish/conf.d/brew-cnf-handler.fish
+        echo "Brew command-not-found has been ${b}${green}enabled${n}"
     fi
 
     if [[ "${OPTION,,}" =~ ^disable ]]; then

--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -146,9 +146,9 @@ setup-brew-not-found ACTION="":
     set -euo pipefail
 
     BREW_BINARY=/home/linuxbrew/.linuxbrew/bin/brew
-    BREW_ROOT=${HOMEBREW_REPOSITORY:-$($BREW_BINARY --repository)}
+    HOMEBREW_REPOSITORY=${HOMEBREW_REPOSITORY:-$($BREW_BINARY --repository)}
     if ! $BREW_BINARY -h > /dev/null; then
-      echo "Make sure Homebrew is first. Check journalctl -e -u brew-setup.service"
+      echo "Make sure Homebrew is installed first. Check journalctl -e -u brew-setup.service"
       exit
     fi
 
@@ -157,13 +157,13 @@ setup-brew-not-found ACTION="":
         pkexec tee /etc/profile.d/brew-command-not-found.sh > /dev/null <<EOF
     # Check for interactive bash or zsh and that we haven't already been sourced
     if [[ -d /home/linuxbrew/.linuxbrew && \$- == *i* && BREW_COMMAND_NOT_FOUND != 1 ]] ; then
-      HB_CNF_HANDLER="${BREW_ROOT}/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"
+      HB_CNF_HANDLER="${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"
       [ -f "\$HB_CNF_HANDLER" ] && source "\$HB_CNF_HANDLER"
       export BREW_COMMAND_NOT_FOUND=1
     fi
     EOF
     pkexec tee /etc/fish/conf.d/brew-command-not-found.fish > /dev/null <<EOF
-    set HB_CNF_HANDLER "${BREW_ROOT}/Library/Taps/homebrew/homebrew-command-not-found/handler.fish"
+    set HB_CNF_HANDLER "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-command-not-found/handler.fish"
     if test -f \$HB_CNF_HANDLER
       set BREW_COMMAND_NOT_FOUND=1
       source \$HB_CNF_HANDLER

--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -165,7 +165,7 @@ setup-brew-not-found ACTION="":
     pkexec tee /etc/fish/conf.d/brew-command-not-found.fish > /dev/null <<EOF
     set HB_CNF_HANDLER "${HOMEBREW_REPOSITORY}/Library/Taps/homebrew/homebrew-command-not-found/handler.fish"
     if test -f \$HB_CNF_HANDLER
-      set BREW_COMMAND_NOT_FOUND=1
+      set BREW_COMMAND_NOT_FOUND 1
       source \$HB_CNF_HANDLER
     end
     EOF

--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -124,3 +124,59 @@ install-k8s-dev-tools:
     #!/usr/bin/bash
     echo "Adding Kubernetes command line tools..."
     brew bundle --file /usr/share/ublue-os/homebrew/kubernetes.Brewfile
+
+# Set up command-not-found for Homebrew
+[group('Apps')]
+setup-brew-not-found ACTION="":
+    #!/usr/bin/env bash
+    source /usr/lib/ujust/ujust.sh
+
+    OPTION={{ ACTION }}
+    if [ "$OPTION" == "help" ]; then
+        echo "Usage: ujust setup-brew-not-found <option>"
+        echo "  <option>: Specify the quick option to skip the prompt"
+        echo "  Use 'enable' to select Enable Brew Not Found"
+        echo "  Use 'disable' to select Disable Brew Not Found"
+        exit 0
+    elif [ "$OPTION" == "" ]; then
+        echo "${bold}Brew command-not-found Setup${normal}"
+        OPTION=$(Choose "Enable Brew command-not-found" "Disable Brew command-not-found")
+    fi
+
+    set -euo pipefail
+
+    BREW_BINARY=/home/linuxbrew/.linuxbrew/bin/brew
+    BREW_ROOT=${HOMEBREW_REPOSITORY:-$($BREW_BINARY --repository)}
+    if ! $BREW_BINARY -h > /dev/null; then
+      echo "Make sure Homebrew is first. Check journalctl -e -u brew-setup.service"
+      exit
+    fi
+
+    if [[ "${OPTION,,}" =~ ^enable ]]; then
+        $BREW_BINARY tap homebrew/command-not-found
+        pkexec tee /etc/profile.d/brew-command-not-found.sh > /dev/null <<EOF
+    # Check for interactive bash or zsh and that we haven't already been sourced
+    if [[ -d /home/linuxbrew/.linuxbrew && \$- == *i* && BREW_COMMAND_NOT_FOUND != 1 ]] ; then
+      HB_CNF_HANDLER="${BREW_ROOT}/Library/Taps/homebrew/homebrew-command-not-found/handler.sh"
+      [ -f "\$HB_CNF_HANDLER" ] && source "\$HB_CNF_HANDLER"
+      export BREW_COMMAND_NOT_FOUND=1
+    fi
+    EOF
+    pkexec tee /etc/fish/conf.d/brew-command-not-found.fish > /dev/null <<EOF
+    set HB_CNF_HANDLER "${BREW_ROOT}/Library/Taps/homebrew/homebrew-command-not-found/handler.fish"
+    if test -f \$HB_CNF_HANDLER
+      set BREW_COMMAND_NOT_FOUND=1
+      source \$HB_CNF_HANDLER
+    end
+    EOF
+      echo "Brew command-not-found has been ${b}${green}enabled${n}"
+    fi
+
+    if [[ "${OPTION,,}" =~ ^disable ]]; then
+        $BREW_BINARY untap homebrew/command-not-found
+        FILES_TO_BE_REMOVED=()
+        [ -f /etc/profile.d/brew-command-not-found.sh ] && FILES_TO_BE_REMOVED+=("/etc/profile.d/brew-command-not-found.sh")
+        [ -f /etc/fish/conf.d/brew-command-not-found.fish ] && FILES_TO_BE_REMOVED+=("/etc/fish/conf.d/brew-command-not-found.fish")
+        pkexec rm -f "${FILES_TO_BE_REMOVED[@]}"
+      echo "Brew command-not-found has been ${b}${red}disabled${n}"
+    fi


### PR DESCRIPTION
This should setup command-not-found alongside brew-setup. The only thing missing is fish support that I couldnt set up yet (idk why it isnt working). Otherwise this seems good? Just needs a bit more testing. - Fixes #1327
