### PR TITLE
feat: accent color theming for fastfetch and MOTD

### DIFF
--- a/system_files/kinoite/etc/profile.d/aurora-fastfetch.sh
+++ b/system_files/kinoite/etc/profile.d/aurora-fastfetch.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/sh
 
-alias fastfetch="/usr/bin/fastfetch --file /usr/share/ublue-os/aurora-logo.txt --logo-type file --logo-color-1 94 --logo-color-2 95 --logo-color-3 91  --logo-color-4 97 -c /usr/share/ublue-os/ublue-os.jsonc"
+alias fastfetch='/usr/bin/fastfetch --color $(/usr/libexec/ublue-bling-fastfetch) --file /usr/share/ublue-os/aurora-logo.txt --logo-type file --logo-color-1 94 --logo-color-2 95 --logo-color-3 91  --logo-color-4 97 -c /usr/share/ublue-os/ublue-os.jsonc'

--- a/system_files/kinoite/usr/share/fish/vendor_conf.d/aurora-fastfetch.fish
+++ b/system_files/kinoite/usr/share/fish/vendor_conf.d/aurora-fastfetch.fish
@@ -1,3 +1,3 @@
 #!/usr/bin/fish
 #shellcheck disable=all
-alias fastfetch="/usr/bin/fastfetch --file /usr/share/ublue-os/aurora-logo.txt --logo-type file --logo-color-1 94 --logo-color-2 95 --logo-color-3 91  --logo-color-4 97 -c /usr/share/ublue-os/ublue-os.jsonc"
+alias fastfetch='/usr/bin/fastfetch --color (/usr/libexec/ublue-bling-fastfetch) --file /usr/share/ublue-os/aurora-logo.txt --logo-type file --logo-color-1 94 --logo-color-2 95 --logo-color-3 91  --logo-color-4 97 -c /usr/share/ublue-os/ublue-os.jsonc'

--- a/system_files/shared/usr/libexec/ublue-bling-fastfetch
+++ b/system_files/shared/usr/libexec/ublue-bling-fastfetch
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+THEME=$(gsettings get org.gnome.desktop.interface accent-color || echo "'slate'")
+THEME=${THEME//\'/}
+
+FASTFETCH_COLOR_SET="38;2;53;132;228"
+case $THEME in
+  "blue")
+    FASTFETCH_COLOR_SET="38;2;53;132;228"
+    ;;
+  "green")
+    FASTFETCH_COLOR_SET="38;2;58;148;74"
+    ;;
+  "orange")
+    FASTFETCH_COLOR_SET="38;2;237;91;0"
+    ;;
+  "pink")
+    FASTFETCH_COLOR_SET="38;2;213;97;153"
+    ;;
+  "purple")
+    FASTFETCH_COLOR_SET="38;2;139;62;165"
+    ;;
+  "red")
+    FASTFETCH_COLOR_SET="38;2;230;45;66"
+    ;;
+  "slate")
+    FASTFETCH_COLOR_SET="38;2;111;131;150"
+    ;;
+  "teal")
+    FASTFETCH_COLOR_SET="38;2;33;144;164"
+    ;;
+  "yellow")
+    FASTFETCH_COLOR_SET="38;2;200;136;0"
+    ;;
+esac
+
+echo $FASTFETCH_COLOR_SET
+exit 0

--- a/system_files/shared/usr/libexec/ublue-motd
+++ b/system_files/shared/usr/libexec/ublue-motd
@@ -30,8 +30,11 @@ KEY_WARN_FILE="/run/user-motd-sbkey-warn.md"
 [ -e $KEY_WARN_FILE ] && KEY_WARN="**WARNING**: $(cat $KEY_WARN_FILE)"
 KEY_WARN_ESCAPED=$(escape "$KEY_WARN")
 
+THEME=$(gsettings get org.gnome.desktop.interface accent-color || echo "'slate'")
+THEME=${THEME//\'/}
+
 sed -e "s/%IMAGE_NAME%/$IMAGE_NAME_ESCAPED/g" \
 	-e "s/%IMAGE_TAG%/$IMAGE_TAG_ESCAPED/g" \
 	-e "s/%TIP%/$TIP_ESCAPED/g" \
 	-e "s/%KEY_WARN%/$KEY_WARN_ESCAPED/g" \
-	/usr/share/ublue-os/motd/bluefin.md | tr '~' '\n' | /usr/bin/glow -s auto -w 78 -
+	/usr/share/ublue-os/motd/bluefin.md | tr '~' '\n' | /usr/bin/glow -s /usr/share/ublue-os/motd/themes/$THEME.json -w 78 -

--- a/system_files/shared/usr/share/ublue-os/motd/themes/blue.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/blue.json
@@ -1,0 +1,90 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "33",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "33",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "69",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "33",
+    "background_color": "236"
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/system_files/shared/usr/share/ublue-os/motd/themes/green.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/green.json
@@ -1,0 +1,90 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "34",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "34",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "28",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "34",
+    "background_color": "236"
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/system_files/shared/usr/share/ublue-os/motd/themes/orange.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/orange.json
@@ -1,0 +1,90 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "208",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "208",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "130",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "208",
+    "background_color": "236"
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/system_files/shared/usr/share/ublue-os/motd/themes/pink.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/pink.json
@@ -1,0 +1,90 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "212",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "212",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "163",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "212",
+    "background_color": "236"
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/system_files/shared/usr/share/ublue-os/motd/themes/purple.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/purple.json
@@ -1,0 +1,90 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "165",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "165",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "164",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "165",
+    "background_color": "236"
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/system_files/shared/usr/share/ublue-os/motd/themes/red.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/red.json
@@ -1,0 +1,90 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "203",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "203",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "124",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "203",
+    "background_color": "236"
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/system_files/shared/usr/share/ublue-os/motd/themes/slate.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/slate.json
@@ -1,0 +1,90 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "104",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "104",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "104",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "250",
+    "background_color": "236"
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/system_files/shared/usr/share/ublue-os/motd/themes/teal.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/teal.json
@@ -1,0 +1,90 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "44",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "44",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "38",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "44",
+    "background_color": "236"
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/system_files/shared/usr/share/ublue-os/motd/themes/yellow.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/yellow.json
@@ -1,0 +1,90 @@
+{
+  "document": {
+    "margin": 2
+  },
+  "block_quote": {
+    "indent": 1,
+    "indent_token": "│ "
+  },
+  "paragraph": {},
+  "list": {
+    "level_indent": 2
+  },
+  "heading": {
+    "block_suffix": "\n",
+    "color": "220",
+    "bold": true
+  },
+  "h1": {
+    "block_prefix": "\n",
+    "block_suffix": "\n"
+  },
+  "h2": {
+    "prefix": "▌ "
+  },
+  "h3": {
+    "prefix": "┃ "
+  },
+  "h4": {
+    "prefix": "│ "
+  },
+  "h5": {
+    "prefix": "┆ "
+  },
+  "h6": {
+    "prefix": "┊ ",
+    "bold": false
+  },
+  "text": {},
+  "strikethrough": {
+    "crossed_out": true
+  },
+  "emph": {
+    "italic": true
+  },
+  "strong": {
+    "bold": true
+  },
+  "hr": {
+    "color": "220",
+    "format": "\n──────\n"
+  },
+  "item": {
+    "block_prefix": "• "
+  },
+  "enumeration": {
+    "block_prefix": ". "
+  },
+  "task": {
+    "ticked": "[✓] ",
+    "unticked": "[ ] "
+  },
+  "link": {
+    "color": "178",
+    "underline": true
+  },
+  "link_text": {
+    "bold": true
+  },
+  "image": {
+    "underline": true
+  },
+  "image_text": {
+    "format": "Image: {{.text}}"
+  },
+  "code": {
+    "prefix": " ",
+    "suffix": " ",
+    "color": "220",
+    "background_color": "236"
+  },
+  "code_block": {},
+  "table": {},
+  "definition_list": {},
+  "definition_term": {},
+  "definition_description": {
+    "block_prefix": "\n🠶 "
+  },
+  "html_block": {},
+  "html_span": {}
+}

--- a/system_files/silverblue/etc/fish/conf.d/bluefin-fastfetch.fish
+++ b/system_files/silverblue/etc/fish/conf.d/bluefin-fastfetch.fish
@@ -2,5 +2,5 @@
 #shellcheck disable=all
 function fastfetch
     set BLUEFIN_FETCH_LOGO (/usr/bin/find "/usr/share/ublue-os/bluefin-logos/symbols/" -mindepth 1 | /usr/bin/shuf -n 1)
-    /usr/bin/fastfetch --logo $BLUEFIN_FETCH_LOGO -c "/usr/share/ublue-os/ublue-os.jsonc"
+    /usr/bin/fastfetch --logo $BLUEFIN_FETCH_LOGO --color (/usr/libexec/ublue-bling-fastfetch) -c "/usr/share/ublue-os/ublue-os.jsonc"
 end

--- a/system_files/silverblue/etc/profile.d/bluefin-fastfetch.sh
+++ b/system_files/silverblue/etc/profile.d/bluefin-fastfetch.sh
@@ -2,4 +2,4 @@
 
 BLUEFIN_FETCH_LOGO="$(/usr/bin/find /usr/share/ublue-os/bluefin-logos/symbols/* | /usr/bin/shuf -n 1 )"
 
-alias fastfetch='/usr/bin/fastfetch --logo ${BLUEFIN_FETCH_LOGO}  -c /usr/share/ublue-os/ublue-os.jsonc'
+alias fastfetch='/usr/bin/fastfetch --logo ${BLUEFIN_FETCH_LOGO} --color $(/usr/libexec/ublue-bling-fastfetch) -c /usr/share/ublue-os/ublue-os.jsonc'


### PR DESCRIPTION
This PR adds support for accent color theming on the MOTD and fastfetch for Aurora and Bluefin

MOTD:
[aurora-motd.webm](https://github.com/user-attachments/assets/df4fd87c-091a-452e-b762-e05be23f19f2)
[bluefin-motd.webm](https://github.com/user-attachments/assets/6bb0c818-12ed-4d60-b6f3-01184edf1919)

Fastfetch:
[aurora-neofetch.webm](https://github.com/user-attachments/assets/379028d1-103d-41e7-8be4-2e3eb9d6566f)
![bluefin-neofetch.webm](https://github.com/user-attachments/assets/7c5363e1-931c-43fb-9e2a-4000e4ff26a8)

