### PR TITLE
fix(ujust): dx-group using built in GROUPS array in bash

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -143,11 +143,11 @@ dx-group:
         fi
     }
 
-    GROUPS=("docker" "incus-admin" "lxd" "libvirt")
+    GROUPS_ADD=("docker" "incus-admin" "lxd" "libvirt")
 
-    for GROUP in "${GROUPS[@]}" ; do
-        append_group $GROUP
-        pkexec usermod -aG $GROUP $USER
+    for GROUP_ADD in "${GROUPS_ADD[@]}" ; do
+        append_group $GROUP_ADD
+        pkexec usermod -aG $GROUP_ADD $USER
     done
 
     echo "Reboot system and log back in to use docker, incus-admin, lxd, libvirt."


### PR DESCRIPTION
Apparently specifically the bash shell sets `$GROUPS` as an array for GIDs the current user is on. This should force it to use the declared array instead of the built-in. Fixes: #1972

(I also did not run into this issue during testing, super weird)