### PR TITLE
chore(ci): add 90 day cleanup action

### DIFF
--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -1,0 +1,24 @@
+name: Cleanup Old Images
+on:
+  schedule:
+    - cron: "15 0 * * 0" # 0015 UTC on Sundays
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+
+jobs:
+  delete-older-than-90:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Delete Images Older Than 90 Days
+        uses: dataaxiom/ghcr-cleanup-action@v1.0.13
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          packages: bluefin, bluefin-dx, bluefin-nvidia, bluefin-dx-nvidia
+          older-than: 90 days
+          delete-orphaned-images: true
+          keep-n-tagged: 7
+          keep-n-untagged: 7


### PR DESCRIPTION
This will clean up images older than 90 days, from bsherman. This has been running fine on kernel-cache.

Only adding a few images, we can add more over time.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
