### PR TITLE
chore: remove 'ujust ollama' from motd tips

### DIFF
--- a/system_files/shared/usr/share/ublue-os/motd/tips/10-tips.md
+++ b/system_files/shared/usr/share/ublue-os/motd/tips/10-tips.md
@@ -8,7 +8,6 @@ Update break something? You can roll back with `sudo bootc rollback`
 Use `brew search` and `brew install` to install packages. Bluefin will take care of the updates automatically
 Use `Ctrl`-`Alt`-`T` to quickly open a terminal
 Tailscale is included, check out [their docs](https://tailscale.com/kb/1017/install)
-Bluefin is your gateway to AI and LLMs | `ujust ollama` to [get started](https://ollama.com/)
 `ujust --choose` will show you each shortcut and the script it's running
 `tldr vim` will give you the basic rundown on commands for a given tool
 `ujust rebase-helper` can help you roll back to a specific image, or to a different channel entirely, check the docs for more info


### PR DESCRIPTION
`ujust ollama` doesn't exist anymore, but I still got a tip to use it. This PR should fix that.