### PR TITLE
fix: return on bling.sh if it already got sourced

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bluefin-cli/bling.sh
+++ b/system_files/shared/usr/share/ublue-os/bluefin-cli/bling.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# Check if bling has already been sourced so that we dont break atuin. https://github.com/atuinsh/atuin/issues/380#issuecomment-1594014644
+[ "${BLING_SOURCED:-0}" -eq 1 ] && return 
+BLING_SOURCED=1
+
 # ls aliases
 if [ "$(command -v eza)" ]; then
     alias ll='eza -l --icons=auto --group-directories-first'


### PR DESCRIPTION
This should just return early return if the script has already been sourced, this should be tested by someone else just to make sure!!!
![image](https://github.com/user-attachments/assets/2172a33a-55ed-4692-bb95-9eaa4f7a0b65)

