### PR TITLE
chore: show nvidia version in changelog

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -61,6 +61,7 @@ From previous `{target}` version `{prev}` there have been the following changes.
 | **KDE** | {pkgrel:plasma-desktop} |
 | **Mesa** | {pkgrel:mesa-filesystem} |
 | **Podman** | {pkgrel:podman} |
+| **Nvidia** | {pkgrel:nvidia-driver} |
 
 ### Major DX packages
 | Name | Version |
@@ -99,7 +100,8 @@ BLACKLIST_VERSIONS = [
     "podman",
     "docker-ce",
     "incus",
-    "devpod"
+    "devpod",
+    "nvidia-driver"
 ]
 
 


### PR DESCRIPTION
This PR adds the `nvidia-driver` version on top of the major packages list as requested in https://github.com/ublue-os/bluefin/issues/1981 and results in the following table:

### Major packages
| Name | Version |
| --- | --- |
| **Kernel** | 6.11.3-300 |
| **Gnome** | 47.1.1-1 |
| **KDE** | 6.2.3-1 |
| **Mesa** | 24.2.4-1 |
| **Podman** | 5.3.0-1 |
| **Nvidia** | 565.57.01-4 |

