### PR TITLE
chore(build-dx): Clean up pretty name in OS release info

### DIFF
--- a/build_files/shared/build-dx.sh
+++ b/build_files/shared/build-dx.sh
@@ -28,7 +28,7 @@ sysctl -p
 /ctx/build_files/dx/04-override-install-dx.sh
 
 # Branding Changes
-sed -i '/^PRETTY_NAME/s/Bluefin/Bluefin-dx/' /usr/lib/os-release
+sed -i '/^PRETTY_NAME/s/Bluefin/Bluefin DX/' /usr/lib/os-release
 
 # Systemd and Disable Repos
 /ctx/build_files/dx/09-cleanup-dx.sh

--- a/build_files/shared/build-dx.sh
+++ b/build_files/shared/build-dx.sh
@@ -28,7 +28,7 @@ sysctl -p
 /ctx/build_files/dx/04-override-install-dx.sh
 
 # Branding Changes
-sed -i '/^PRETTY_NAME/s/Bluefin/Bluefin DX/' /usr/lib/os-release
+sed -i '/^PRETTY_NAME/s/Bluefin/Bluefin/' /usr/lib/os-release
 
 # Systemd and Disable Repos
 /ctx/build_files/dx/09-cleanup-dx.sh

--- a/build_files/shared/build-dx.sh
+++ b/build_files/shared/build-dx.sh
@@ -27,9 +27,6 @@ sysctl -p
 # Fetch Install
 /ctx/build_files/dx/04-override-install-dx.sh
 
-# Branding Changes
-sed -i '/^PRETTY_NAME/s/Bluefin/Bluefin/' /usr/lib/os-release
-
 # Systemd and Disable Repos
 /ctx/build_files/dx/09-cleanup-dx.sh
 


### PR DESCRIPTION
Remove -dx from the pretty name in OS release info to consolidate brew stats given it is a mode and not a variant