### PR TITLE
fix(ujust): dx detection on nvidia/surface/others

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -110,7 +110,7 @@ install-incus:
     #!/usr/bin/env bash
     source /usr/lib/ujust/ujust.sh
     CURRENT_IMAGE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"')
-    if ! grep -e "-dx:" <<< $CURRENT_IMAGE ; then
+    if ! grep -e "-dx" <<< $CURRENT_IMAGE ; then
         echo "Developer mode is currently ${b}${red}Disabled${n}."
         echo "Run \"just devmode\" to turn on Developer mode."
         exit

--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -39,7 +39,7 @@ toggle-devmode:
     EOF
         exit
     fi
-    if /bin/grep -q "\-dx:" <<< $CURRENT_IMAGE ; then
+    if /bin/grep -q "\-dx" <<< $CURRENT_IMAGE ; then
         CURRENT_STATE="enabled"
     else
         CURRENT_STATE="disabled"
@@ -68,7 +68,7 @@ toggle-devmode:
         fi
         echo "Rebasing to a non developer image"
         # Remove -dx suffix from image, specifies ":" to mark the end of the image name
-        NEW_IMAGE=$(sed "s/\-dx:/:/" <<< $CURRENT_IMAGE)
+        NEW_IMAGE=$(sed "s/\-dx//" <<< $CURRENT_IMAGE)
         rpm-ostree rebase $NEW_IMAGE
     fi
 


### PR DESCRIPTION
Did an oopsie when was refactoring the ujust recipes, this should make -dx detection work fine on `ujust devmode` and `ujust incus`. Sorry guys
