### PR TITLE
fix: remove Alt-F5 from GNOME unmaximize keybinding

### DIFF
--- a/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
+++ b/system_files/silverblue/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override
@@ -37,6 +37,7 @@ switch-windows=['<Alt>Tab']
 switch-windows-backward=['<Shift><Alt>Tab']
 switch-input-source=['<Shift><Super>space']
 switch-input-source-backward=['']
+unmaximize=['<Super>Down']
 
 [org.gnome.desktop.peripherals.keyboard]
 numlock-state=true


### PR DESCRIPTION
GNOME Settings only shows '\<Super\>Down' as the "unmaximize" keybinding however, '\<Alt\>F5' is also there as a hidden default.

This is confusing enough, but the real trouble is this keybinding conflicts with VSCode's default "next diff" shortcut.

As this hidden shortcut seems somewhat deprecated and conflicts with VSCode, which we ship in DX, I'm removing it.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
