### PR TITLE
fix: enable incus copr for F41

### DIFF
--- a/build_files/dx/01-install-copr-repos-dx.sh
+++ b/build_files/dx/01-install-copr-repos-dx.sh
@@ -3,7 +3,7 @@
 set -eoux pipefail
 
 #incus, lxc, lxd
-if [[ "${FEDORA_MAJOR_VERSION}" -lt "41" ]]; then
+if [[ "${FEDORA_MAJOR_VERSION}" -lt "42" ]]; then
     curl -Lo /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo \
         https://copr.fedorainfracloud.org/coprs/ganto/lxc4/repo/fedora-"${FEDORA_MAJOR_VERSION}"/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
 fi


### PR DESCRIPTION
Currently, incus comes from the Fedora repositories on latest, which are at version 6.2, while it was previously sourced from a COPR that is already at version 6.6. This PR also enables the COPR for F41 builds, ensuring that user don't experience a downgrade. As seen in https://github.com/ublue-os/bluefin/issues/1894.
