### PR TITLE
feat: set mutter experimental kms-modifiers for nvidia

### DIFF
--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -80,10 +80,21 @@ elif [[ "${BASE_IMAGE_NAME}" = "silverblue" ]]; then
     ln -s "/usr/share/backgrounds/xe_space_needle.jxl" "/usr/share/backgrounds/xe_space_needle.jpeg"
     ln -s "/usr/share/backgrounds/xe_sunset.jxl" "/usr/share/backgrounds/xe_sunset.jpeg"
 
+    # Add Mutter experimental-features
+    MUTTER_EXP_FEATS="'scale-monitor-framebuffer', 'xwayland-native-scaling'"
+    if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
+        MUTTER_EXP_FEATS="'kms-modifiers', ${MUTTER_EXP_FEATS}"
+    fi
+    tee /usr/share/glib-2.0/schemas/zz1-bluefin-modifications-mutter-exp-feats.gschema.override << EOF
+[org.gnome.mutter]
+experimental-features=[${MUTTER_EXP_FEATS}]
+EOF
+
     # Test bluefin gschema override for errors. If there are no errors, proceed with compiling bluefin gschema, which includes setting overrides.
     mkdir -p /tmp/bluefin-schema-test
     find /usr/share/glib-2.0/schemas/ -type f ! -name "*.gschema.override" -exec cp {} /tmp/bluefin-schema-test/ \;
     cp /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override /tmp/bluefin-schema-test/
+    cp /usr/share/glib-2.0/schemas/zz1-bluefin-modifications-mutter-exp-feats.gschema.override /tmp/bluefin-schema-test/
     echo "Running error test for bluefin gschema override. Aborting if failed."
     # We are omitting "--strict" from the schema validation since GNOME <47 do not contain the accent-color keys.
     # We should ideally refactor this to handle multiple GNOME version schemas better

--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -63,11 +63,21 @@ elif [[ "${BASE_IMAGE_NAME}" = "silverblue" ]]; then
         sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nHidden=true@g' /usr/share/applications/org.gnome.SystemMonitor.desktop
     fi
 
+    # Add Mutter experimental-features
+    MUTTER_EXP_FEATS="'scale-monitor-framebuffer', 'xwayland-native-scaling'"
+    if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
+        MUTTER_EXP_FEATS="'kms-modifiers', ${MUTTER_EXP_FEATS}"
+    fi
+    tee /usr/share/glib-2.0/schemas/zz1-bluefin-modifications-mutter-exp-feats.gschema.override << EOF
+[org.gnome.mutter]
+experimental-features=[${MUTTER_EXP_FEATS}]
+EOF
+
     # GNOME Terminal is replaced with Ptyxis in F41+
     if [[ "${FEDORA_MAJOR_VERSION}" -lt "41" ]]; then
         sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/org.gnome.Terminal.desktop
         sed -i 's@accent-color="slate"@@g' /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
-        sed -i 's@'", "\''xwayland-native-scaling'\''@@g' /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+        sed -i 's@'", "\''xwayland-native-scaling'\''@@g' /usr/share/glib-2.0/schemas/zz1-bluefin-modifications-mutter-exp-feats.gschema.override
     fi
 
     # Create symlinks from old to new wallpaper names for backwards compatibility
@@ -79,16 +89,6 @@ elif [[ "${BASE_IMAGE_NAME}" = "silverblue" ]]; then
     ln -s "/usr/share/backgrounds/xe_foothills.jxl" "/usr/share/backgrounds/xe_foothills.jpeg"
     ln -s "/usr/share/backgrounds/xe_space_needle.jxl" "/usr/share/backgrounds/xe_space_needle.jpeg"
     ln -s "/usr/share/backgrounds/xe_sunset.jxl" "/usr/share/backgrounds/xe_sunset.jpeg"
-
-    # Add Mutter experimental-features
-    MUTTER_EXP_FEATS="'scale-monitor-framebuffer', 'xwayland-native-scaling'"
-    if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
-        MUTTER_EXP_FEATS="'kms-modifiers', ${MUTTER_EXP_FEATS}"
-    fi
-    tee /usr/share/glib-2.0/schemas/zz1-bluefin-modifications-mutter-exp-feats.gschema.override << EOF
-[org.gnome.mutter]
-experimental-features=[${MUTTER_EXP_FEATS}]
-EOF
 
     # Test bluefin gschema override for errors. If there are no errors, proceed with compiling bluefin gschema, which includes setting overrides.
     mkdir -p /tmp/bluefin-schema-test

--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -74,6 +74,7 @@ experimental-features=[${MUTTER_EXP_FEATS}]
 EOF
 
     # GNOME Terminal is replaced with Ptyxis in F41+
+    # Modify schema validation since GNOME <47 do not contain the accent-color key or xwayland-native-scaling mutter feature
     if [[ "${FEDORA_MAJOR_VERSION}" -lt "41" ]]; then
         sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/org.gnome.Terminal.desktop
         sed -i 's@accent-color="slate"@@g' /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -96,7 +97,6 @@ EOF
     cp /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override /tmp/bluefin-schema-test/
     cp /usr/share/glib-2.0/schemas/zz1-bluefin-modifications-mutter-exp-feats.gschema.override /tmp/bluefin-schema-test/
     echo "Running error test for bluefin gschema override. Aborting if failed."
-    # We are omitting "--strict" from the schema validation since GNOME <47 do not contain the accent-color keys.
     # We should ideally refactor this to handle multiple GNOME version schemas better
     glib-compile-schemas --strict /tmp/bluefin-schema-test
     echo "Compiling gschema to include bluefin setting overrides"

--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -74,7 +74,7 @@ experimental-features=[${MUTTER_EXP_FEATS}]
 EOF
 
     # GNOME Terminal is replaced with Ptyxis in F41+
-    # Modify schema validation since GNOME <47 do not contain the accent-color key or xwayland-native-scaling mutter feature
+    # Make schema valid on GNOME <47 which do not contain the accent-color key or xwayland-native-scaling mutter feature
     if [[ "${FEDORA_MAJOR_VERSION}" -lt "41" ]]; then
         sed -i 's@\[Desktop Entry\]@\[Desktop Entry\]\nNoDisplay=true@g' /usr/share/applications/org.gnome.Terminal.desktop
         sed -i 's@accent-color="slate"@@g' /usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override

--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -72,47 +72,6 @@ toggle-devmode:
         rpm-ostree rebase $NEW_IMAGE
     fi
 
-# alias for gnome-vrr
-[group('System')]
-gnome-vrr:
-    @ujust toggle-gnome-vrr
-
-# Enable or Disable Gnome-VRR
-[group('System')]
-toggle-gnome-vrr:
-    #!/usr/bin/env bash
-    source /usr/lib/ujust/ujust.sh
-    if gsettings get org.gnome.mutter experimental-features | grep -q "variable-refresh-rate" ; then
-        CURRENT_STATE="Enabled"
-    else
-        CURRENT_STATE="Disabled"
-    fi
-    echo "Gnome-VRR is currently ${CURRENT_STATE}"
-    echo "Enable or Disable Gnome-VRR"
-    OPTION=$(Choose Enable Disable)
-    CURRENT_SETTINGS=($(gsettings get org.gnome.mutter experimental-features | tr -d "[]'," | xargs -n1))
-    if [[ "${OPTION,,}" =~ ^enable ]]; then
-        echo "Enabling Gnome-VRR"
-        CURRENT_SETTINGS+=("variable-refresh-rate")
-        FINAL_ARRAY=()
-        for item in "${CURRENT_SETTINGS[@]}"; do
-            FINAL_ARRAY+=("\"$item\"")
-        done
-        FINAL=$(printf "[%s]\n" "$(IFS=,; echo "${FINAL_ARRAY[*]}")")
-        gsettings set org.gnome.mutter experimental-features "${FINAL}"
-    fi
-    if [[ "${OPTION,,}" =~ ^disable ]]; then
-        echo "Disabling Gnome-VRR"
-        NO_VRR_ARRAY=($(printf "%s\n" "${CURRENT_SETTINGS[@]}" | grep -v "variable-refresh-rate"))
-        FINAL_ARRAY=()
-        for item in "${NO_VRR_ARRAY[@]}"; do
-            FINAL_ARRAY+=("\"$item\"")
-        done
-        FINAL=$(printf "[%s]\n" "$(IFS=,; echo "${FINAL_ARRAY[*]}")")
-        gsettings set org.gnome.mutter experimental-features "${FINAL}"
-    fi
-    echo "To apply the changes make sure you logout and restart your session"
-
 # Ptyxis terminal transparency
 [group('System')]
 ptyxis-transparency opacity="0.95":

--- a/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -66,7 +66,6 @@ sort-directories-first=true
 sort-directories-first=true
 
 [org.gnome.mutter]
-experimental-features=['scale-monitor-framebuffer', 'xwayland-native-scaling']
 check-alive-timeout=uint32 20000
 
 [org.gnome.software]


### PR DESCRIPTION
Nvidia driver documentation specifies that the mutter experimental feature 'kms-modifiers' should be set when using the driver.

This condtionally sets this feature on Bvidia image builds.

Also, removes the ujust toggle-vrr recipe since if used it would lose this setting and vrr is now default on our images anyway.

Closes: #1567

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
