### PR TITLE
fix: stable tag on schedule

### DIFF
--- a/.github/workflows/build-image-beta.yml
+++ b/.github/workflows/build-image-beta.yml
@@ -38,7 +38,7 @@ jobs:
   generate-release:
     name: Generate Release
     needs: [build-image-beta]
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name.scheduled == '40 4 * * 0'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name.schedule == '40 4 * * 0'
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:

--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -27,7 +27,7 @@ jobs:
   generate_release:
     name: Generate Release
     needs: [build-image-gts]
-    if: github.event_name == 'scheduled' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call'
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:
@@ -36,6 +36,6 @@ jobs:
   build-iso-gts:
     name: Build GTS ISOs
     needs: [build-image-gts]
-    if: github.event_name == 'scheduled'
+    if: github.event_name == 'schedule'
     secrets: inherit
     uses: ./.github/workflows/build-iso-gts.yml

--- a/.github/workflows/build-image-latest.yml
+++ b/.github/workflows/build-image-latest.yml
@@ -39,7 +39,7 @@ jobs:
   generate-release:
     name: Generate Release
     needs: [build-image-latest]
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name.scheduled == '40 4 * * 0'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name.schedule == '40 4 * * 0'
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:
@@ -48,6 +48,6 @@ jobs:
   build-iso-latest:
     name: Build Latest ISOs
     needs: [build-image-latest]
-    if: github.event_name.scheduled == '40 4 * * 0'
+    if: github.event_name.schedule == '40 4 * * 0'
     secrets: inherit
     uses: ./.github/workflows/build-iso-latest.yml

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -38,7 +38,7 @@ jobs:
   generate-release:
     name: Generate Release
     needs: [build-image-stable]
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name.scheduled == '45 5 * * 0'
+    if: github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call' || github.event_name.schedule == '45 5 * * 0'
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:
@@ -47,6 +47,6 @@ jobs:
   build-iso-stable:
     name: Build Stable ISOs
     needs: [build-image-stable]
-    if: github.event_name.scheduled == '45 5 * * 0'
+    if: github.event_name.schedule == '45 5 * * 0'
     secrets: inherit
     uses: ./.github/workflows/build-iso-stable.yml

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -99,14 +99,8 @@ jobs:
             fi
 
             # Kernel Release for ostree.linux label
-            if [[ "${{ matrix.image_flavor }}" =~ hwe ]]; then
-              kernel_release=$(skopeo inspect docker://ghcr.io/ublue-os/bazzite-kernel:"${fedora_version}" | jq -r '.Labels["ostree.linux"]')
-            elif [[ "${{ matrix.stream_name }}" =~ latest|beta ]]; then
-              kernel_release=$(skopeo inspect docker://ghcr.io/ublue-os/main-kernel:"${fedora_version}" | jq -r '.Labels["ostree.linux"]')
-            else
-              kernel_release=$(skopeo inspect docker://ghcr.io/ublue-os/coreos-stable-kernel:"${fedora_version}" | jq -r '.Labels["ostree.linux"]')
-            fi
-
+            kernel_release=$(skopeo inspect docker://ghcr.io/ublue-os/${{ env.AKMODS_FLAVOR }}-kernel:"${fedora_version}" | jq -r '.Labels["ostree.linux"]')
+            
             # Get Version
             ver=$(skopeo inspect docker://ghcr.io/ublue-os/"${{ env.BASE_IMAGE_NAME }}"-main:"${fedora_version}" | jq -r '.Labels["org.opencontainers.image.version"]')
             if [ -z "$ver" ] || [ "null" = "$ver" ]; then

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -189,7 +189,7 @@ jobs:
           fi
 
           # Weekly Stable / Rebuild Stable on workflow_dispatch
-          if [[ "${{ matrix.stream_name }}" =~ "stable" && "${WEEKLY}" == "${TODAY}" && "${{ github.event_name }}" =~ scheduled ]]; then
+          if [[ "${{ matrix.stream_name }}" =~ "stable" && "${WEEKLY}" == "${TODAY}" && "${{ github.event_name }}" =~ schedule ]]; then
               BUILD_TAGS+=("stable" "stable-${TIMESTAMP}")
           elif [[ "${{ matrix.stream_name }}" =~ "stable" && "${{ github.event_name }}" =~ workflow_dispatch|workflow_call ]]; then
               BUILD_TAGS+=("stable" "stable-${TIMESTAMP}")


### PR DESCRIPTION
Fix a typo to match for stable weekly tag.

Today scheduled run where it missed the stable tag because of checking for "scheduled" instead of "schedule"
https://github.com/ublue-os/bluefin/actions/runs/11762641102/job/32765731717#step:14:26

Should fix https://github.com/ublue-os/bluefin/issues/1918

And you probably want a manual rebuild today of stable images, because it missed the scheduled one.