### PR TITLE
fix: Framework 13 AMD support

### DIFF
--- a/system_files/shared/usr/libexec/ublue-system-setup
+++ b/system_files/shared/usr/libexec/ublue-system-setup
@@ -9,7 +9,7 @@ VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
 CPU_VENDOR=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
 
 # SCRIPT VERSION
-HWS_VER=3
+HWS_VER=4
 HWS_VER_FILE="/etc/ublue/hws_version"
 [[ -f "$HWS_VER_FILE" ]] && HWS_VER_RAN=$(cat $HWS_VER_FILE)
 
@@ -63,9 +63,11 @@ else
   echo "No karg changes needed"
 fi
 
+SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
+
 # FRAMEWORK 13 AMD FIXES
 if [[ ":Framework:" =~ ":$VEN_ID:" ]]; then
-  if [[ $SYS_ID == "Laptop ("* ]]; then
+  if [[ $SYS_ID == "Laptop 13 ("* ]]; then
     if [[ "AuthenticAMD" == "$CPU_VENDOR" ]]; then
       if [[ ! -f /etc/modprobe.d/alsa.conf ]]; then
         echo 'Fixing 3.5mm jack'


### PR DESCRIPTION
See https://github.com/ublue-os/aurora/pull/106.

Two issues with the system setup script:

1. `$SYS_ID` is not defined anywhere, so we never actually take the branch to compare the product name.

2. I'm assuming `$SYS_ID` is supposed to be defined as the contents of `/sys/devices/virtual/dmi/id/product_name`, which is from Bazzite's [`/usr/libexec/hwsupport/sysid`](https://github.com/ublue-os/bazzite/blob/abeed9ace51ebb1297d975de4ceb72c41b4da363/system_files/desktop/shared/usr/libexec/hwsupport/sysid#L3). This string is something like `Laptop 13 (AMD Ryzen 7040Series)` which doesn't match the regex `Laptop (*`.

I discovered this when I noticed that I didn't have any of these tweaks on my Framework 13 (with Aurora). I checked the first log entry for `ublue-system-setup.service` and it completed succesfully, but the script didn't take the correct branch and apply the tweaks because of the above issues.

