### PR TITLE
fix(ci): remove footguns.

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -159,13 +159,18 @@ def get_manifests(target: str):
 def get_tags(target: str, manifests: dict[str, Any]):
     tags = set()
 
+    first = next(iter(manifests.values()))
+    for tag in first["RepoTags"]:
+        # Tags ending with .0 should not exist
+        if tag.endswith(".0"):
+            continue
+        if re.match(START_PATTERN(target), tag):
+            tags.add(tag)
+
     for manifest in manifests.values():
-        for tag in manifest["RepoTags"]:
-            # Tags ending with .0 should not exist
-            if tag.endswith(".0"):
-                continue
-            if re.match(START_PATTERN(target), tag):
-                tags.add(tag)
+        for tag in list(tags):
+            if tag not in manifest["RepoTags"]:
+                tags.remove(tag)
 
     tags = list(sorted(tags))
     if not len(tags) >= 2:
@@ -390,6 +395,11 @@ def generate_changelog(
     title = CHANGELOG_TITLE.format_map(defaultdict(str, tag=curr, pretty=pretty))
 
     changelog = CHANGELOG_FORMAT
+
+    if target == "gts":
+        changelog = changelog.splitlines()
+        del changelog[9]
+        changelog = '\n'.join(changelog)
 
     changelog = (
         changelog.replace("{handwritten}", handwritten if handwritten else HANDWRITTEN_PLACEHOLDER)

--- a/.github/workflows/build-image-beta.yml
+++ b/.github/workflows/build-image-beta.yml
@@ -12,15 +12,6 @@ on:
     - cron: "40 4 * * 0" # 4:40 UTC Sunday
   workflow_call:
   workflow_dispatch:
-    inputs:
-      brand_name:
-        description: "Image Brand to Build"
-        default: '["bluefin"]'
-        type: choice
-        options:
-          - '["bluefin"]'
-          - '["aurora"]'
-          - '["bluefin", "aurora"]'
 
 jobs:
   build-image-beta:
@@ -30,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        brand_name: ${{ fromJson(inputs.brand_name || '["bluefin", "aurora"]') }}
+        brand_name: ["bluefin", "aurora"]
     with:
       brand_name: ${{ matrix.brand_name }}
       stream_name: beta

--- a/.github/workflows/build-image-latest.yml
+++ b/.github/workflows/build-image-latest.yml
@@ -12,15 +12,6 @@ on:
     - cron: "40 4 * * 0" # 4:40 UTC Sunday
   workflow_call:
   workflow_dispatch:
-    inputs:
-      brand_name:
-        description: "Image Brand to Build"
-        default: '["bluefin"]'
-        type: choice
-        options:
-          - '["bluefin"]'
-          - '["aurora"]'
-          - '["bluefin", "aurora"]'
 
 jobs:
   build-image-latest:
@@ -30,11 +21,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        brand_name: ${{ fromJson(inputs.brand_name || '["bluefin", "aurora"]') }}
+        brand_name: ["bluefin", "aurora"]
     with:
       image_flavors: '["main", "nvidia", "hwe", "hwe-nvidia"]'
       brand_name: ${{ matrix.brand_name }}
       stream_name: latest
+    # This needs splitting, right now a kernel pin will not work due to hwe kernel
 
   generate-release:
     name: Generate Release

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -12,15 +12,6 @@ on:
     - cron: "45 5 * * 0" # 5:41 UTC sunday
   workflow_call:
   workflow_dispatch:
-    inputs:
-      brand_name:
-        description: "Image Brand to Build"
-        default: '["bluefin"]'
-        type: choice
-        options:
-          - '["bluefin"]'
-          - '["aurora"]'
-          - '["bluefin", "aurora"]'
 
 jobs:
   build-image-stable:
@@ -30,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        brand_name: ${{ fromJson(inputs.brand_name || '["bluefin", "aurora"]') }}
+        brand_name: ["bluefin", "aurora"]
     with:
       kernel_pin: 6.11.3-300.fc41.x86_64
       brand_name: ${{ matrix.brand_name }}

--- a/.github/workflows/build-iso-latest.yml
+++ b/.github/workflows/build-iso-latest.yml
@@ -22,6 +22,6 @@ jobs:
       matrix:
         brand_name: ${{ fromJson(inputs.brand_name || '["bluefin", "aurora"]') }}
     with:
-      image_flavors: '["main", "nvidia", "asus", "asus-nvidia", "surface", "surface-nvidia"]'
+      image_flavors: '["main", "nvidia", "hwe", "hwe-nvidia"]'
       brand_name: ${{ matrix.brand_name }}
       stream_name: latest

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -1,10 +1,6 @@
 on:
   workflow_call:
     inputs:
-      make_latest:
-        description: "Make latest for Release"
-        type: string
-        default: 'False'
       stream_name:
         description: "Release Tag (e.g. gts, stable)"
         type: string
@@ -13,13 +9,6 @@ on:
     inputs:
       handwritten:
         description: "Small Changelog about changes in this build"
-      make_latest:
-        description: "Make latest for Release"
-        type: choice
-        default: 'False'
-        options:
-          - 'False'
-          - 'True'
       stream_name:
         description: "Release Tag (e.g. gts, stable)"
         required: true
@@ -28,11 +17,6 @@ on:
           - '["gts", "stable"]'
           - '["gts"]'
           - '["stable"]'
-          # - '["stable-daily"]'
-          # - '["latest"]'
-          # - '["beta"]'
-          # - '["stable-daily", "latest", "beta"]'
-          # - '["gts", "stable", "stable-daily", "latest", "beta"]'
 
 permissions:
   contents: write
@@ -83,5 +67,5 @@ jobs:
           name: ${{ steps.generate-release-text.outputs.title }}
           tag_name: ${{ steps.generate-release-text.outputs.tag }}
           body_path: ./changelog.md
-          make_latest: ${{ inputs.make_latest == 'True' && matrix.version == 'stable' || false }}
-          prerelease: ${{ inputs.make_latest != 'True' }}
+          make_latest: ${{ matrix.version == 'stable' }}
+          prerelease: ${{ matrix.version != 'stable' }}

--- a/.github/workflows/reusable-build-iso.yml
+++ b/.github/workflows/reusable-build-iso.yml
@@ -84,6 +84,20 @@ jobs:
           retention-days: 0
           compression-level: 0
           overwrite: true
+        
+      - name: HWE ISO rename
+        if: contains(matrix.image_flavor, 'hwe')
+        shell: bash
+        run: |
+          set -eoux pipefail
+          iso_name="${{ env.ISO_NAME }}"
+          asus_name="${iso_name/hwe/asus}"
+          surface_name="${iso_name/hwe/surface}"
+          mv "${{ env.ISO_UPLOAD_DIR }}/${iso_name}" "${{ env.ISO_UPLOAD_DIR}}/${asus_name}"
+          mv "${{ env.ISO_UPLOAD_DIR }}/${iso_name}-CHECKSUM" "${{ env.ISO_UPLOAD_DIR}}/${asus_name}-CHECKSUM"
+          cp "${{ env.ISO_UPLOAD_DIR }}/${asus_name}" "${{ env.ISO_UPLOAD_DIR}}/${surface_name}"
+          cp "${{ env.ISO_UPLOAD_DIR }}/${asus_name}-CHECKSUM" "${{ env.ISO_UPLOAD_DIR}}/${surface_name}-CHECKSUM"
+          tree "${{ env.ISO_UPLOAD_DIR }}"
 
       - name: Upload ISOs and Checksum to R2 to Bluefin Bucket
         if: github.ref_name == 'main' && contains(matrix.base_name,'bluefin')

--- a/.github/workflows/reusable-build-iso.yml
+++ b/.github/workflows/reusable-build-iso.yml
@@ -93,11 +93,11 @@ jobs:
           iso_name="${{ env.ISO_NAME }}"
           asus_name="${iso_name/hwe/asus}"
           surface_name="${iso_name/hwe/surface}"
-          mv "${{ env.ISO_UPLOAD_DIR }}/${iso_name}" "${{ env.ISO_UPLOAD_DIR}}/${asus_name}"
-          mv "${{ env.ISO_UPLOAD_DIR }}/${iso_name}-CHECKSUM" "${{ env.ISO_UPLOAD_DIR}}/${asus_name}-CHECKSUM"
-          cp "${{ env.ISO_UPLOAD_DIR }}/${asus_name}" "${{ env.ISO_UPLOAD_DIR}}/${surface_name}"
-          cp "${{ env.ISO_UPLOAD_DIR }}/${asus_name}-CHECKSUM" "${{ env.ISO_UPLOAD_DIR}}/${surface_name}-CHECKSUM"
-          tree "${{ env.ISO_UPLOAD_DIR }}"
+          mv "${{ steps.upload-directory.outputs.iso-upload-dir }}/${iso_name}" "${{ steps.upload-directory.outputs.iso-upload-dir}}/${asus_name}"
+          mv "${{ steps.upload-directory.outputs.iso-upload-dir }}/${iso_name}-CHECKSUM" "${{ steps.upload-directory.outputs.iso-upload-dir}}/${asus_name}-CHECKSUM"
+          cp "${{ steps.upload-directory.outputs.iso-upload-dir }}/${asus_name}" "${{ steps.upload-directory.outputs.iso-upload-dir}}/${surface_name}"
+          cp "${{ steps.upload-directory.outputs.iso-upload-dir }}/${asus_name}-CHECKSUM" "${{ steps.upload-directory.outputs.iso-upload-dir}}/${surface_name}-CHECKSUM"
+          tree "${{ steps.upload-directory.outputs.iso-upload-dir }}"
 
       - name: Upload ISOs and Checksum to R2 to Bluefin Bucket
         if: github.ref_name == 'main' && contains(matrix.base_name,'bluefin')


### PR DESCRIPTION
Removes a few footguns with our CI.

1. Disable building bluefin/aurora separate from each other to avoid a release saying an image exists.
2. Remove having to manually run generate-release to actually have latest get tagged in releases
3. Changelogs remove KDE in gts images and make sure tag exists in all images.
4. Build ISOs tries to not run as many images and use hwe images.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
