### PR TITLE
chore: fix name of Latest ISO workflow

### DIFF
--- a/.github/workflows/build-image-latest.yml
+++ b/.github/workflows/build-image-latest.yml
@@ -51,7 +51,7 @@ jobs:
       stream_name: '["latest"]'
 
   build-iso-latest:
-    name: Build Stable ISOs
+    name: Build Latest ISOs
     needs: [build-image-latest]
     if: github.event_name.scheduled == '40 4 * * 0'
     secrets: inherit


### PR DESCRIPTION
it says Stable ISOs in Github UI but it's actually latest.

A little something I missed in my review.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
