### PR TITLE
chore: remove systemd unit disable for unknown services on bluefin-dx

### DIFF
--- a/build_files/dx/09-cleanup-dx.sh
+++ b/build_files/dx/09-cleanup-dx.sh
@@ -8,7 +8,6 @@ systemctl enable swtpm-workaround.service
 systemctl enable libvirt-workaround.service
 systemctl enable bluefin-dx-groups.service
 systemctl enable --global bluefin-dx-user-vscode.service
-systemctl disable pmlogger.service
 
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo
 if [[ -f /etc/yum.repos.d/ganto-lxc4-fedora-"${FEDORA_MAJOR_VERSION}".repo ]]; then

--- a/build_files/dx/09-cleanup-dx.sh
+++ b/build_files/dx/09-cleanup-dx.sh
@@ -8,7 +8,6 @@ systemctl enable swtpm-workaround.service
 systemctl enable libvirt-workaround.service
 systemctl enable bluefin-dx-groups.service
 systemctl enable --global bluefin-dx-user-vscode.service
-systemctl disable pmie.service
 systemctl disable pmlogger.service
 
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/ublue-os-staging-fedora-"${FEDORA_MAJOR_VERSION}".repo


### PR DESCRIPTION
There are no units named `pmie.service` or `pmlogger.service`. Trying to disable them is throwing errors that these units do not exist when building dx variants.

Stable: https://github.com/ublue-os/bluefin/actions/runs/12604017907/job/35130160146

```
2025-01-03T21:38:43.1653202Z + systemctl disable pmie.service
2025-01-03T21:38:43.1774426Z Failed to disable unit: Unit pmie.service does not exist
2025-01-03T21:38:43.1775098Z Failed to disable unit: Unit pmie.service does not exist
2025-01-03T21:38:43.1783989Z + systemctl disable pmlogger.service
2025-01-03T21:38:43.1904775Z Failed to disable unit: Unit pmlogger.service does not exist
2025-01-03T21:38:43.1905417Z Failed to disable unit: Unit pmlogger.service does not exist
```

GTS: https://github.com/ublue-os/bluefin/actions/runs/12532949173/job/34952152148
```
2024-12-29T06:03:04.6735521Z + systemctl disable pmie.service
2024-12-29T06:03:04.6857150Z Failed to disable unit, unit pmie.service does not exist.
2024-12-29T06:03:04.6857921Z Failed to disable unit, unit pmie.service does not exist.
2024-12-29T06:03:04.6869052Z + systemctl disable pmlogger.service
2024-12-29T06:03:04.6989691Z Failed to disable unit, unit pmlogger.service does not exist.
2024-12-29T06:03:04.6990463Z Failed to disable unit, unit pmlogger.service does not exist.
```