### PR TITLE
chore(build): move to dnf5 instead of rpm-ostree

### DIFF
--- a/build_files/base/01-build-fix.sh
+++ b/build_files/base/01-build-fix.sh
@@ -18,9 +18,7 @@ for repo in "${repos[@]}"; do
 done
 
 if grep -q "kinoite" <<<"${BASE_IMAGE_NAME}"; then
-    rpm-ostree override replace \
-        --experimental \
-        --from repo=updates \
+    dnf5 -y upgrade --repo updates \
         qt6-qtbase \
         qt6-qtbase-common \
         qt6-qtbase-mysql \
@@ -28,9 +26,7 @@ if grep -q "kinoite" <<<"${BASE_IMAGE_NAME}"; then
         true
 fi
 
-rpm-ostree override replace \
-    --experimental \
-    --from repo=updates \
+dnf5 -y upgrade --repo updates \
     elfutils-libelf \
     elfutils-libs ||
     true

--- a/build_files/base/02-install-copr-repos.sh
+++ b/build_files/base/02-install-copr-repos.sh
@@ -4,12 +4,6 @@
 set -eoux pipefail
 
 # Add Staging repo
-curl --retry 3 -Lo /etc/yum.repos.d/ublue-os-staging-fedora-"$(rpm -E %fedora)".repo \
-    https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"$(rpm -E %fedora)"/ublue-os-staging-fedora-"$(rpm -E %fedora)".repo
-
-# Add Switcheroo Repo
-curl --retry 3 -Lo /etc/yum.repos.d/_copr_sentry-switcheroo-control_discrete.repo \
-    https://copr.fedorainfracloud.org/coprs/sentry/switcheroo-control_discrete/repo/fedora-"$(rpm -E %fedora)"/sentry-switcheroo-control_discrete-fedora-"$(rpm -E %fedora)".repo
-
-# Add Nerd Fonts Repo
-curl --retry 3 -Lo /etc/yum.repos.d/_copr_che-nerd-fonts-"$(rpm -E %fedora)".repo https://copr.fedorainfracloud.org/coprs/che/nerd-fonts/repo/fedora-"$(rpm -E %fedora)"/che-nerd-fonts-fedora-"$(rpm -E %fedora)".repo
+dnf5 -y -q copr enable ublue-os/staging
+dnf5 -y -q copr enable sentry/switcheroo-control_discrete
+dnf5 -y -q copr enable che/nerd-fonts

--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -26,14 +26,12 @@ fi
 
 # simple case to install where no packages need excluding
 if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#INSTALLED_EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
-    rpm-ostree install \
-        ${INCLUDED_PACKAGES[@]}
-
+    dnf5 -y install \
+        "${INCLUDED_PACKAGES[@]}"
 # install/excluded packages both at same time
 elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#INSTALLED_EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    rpm-ostree override remove \
-        ${INSTALLED_EXCLUDED_PACKAGES[@]} \
-        $(printf -- "--install=%s " ${INCLUDED_PACKAGES[@]})
+    dnf5 -y remove "${INSTALLED_EXCLUDED_PACKAGES[@]}"
+    dnf5 -y install "${INCLUDED_PACKAGES[@]}"
 else
     echo "No packages to install."
 fi
@@ -46,6 +44,6 @@ fi
 
 # remove any excluded packages which are still present on image
 if [[ "${#INSTALLED_EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    rpm-ostree override remove \
-        ${INSTALLED_EXCLUDED_PACKAGES[@]}
+    dnf5 -y remove \
+        "${INSTALLED_EXCLUDED_PACKAGES[@]}"
 fi

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -4,14 +4,10 @@ set -eoux pipefail
 
 # Patched shells
 if [[ "${BASE_IMAGE_NAME}" =~ silverblue ]]; then
-    rpm-ostree override replace \
-    --experimental \
-    --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
+    dnf5 -y upgrade --repo copr:copr.fedorainfracloud.org:ublue-os:staging \
         gnome-shell
 elif [[ "${BASE_IMAGE_NAME}" =~ kinoite ]]; then
-    rpm-ostree override replace \
-    --experimental \
-    --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
+    dnf5 -y upgrade --repo copr:copr.fedorainfracloud.org:ublue-os:staging \
         kf6-kio-doc \
         kf6-kio-widgets-libs \
         kf6-kio-core-libs \
@@ -23,29 +19,23 @@ fi
 
 # GNOME Triple Buffering
 if [[ "${BASE_IMAGE_NAME}" =~ silverblue && "${FEDORA_MAJOR_VERSION}" -lt "41" ]]; then
-    rpm-ostree override replace \
-    --experimental \
-    --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
+    dnf5 -y upgrade --repo copr:copr.fedorainfracloud.org:ublue-os:staging \
         mutter \
         mutter-common
 fi
 
 # Fix for ID in fwupd
-rpm-ostree override replace \
-    --experimental \
-    --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
+dnf5 -y upgrade --repo copr:copr.fedorainfracloud.org:ublue-os:staging \
         fwupd \
         fwupd-plugin-flashrom \
         fwupd-plugin-modem-manager \
         fwupd-plugin-uefi-capsule-data
 
 # Switcheroo patch
-rpm-ostree override replace \
-    --experimental \
-    --from repo=copr:copr.fedorainfracloud.org:sentry:switcheroo-control_discrete \
+dnf5 -y upgrade --repo copr:copr.fedorainfracloud.org:sentry:switcheroo-control_discrete \
         switcheroo-control
 
-rm /etc/yum.repos.d/_copr_sentry-switcheroo-control_discrete.repo
+dnf5 -y copr remove sentry/switcheroo-control_discrete
 
 # Starship Shell Prompt
 curl --retry 3 -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz"
@@ -61,7 +51,7 @@ curl --retry 3 -Lo /usr/share/bash-prexec https://raw.githubusercontent.com/rcal
 pip install --prefix=/usr topgrade
 
 # Install ublue-update -- breaks with packages.json due to missing topgrade
-rpm-ostree install ublue-update
+dnf5 -y install ublue-update
 
 # Consolidate Just Files
 find /tmp/just -iname '*.just' -exec printf "\n\n" \; -exec cat {} \; >> /usr/share/ublue-os/just/60-custom.just

--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -8,7 +8,7 @@ if [[ "${BASE_IMAGE_NAME}" = "kinoite" ]]; then
 
     # Restore x11 for Nvidia Images
     if [[ "${FEDORA_MAJOR_VERSION}" -eq "40" ]]; then
-        rpm-ostree install plasma-workspace-x11
+        dnf5 -y install plasma-workspace-x11
     fi
 
     # Branding for Images

--- a/build_files/base/09-hwe-additions.sh
+++ b/build_files/base/09-hwe-additions.sh
@@ -10,11 +10,9 @@ else
 fi
 
 # Asus/Surface for HWE
-curl --retry 3 -Lo /etc/yum.repos.d/_copr_lukenukem-asus-linux.repo \
-    https://copr.fedorainfracloud.org/coprs/lukenukem/asus-linux/repo/fedora-$(rpm -E %fedora)/lukenukem-asus-linux-fedora-$(rpm -E %fedora).repo
+dnf5 -y -q copr enable lukenukem/asus-linux
 
-curl --retry 3 -Lo /etc/yum.repos.d/linux-surface.repo \
-        https://pkg.surfacelinux.com/fedora/linux-surface.repo
+dnf5 config-manager addrepo --from-repofile=https://pkg.surfacelinux.com/fedora/linux-surface.repo
 
 # Asus Firmware
 git clone https://gitlab.com/asus-linux/firmware.git --depth 1 /tmp/asus-firmware
@@ -35,7 +33,7 @@ SURFACE_PACKAGES=(
     pipewire-plugin-libcamera
 )
 
-rpm-ostree install \
+dnf5 -y install \
     "${ASUS_PACKAGES[@]}" \
     "${SURFACE_PACKAGES[@]}"
 

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -29,10 +29,10 @@ rm -f /etc/xdg/autostart/solaar.desktop
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/tailscale.repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/charm.repo
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_che-nerd-fonts-"${FEDORA_MAJOR_VERSION}".repo
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
+dnf5 -y copr disable ublue-os/staging
+dnf5 -y copr disable ublue-os/akmods
+dnf5 -y copr disable che/nerd-fonts
 for i in /etc/yum.repos.d/rpmfusion-*; do
     sed -i 's@enabled=1@enabled=0@g' "$i"
 done

--- a/build_files/dx/01-install-copr-repos-dx.sh
+++ b/build_files/dx/01-install-copr-repos-dx.sh
@@ -4,26 +4,11 @@ set -eoux pipefail
 
 #incus, lxc, lxd
 if [[ "${FEDORA_MAJOR_VERSION}" -lt "42" ]]; then
-    curl -Lo /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo \
-        https://copr.fedorainfracloud.org/coprs/ganto/lxc4/repo/fedora-"${FEDORA_MAJOR_VERSION}"/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo
+    dnf5 -y -q copr enable ganto/lxc4
 fi
 
-#umoci
-curl --retry 3 -Lo /etc/yum.repos.d/ganto-umoci-fedora-"${FEDORA_MAJOR_VERSION}".repo \
-    https://copr.fedorainfracloud.org/coprs/ganto/umoci/repo/fedora-"${FEDORA_MAJOR_VERSION}"/ganto-umoci-fedora-"${FEDORA_MAJOR_VERSION}".repo
-
-#ublue-os staging
-curl --retry 3 -Lo /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo \
-    https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"${FEDORA_MAJOR_VERSION}"/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo
-
-#karmab-kcli
-curl --retry 3 -Lo /etc/yum.repos.d/karmab-kcli-fedora-"${FEDORA_MAJOR_VERSION}".repo \
-    https://copr.fedorainfracloud.org/coprs/karmab/kcli/repo/fedora-"${FEDORA_MAJOR_VERSION}"/karmab-kcli-fedora-"${FEDORA_MAJOR_VERSION}".repo
-
-# Fonts
-curl --retry 3 -Lo /etc/yum.repos.d/atim-ubuntu-fonts-fedora-"${FEDORA_MAJOR_VERSION}".repo \
-    https://copr.fedorainfracloud.org/coprs/atim/ubuntu-fonts/repo/fedora-"${FEDORA_MAJOR_VERSION}"/atim-ubuntu-fonts-fedora-"${FEDORA_MAJOR_VERSION}".repo
-
-# Kvmfr module
-curl --retry 3 -Lo /etc/yum.repos.d/hikariknight-looking-glass-kvmfr-fedora-"${FEDORA_MAJOR_VERSION}".repo \
-    https://copr.fedorainfracloud.org/coprs/hikariknight/looking-glass-kvmfr/repo/fedora-"${FEDORA_MAJOR_VERSION}"/hikariknight-looking-glass-kvmfr-fedora-"${FEDORA_MAJOR_VERSION}".repo
+dnf5 -y -q copr enable ganto/umoci
+dnf5 -y -q copr enable ublue-os/staging
+dnf5 -y -q copr enable karmab/kcli
+dnf5 -y -q copr enable atim/ubuntu-fonts
+dnf5 -y -q copr enable hikariknight/looking-glass-kvmfr

--- a/build_files/dx/02-install-kernel-akmods-dx.sh
+++ b/build_files/dx/02-install-kernel-akmods-dx.sh
@@ -2,7 +2,7 @@
 
 set -ouex pipefail
 
-sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+dnf5 -y -q copr enable ublue-os/akmods
 
 # Fetch Kernel RPMS
 skopeo copy --retry-times 3 docker://ghcr.io/ublue-os/"${AKMODS_FLAVOR}"-kernel:"$(rpm -E %fedora)"-"${KERNEL}" dir:/tmp/kernel-rpms
@@ -11,7 +11,7 @@ tar -xvzf /tmp/kernel-rpms/"$KERNEL_TARGZ" -C /
 mv /tmp/rpms/* /tmp/kernel-rpms/
 
 if [[ -z "$(grep kernel-devel <<< $(rpm -qa))" ]]; then
-    rpm-ostree install /tmp/kernel-rpms/kernel-devel-*.rpm
+    dnf5 -y install /tmp/kernel-rpms/kernel-devel-*.rpm
 fi
 
 # Fetch AKMODS RPMS
@@ -21,4 +21,4 @@ tar -xvzf /tmp/akmods/"$AKMODS_TARGZ" -C /tmp/
 mv /tmp/rpms/* /tmp/akmods/
 
 # Install RPMS
-rpm-ostree install /tmp/akmods/kmods/*kvmfr*.rpm
+dnf5 -y install /tmp/akmods/kmods/*kvmfr*.rpm

--- a/build_files/dx/03-packages-dx.sh
+++ b/build_files/dx/03-packages-dx.sh
@@ -30,14 +30,13 @@ fi
 
 # simple case to install where no packages need excluding
 if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#INSTALLED_EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
-    rpm-ostree install \
+    dnf5 -y install \
         ${INCLUDED_PACKAGES[@]}
 
 # install/excluded packages both at same time
 elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#INSTALLED_EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    rpm-ostree override remove \
-        ${INSTALLED_EXCLUDED_PACKAGES[@]} \
-        $(printf -- "--install=%s " ${INCLUDED_PACKAGES[@]})
+    dnf5 -y remove ${INSTALLED_EXCLUDED_PACKAGES[@]}
+    dnf5 -y install ${INCLUDED_PACKAGES[@]}
 else
     echo "No packages to install."
 fi
@@ -50,6 +49,6 @@ fi
 
 # remove any excluded packages which are still present on image
 if [[ "${#INSTALLED_EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    rpm-ostree override remove \
+    dnf5 -y remove \
         ${INSTALLED_EXCLUDED_PACKAGES[@]}
 fi

--- a/build_files/dx/09-cleanup-dx.sh
+++ b/build_files/dx/09-cleanup-dx.sh
@@ -20,9 +20,9 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/karmab-kcli-fedora-"${FEDORA_M
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/atim-ubuntu-fonts-fedora-"${FEDORA_MAJOR_VERSION}".repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/vscode.repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/docker-ce.repo
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:phracek:PyCharm.repo
+dnf5 -y copr disable phracek/PyCharm
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
+dnf5 -y copr disable ublue-os/akmods
 
 for i in /etc/yum.repos.d/rpmfusion-*; do
     sed -i 's@enabled=1@enabled=0@g' "$i"


### PR DESCRIPTION
This PR still needs cliwrap to be disabled in main to actually function properly (e.g.: use dnf instead of dnf5, and a weird systemctl issue in the middle too).

I tested this out on a VM and here is the output from `ujust device-info` and `rpm -qa`:

[ujust-device-info.txt](https://github.com/user-attachments/files/17840419/ujust-device-info.txt) (from the VM)
[rpm-qa-vm.txt](https://github.com/user-attachments/files/17840422/rpm-qa.txt) (from the VM)
[rpm-qa-latest.txt](https://github.com/user-attachments/files/17840533/rpm-qa-latest.txt) (current rpm -qa)



