### PR TITLE
fix: hide accent-color errors

### DIFF
--- a/system_files/shared/usr/libexec/ublue-bling-fastfetch
+++ b/system_files/shared/usr/libexec/ublue-bling-fastfetch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-THEME=$(gsettings get org.gnome.desktop.interface accent-color || echo "'slate'")
+THEME=$(gsettings get org.gnome.desktop.interface accent-color 2>/dev/null || echo "'slate'")
 THEME=${THEME//\'/}
 
 FASTFETCH_COLOR_SET="38;2;53;132;228"

--- a/system_files/shared/usr/libexec/ublue-motd
+++ b/system_files/shared/usr/libexec/ublue-motd
@@ -30,7 +30,7 @@ KEY_WARN_FILE="/run/user-motd-sbkey-warn.md"
 [ -e $KEY_WARN_FILE ] && KEY_WARN="**WARNING**: $(cat $KEY_WARN_FILE)"
 KEY_WARN_ESCAPED=$(escape "$KEY_WARN")
 
-THEME=$(gsettings get org.gnome.desktop.interface accent-color || echo "'slate'")
+THEME=$(gsettings get org.gnome.desktop.interface accent-color 2>/dev/null || echo "'slate'")
 THEME=${THEME//\'/}
 THEME=${MOTD_FORCE_THEME:-$THEME}
 


### PR DESCRIPTION
Redirecting the error output to /dev/null. 

Since this is my first PR on uBlue I wanted to ask if the changes will reflect on Aurora and Bazzite? I assume that I have to open a PR on Bazzite too.