### PR TITLE
feat: tell dash-to-dock to use the built-in theme

### DIFF
--- a/system_files/silverblue/etc/dconf/db/distro.d/06-bluefin-dash-to-dock-extension
+++ b/system_files/silverblue/etc/dconf/db/distro.d/06-bluefin-dash-to-dock-extension
@@ -1,0 +1,5 @@
+# Relocatable schemas are located here in dconf
+# Some Gnome extensions don't ship gschema XML, so their settings also need to go in dconf
+
+[org/gnome/shell/extensions/dash-to-dock]
+apply-custom-theme=true


### PR DESCRIPTION
This defers to blur-my-shell, leading to a more polished dock/dash

