### PR TITLE
feat(just): add nix derminate systems installer

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -102,3 +102,8 @@ install-incus:
         echo "Run \"just devmode\" to turn on Developer mode."
         exit
     fi
+
+# Install nix using the determinate systems installer
+install-nix:
+    #!/usr/bin/env bash
+    curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install


### PR DESCRIPTION
Added a ujust entry to install nix using the determinate system installer. https://github.com/DeterminateSystems/nix-installer which supports OSes built on top of silverblue.

