### PR TITLE
chore(f39): remove vestigial f39 reference in packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -183,26 +183,6 @@
 			"dx": []
 		}
 	},
-	"39": {
-		"include": {
-			"all": [],
-			"silverblue": [
-				"fmt"
-			],
-			"dx": [
-				"lxd-agent",
-				"lxd",
-				"distrobuilder",
-				"podman-plugins"
-			]
-		},
-		"exclude": {
-			"all": [],
-			"silverblue": [],
-			"kinoite": [],
-			"dx": []
-		}
-	},
 	"40": {
 		"include": {
 			"all": [


### PR DESCRIPTION
We should also probably remove libratbagd from packages.json, apparently it got replaced entirely by Solaar AFAIK