### PR TITLE
fix: deprecate playerctl

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -36,7 +36,6 @@
 				"nerd-fonts",
 				"oddjob-mkhomedir",
 				"opendyslexic-fonts",
-				"playerctl",
 				"printer-driver-brlaser",
 				"pulseaudio-utils",
 				"python3-pip",


### PR DESCRIPTION
This is unmaintained

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
