### PR TITLE
fix: pin to 6..8.11 kernel

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         brand_name: [bluefin]
     with:
-#     kernel_pin: 6.11.3-200.fc40.x86_64     ## This is where kernels get pinned.
+      kernel_pin: 6.11.8-200.fc40.x86_64     ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: gts
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      #     kernel_pin: 6.11.3-300.fc41.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.11.8-300.fc41.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Fixes #2103 - hopefully we can avoid this entirely. 