### PR TITLE
fix: move powertop to all images

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -130,7 +130,6 @@
 				"podman-tui",
 				"podmansh",
 				"powerline-fonts",
-				"powertop",
 				"qemu-char-spice",
 				"qemu-device-display-virtio-gpu",
 				"qemu-device-display-virtio-vga",

--- a/packages.json
+++ b/packages.json
@@ -38,6 +38,7 @@
 				"opendyslexic-fonts",
 				"printer-driver-brlaser",
 				"pulseaudio-utils",
+				"powertop",
 				"python3-pip",
 				"rclone",
 				"restic",


### PR DESCRIPTION
People without dx should be able to use this.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
