### PR TITLE
chore(topgrade): make it so topgrade-bootc follows allowlist pattern

### DIFF
--- a/system_files/shared/usr/share/ublue-os/topgrade-bootc.toml
+++ b/system_files/shared/usr/share/ublue-os/topgrade-bootc.toml
@@ -1,5 +1,6 @@
 [misc]
 no_self_update = true
+only = ["custom_commands", "flatpak", "distrobox", "firmware"]
 disable = ["self_update", "toolbx", "containers", "helm", "system"]
 ignore_failures = ["distrobox", "flatpak", "brew_cask", "brew_formula", "nix", "node", "pip3", "home_manager", "firmware"]
 assume_yes = true


### PR DESCRIPTION
Should make it so when using LockLayering, the bootc topgrade file will also follow our allowlist from the other topgrade config, seems to work locally
![image](https://github.com/user-attachments/assets/43540a26-88b8-41d1-b511-c84f2cdd39ce)

