### PR TITLE
fix(motd): use bold for color blocks instead of background color

### DIFF
--- a/system_files/shared/usr/share/ublue-os/motd/themes/blue.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/blue.json
@@ -74,7 +74,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "background_color": "236"
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/shared/usr/share/ublue-os/motd/themes/green.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/green.json
@@ -74,7 +74,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "background_color": "236"
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/shared/usr/share/ublue-os/motd/themes/orange.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/orange.json
@@ -74,7 +74,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "background_color": "236"
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/shared/usr/share/ublue-os/motd/themes/pink.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/pink.json
@@ -74,7 +74,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "background_color": "236"
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/shared/usr/share/ublue-os/motd/themes/purple.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/purple.json
@@ -74,7 +74,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "background_color": "236"
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/shared/usr/share/ublue-os/motd/themes/red.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/red.json
@@ -74,7 +74,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "background_color": "236"
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/shared/usr/share/ublue-os/motd/themes/slate.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/slate.json
@@ -74,7 +74,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "background_color": "236"
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/shared/usr/share/ublue-os/motd/themes/teal.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/teal.json
@@ -74,7 +74,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "background_color": "236"
+    "bold": true
   },
   "code_block": {},
   "table": {},

--- a/system_files/shared/usr/share/ublue-os/motd/themes/yellow.json
+++ b/system_files/shared/usr/share/ublue-os/motd/themes/yellow.json
@@ -74,7 +74,7 @@
   "code": {
     "prefix": " ",
     "suffix": " ",
-    "background_color": "236"
+    "bold": true
   },
   "code_block": {},
   "table": {},


### PR DESCRIPTION
This is kind of a workaround but it works perfectly well. It just makes it so light and dark themes look the same!!! LES GOOOO this should be the last fix for the MOTD
