### PR TITLE
fix: remove background-logo extension, restore gnome-tour

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -173,9 +173,9 @@
 			],
 			"silverblue": [
 				"gnome-extensions-app",
+				"gnome-shell-extension-background-logo",
 				"gnome-software-rpm-ostree",
-				"gnome-terminal-nautilus",
-				"gnome-tour"
+				"gnome-terminal-nautilus"
 			],
 			"kinoite": [
 				"krfb",


### PR DESCRIPTION
This was mentioned in a review and I had forgotten about this thing and we don't use it so removing it.

Also the newer versions of gnome-tour are much nicer than the old ones so restoring this, it's a one time thing for new users.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
