### PR TITLE
feat(hwe-additions): Load pinctrl for more Surface devices

### DIFF
--- a/build_files/base/09-hwe-additions.sh
+++ b/build_files/base/09-hwe-additions.sh
@@ -58,10 +58,19 @@ pinctrl_amd
 intel_lpss
 intel_lpss_pci
 
+# Surface Book 2
+pinctrl_sunrisepoint
+
 # For Surface Laptop 3/Surface Book 3
 pinctrl_icelake
 
 # For Surface Laptop 4/Surface Laptop Studio
 pinctrl_tigerlake
+
+# For Surface Pro 9/Surface Laptop 5
+pinctrl_alderlake
+
+# For Surface Pro 10/Surface Laptop 6
+pinctrl_meteorlake
 EOF
 


### PR DESCRIPTION
Support GPIO pins on the Surface Book 2, Surface Pro 9/10, and Surface Laptop 5/6
