### PR TITLE
fix(dx): disable kvmfr and podman-bootc repos on cleanup

### DIFF
--- a/build_files/dx/09-cleanup-dx.sh
+++ b/build_files/dx/09-cleanup-dx.sh
@@ -18,6 +18,8 @@ fi
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/ganto-umoci-fedora-"${FEDORA_MAJOR_VERSION}".repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/karmab-kcli-fedora-"${FEDORA_MAJOR_VERSION}".repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/atim-ubuntu-fonts-fedora-"${FEDORA_MAJOR_VERSION}".repo
+sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/hikariknight-looking-glass-kvmfr-fedora-"${FEDORA_MAJOR_VERSION}".repo
+sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/gmaglione-podman-bootc-fedora-"${FEDORA_MAJOR_VERSION}".repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/vscode.repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/docker-ce.repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr:copr.fedorainfracloud.org:phracek:PyCharm.repo


### PR DESCRIPTION
kvmfr and podman-bootc repos are currently not being disabled in the cleanup stage