### PR TITLE
chore(ci): Add artifacthub metadata

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,4 +1,4 @@
-repositoryID: 1196b123-c8db-4a49-bae5-cd046daddafa
+repositoryID: 6f68e5bb-ffaf-4a70-9c1b-b154b772044e
 owners: # (optional, used to claim repository ownership)
   - name: Jorge Castro
     email: jorge.castro@gmail.com


### PR DESCRIPTION
This is tied to my artifacthub account to get bazzite listed as verified with the ublue org. Tulip will have a follow up PR with metadata updates for the container build.

Readme has rendering issues but that's a seperate problem: https://artifacthub.io/packages/container/bazzite/bazzite

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
