### PR TITLE
fix(sddm): Use default permissions for themes directories

### DIFF
--- a/system_files/kinoite/usr/lib/tmpfiles.d/usr-share-ssdm-themes.conf
+++ b/system_files/kinoite/usr/lib/tmpfiles.d/usr-share-ssdm-themes.conf
@@ -1,2 +1,2 @@
-d /var/sddm_themes/themes 0750 - - -
-d /var/sddm_themes/themes.work 0750 - - -
+d /var/sddm_themes/themes 0755 - - -
+d /var/sddm_themes/themes.work 0755 - - -


### PR DESCRIPTION
This should fix #1971