### PR TITLE
fix: remove pkcs11-provider workaround

### DIFF
--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -10,6 +10,10 @@ fi
 
 ## Pins and Overrides
 ## Use this section to pin packages in order to avoid regressions
-if [ "$FEDORA_MAJOR_VERSION" -eq "41" ]; then
-    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225    
-fi
+# Remember to leave a note with rationale/link to issue for each pin! 
+#
+# Example:
+#if [ "$FEDORA_MAJOR_VERSION" -eq "41" ]; then
+#    Workaround pkcs11-provider regression, see issue #1943
+#    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225    
+#fi


### PR DESCRIPTION
Fedora has rolled back the problematic issue:

https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225  

Additionally I've left this one as a commented out example for future pins. 

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
