### PR TITLE
pin: kernel back to 6.11.8

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         brand_name: [bluefin]
     with:
-      kernel_pin: 6.11.11-200.fc40.x86_64     ## This is where kernels get pinned.
+      kernel_pin: 6.11.8-200.fc40.x86_64     ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: gts
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      kernel_pin: 6.11.11-300.fc41.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.11.8-300.fc41.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Otherwise people with IPU cameras get stuck, I'm going to push out new gts/stable since this one sucks. 

https://hansdegoede.dreamwidth.org/29039.html

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
