### PR TITLE
chore(just): restrict topgrade to only supported things

### DIFF
--- a/system_files/shared/usr/share/ublue-os/topgrade.toml
+++ b/system_files/shared/usr/share/ublue-os/topgrade.toml
@@ -1,5 +1,6 @@
 [misc]
 no_self_update = true
+only = ["system", "flatpak", "distrobox", "firmware"]
 disable = ["self_update", "toolbx", "containers", "helm"]
 ignore_failures = ["distrobox", "flatpak", "brew_cask", "brew_formula", "nix", "node", "pip3", "home_manager", "firmware"]
 assume_yes = true


### PR DESCRIPTION
This is much more of a RFC than anything concrete, I just wanted to really know what you guys feel like should be directly supported by bluefin (and thus should be added to this `only` array). Restricting topgrade on ujust update should mitigate issues like #1912 and #1845
