### PR TITLE
feat: add a commented rpm-ostreed.conf

### DIFF
--- a/system_files/shared/etc/rpm-ostreed.conf
+++ b/system_files/shared/etc/rpm-ostreed.conf
@@ -1,0 +1,17 @@
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# For option meanings, see rpm-ostreed.conf(5).
+
+[Daemon]
+AutomaticUpdatePolicy=stage
+
+##########
+# NOTE: This will be set to true by default in Spring 2025
+#
+# Set this to false to enable local layering with dnf
+# This is an unsupported configuration that can lead to upgrade isses
+# Be careful when setting this to true
+#
+# See [future link] for more information
+##########
+LockLayering=false


### PR DESCRIPTION
This adds boilerplate to a bluefin/aurora only rpm-ostreed.conf so that we can turn this on in the future.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
