### PR TITLE
chore(containers, dx): move remaining container things over to -dx

### DIFF
--- a/aurora_flatpaks/flatpaks
+++ b/aurora_flatpaks/flatpaks
@@ -10,7 +10,6 @@ app/org.fkoehler.KTailctl/x86_64/stable
 app/org.kde.haruna/x86_64/stable
 app/org.kde.filelight/x86_64/stable
 app/com.github.tchx84.Flatseal/x86_64/stable
-app/io.github.dvlv.boxbuddyrs/x86_64/stable
 app/io.github.flattool.Warehouse/x86_64/stable
 app/org.fedoraproject.MediaWriter/x86_64/stable
 app/io.missioncenter.MissionCenter/x86_64/stable

--- a/bluefin_flatpaks/flatpaks
+++ b/bluefin_flatpaks/flatpaks
@@ -1,4 +1,3 @@
-app/io.github.dvlv.boxbuddyrs/x86_64/stable
 app/com.github.rafostar.Clapper/x86_64/stable
 app/org.fedoraproject.MediaWriter/x86_64/stable
 app/com.github.tchx84.Flatseal/x86_64/stable

--- a/dx_flatpaks/flatpaks
+++ b/dx_flatpaks/flatpaks
@@ -1,1 +1,2 @@
 app/io.podman_desktop.PodmanDesktop/x86_64/stable
+app/io.github.dvlv.boxbuddyrs/x86_64/stable

--- a/system_files/dx/etc/dconf/db/distro.d/05-dx-logomenu-extension
+++ b/system_files/dx/etc/dconf/db/distro.d/05-dx-logomenu-extension
@@ -1,0 +1,5 @@
+# Relocatable schemas are located here in dconf
+# Some Gnome extensions don't ship gschema XML, so their settings also need to go in dconf
+
+[org/gnome/shell/extensions/Logo-menu]
+show-boxbuddy=true

--- a/system_files/dx/usr/share/glib-2.0/schemas/zz1-dx-modifications.gschema.override
+++ b/system_files/dx/usr/share/glib-2.0/schemas/zz1-dx-modifications.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.shell.extensions.Logo-menu]
+show-boxbuddy=true

--- a/system_files/silverblue/etc/dconf/db/distro.d/04-bluefin-logomenu-extension
+++ b/system_files/silverblue/etc/dconf/db/distro.d/04-bluefin-logomenu-extension
@@ -13,4 +13,3 @@ show-lockscreen=false
 show-power-option=false
 show-gamemode=false
 hide-forcequit=true
-show-boxbuddy=true

--- a/system_files/silverblue/etc/dconf/db/distro.d/05-dx-logomenu-extension
+++ b/system_files/silverblue/etc/dconf/db/distro.d/05-dx-logomenu-extension
@@ -1,0 +1,5 @@
+# Relocatable schemas are located here in dconf
+# Some Gnome extensions don't ship gschema XML, so their settings also need to go in dconf
+
+[org/gnome/shell/extensions/Logo-menu]
+show-boxbuddy=true

--- a/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -91,7 +91,6 @@ show-lockscreen=false
 show-power-option=false
 show-gamemode=false
 hide-forcequit=true
-show-boxbuddy=true
 
 [org.gnome.shell.extensions.search-light]
 shortcut-search=['<Super>space']


### PR DESCRIPTION
This PR aims to move all the remaining container-related things over to -dx, for now I moved BoxBuddy but idk what else should be moved. (also needs some local testing still.)

Related: #1321
