### PR TITLE
fix(ujust, benchmark): make benchmark be run on unique path on tmp

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -13,7 +13,10 @@
 # Run a one minute system benchmark
 [group('System')]
 benchmark:
-    @echo 'Running a 1 minute benchmark ...'
+    #!/usr/bin/env bash
+    echo 'Running a 1 minute benchmark ...'
+    trap popd EXIT
+    pushd $(mktemp -d)
     stress-ng --matrix 0 -t 1m --times
 
 # Configure Bluefin-CLI Terminal Experience with Brew


### PR DESCRIPTION
This should guarantee the tmp directory does not conflict with something else while also being writeable. Fixes: #2060