### PR TITLE
feat(packages): add google-noto-fonts-all

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -206,7 +206,7 @@
 	"41": {
 		"include": {
 			"all": [
-				"google-noto-fonts-all",
+				"google-noto-fonts-all"
 			],
 			"kinoite": [
 				"ptyxis"

--- a/packages.json
+++ b/packages.json
@@ -205,7 +205,9 @@
 	},
 	"41": {
 		"include": {
-			"all": [],
+			"all": [
+				"google-noto-fonts-all",
+			],
 			"kinoite": [
 				"ptyxis"
 			],


### PR DESCRIPTION
This should fix some weird font issues that I had discussed with @RoyalOughtness. 

For example, if you open up [this post](https://www.reddit.com/r/CrestedGecko/comments/1anzfkz/%E1%A5%B2_%E1%A5%A3%E1%A5%86%F0%9D%97%8D_%E1%A5%86%F0%9D%96%BF_%E1%A5%B1%E1%A5%86%E1%A5%A3%E1%A5%B1_%E1%A5%95%E1%A5%86%E1%A5%92%E1%83%AB%E1%A5%B1r_%E1%A5%95%D2%BB%E1%A5%A1_z%D1%96gg%E1%A5%A1_%D1%96s_s%E1%A5%86_%E1%A5%B4%E1%A5%B2%E1%A5%A3m_%E1%A5%B2%E1%A5%92%E1%83%AB/) on bluefin currently the weird font just breaks everything. This PR is meant to fix stuff like that, although maybe this might be an edge case that does not need to be addressed
