### PR TITLE
feat: Update VFIO to be bootc compliant

### DIFF
--- a/build_files/dx/04-override-install-dx.sh
+++ b/build_files/dx/04-override-install-dx.sh
@@ -20,4 +20,11 @@ rm -rf /tmp/monaspace-font*
 fc-cache -f /usr/share/fonts/monaspace
 fc-cache --system-only --really-force --verbose
 
+# ls-iommu helper tool for listing devices in iommu groups (PCI Passthrough tool)
+DOWNLOAD_URL=$(curl https://api.github.com/repos/HikariKnight/ls-iommu/releases/latest | jq -r '.assets[] | select(.name| test(".*x86_64.tar.gz$")).browser_download_url')
+curl --retry 3 -Lo /tmp/ls-iommu.tar.gz "$DOWNLOAD_URL"
+tar --no-same-owner --no-same-permissions --no-overwrite-dir -xvzf /tmp/ls-iommu.tar.gz -C /tmp/
+mv /tmp/ls-iommu /usr/bin/
+rm -rf /tmp/ls-iommu*
+
 echo "::endgroup::"

--- a/build_files/dx/04-override-install-dx.sh
+++ b/build_files/dx/04-override-install-dx.sh
@@ -20,11 +20,12 @@ rm -rf /tmp/monaspace-font*
 fc-cache -f /usr/share/fonts/monaspace
 fc-cache --system-only --really-force --verbose
 
-# ls-iommu helper tool for listing devices in iommu groups (PCI Passthrough tool)
+# ls-iommu helper tool for listing devices in iommu groups (PCI Passthrough)
 DOWNLOAD_URL=$(curl https://api.github.com/repos/HikariKnight/ls-iommu/releases/latest | jq -r '.assets[] | select(.name| test(".*x86_64.tar.gz$")).browser_download_url')
 curl --retry 3 -Lo /tmp/ls-iommu.tar.gz "$DOWNLOAD_URL"
-tar --no-same-owner --no-same-permissions --no-overwrite-dir -xvzf /tmp/ls-iommu.tar.gz -C /tmp/
-mv /tmp/ls-iommu /usr/bin/
+mkdir /tmp/ls-iommu
+tar --no-same-owner --no-same-permissions --no-overwrite-dir -xvzf /tmp/ls-iommu.tar.gz -C /tmp/ls-iommu
+mv /tmp/ls-iommu/ls-iommu /usr/bin/
 rm -rf /tmp/ls-iommu*
 
 echo "::endgroup::"

--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -180,8 +180,8 @@ configure-vfio ACTION="":
                 sudo chmod +x /etc/libvirt/hooks/qemu
                 sudo grep -A1 -B1 "# Add" /etc/libvirt/hooks/qemu | sed 's/^# //g'
                 echo ""
-                if sudo test ! -d "/etc/libvirt/hooks/qemu/qemu.d"; then
-                    sudo mkdir /etc/libvirt/hooks/qemu/qemu.d
+                if sudo test ! -d "/etc/libvirt/hooks/qemu.d"; then
+                    sudo mkdir /etc/libvirt/hooks/qemu.d
                 fi
             fi
             echo "VFIO will be enabled on next boot, make sure you enable IOMMU, VT-d or AMD-v in your BIOS!"

--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -35,11 +35,11 @@ toggle-devmode:
     source /usr/lib/ujust/ujust.sh
     CURRENT_IMAGE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"')
     if grep -q "/var/ublue-os/image" <<< $CURRENT_IMAGE ; then
-        cat <<EOF
+        bash -c "cat <<EOF
     Before we can switch to the Bluefin Developer Experience
     the current system needs an update. Please run 'ujust update'
     and reboot your system when the update is finished
-    EOF
+    EOF"
         exit
     fi
     if /bin/grep -q "\-dx" <<< $CURRENT_IMAGE ; then
@@ -132,22 +132,22 @@ configure-vfio ACTION="":
     fi
     OPTION={{ ACTION }}
     if [ "$OPTION" == "help" ]; then
-        cat <<EOF
+        bash -c "cat <<EOF
     Usage: ujust configure-vfio <option>
       <option>: Specify the quick option to skip the prompt
       Use 'vfio-on' to select Enable VFIO drivers
       Use 'vfio-off' to select Disable VFIO drivers
-      Use 'kvmfr' to select Autocreate Looking-Glass shm
-    EOF
+      Use 'kvmfr' to enable kvmfr module for looking-glass
+    EOF"
         exit 0
     elif [ "$OPTION" == "" ]; then
-        cat <<EOF
+        bash -c "cat <<EOF
     ${bold}VFIO and kvmfr Configuration${normal}
     This is only used for GPU passthrough of a secondary dGPU.
     It will enable vfio and configure kvmfr for use with $(Urllink "https://looking-glass.io" "Looking Glass")
     If you do not plan to use any of this then press ESC.
     ${bold}NOTE:${normal} Since this is a niche use case, support will be ${b}very limited${n}
-    EOF
+    EOF"
         OPTION=$(Choose \
           "Enable VFIO drivers" \
           "Disable VFIO drivers" \
@@ -158,8 +158,6 @@ configure-vfio ACTION="":
         echo "Enabling VFIO..."
         CPU_VENDOR=$(grep "vendor_id" "/proc/cpuinfo" | uniq | awk -F": " '{ print $2 }')
         VENDOR_KARG="unset"
-        echo 'add_drivers+=" vfio vfio_iommu_type1 vfio-pci "' | sudo tee /etc/dracut.conf.d/vfio.conf
-        rpm-ostree initramfs --enable
         if [[ ${CPU_VENDOR} == "AuthenticAMD" ]]; then
             VENDOR_KARG="amd_iommu=on"
         elif [[ ${CPU_VENDOR} == "GenuineIntel" ]]; then
@@ -195,9 +193,6 @@ configure-vfio ACTION="":
               echo "$VFIO_IDS"
               VFIO_IDS_KARG="--delete-if-present=\"$VFIO_IDS\""
             fi
-            echo "Removing dracut modules"
-            sudo rm /etc/dracut.conf.d/vfio.conf
-            rpm-ostree initramfs --enable
             rpm-ostree kargs \
                 --delete-if-present="iommu=pt" \
                 --delete-if-present="iommu=on" \

--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -178,6 +178,8 @@ configure-vfio ACTION="":
             echo "Please understand that since this is such a niche use case, support will be very limited!"
             echo "To add your unused/second GPU device ids to the vfio driver by running"
             echo 'rpm-ostree kargs --append-if-missing="vfio-pci.ids=xxxx:yyyy,xxxx:yyzz"'
+            echo 'you can find these using "ls-iommu -gr" or "ls-iommu -grr"'
+            echo 'for a dedicated gpu there will be at least 1 vga device and 1 audio device.'
             echo "NOTE: Your second GPU will not be usable by the host after you do this!"
         fi
     elif [[ "${OPTION,,}" =~ (^disable[[:space:]]vfio|vfio-off) ]]; then

--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -174,6 +174,16 @@ configure-vfio ACTION="":
                 --append-if-missing="vfio_pci.disable_vga=1" \
                 --append-if-missing="kvm.ignore_msrs=1" \
                 --append-if-missing="kvm.report_ignored_msrs=0"
+            if sudo test ! -f "/etc/libvirt/hooks/qemu"; then
+                echo "Adding libvirt qemu hooks"
+                sudo wget 'https://raw.githubusercontent.com/PassthroughPOST/VFIO-Tools/master/libvirt_hooks/qemu' -O /etc/libvirt/hooks/qemu
+                sudo chmod +x /etc/libvirt/hooks/qemu
+                sudo grep -A1 -B1 "# Add" /etc/libvirt/hooks/qemu | sed 's/^# //g'
+                echo ""
+                if sudo test ! -d "/etc/libvirt/hooks/qemu/qemu.d"; then
+                    sudo mkdir /etc/libvirt/hooks/qemu/qemu.d
+                fi
+            fi
             echo "VFIO will be enabled on next boot, make sure you enable IOMMU, VT-d or AMD-v in your BIOS!"
             echo "Please understand that since this is such a niche use case, support will be very limited!"
             echo "To add your unused/second GPU device ids to the vfio driver by running"
@@ -191,9 +201,9 @@ configure-vfio ACTION="":
             VFIO_IDS="$(rpm-ostree kargs | sed -E 's/.+(vfio_pci.ids=.+\s)/\1/' | awk '{ print $1 }' | grep vfio_pci.ids)"
             VFIO_IDS_KARG=""
             if [ -n "$VFIO_IDS" ]; then
-              echo "Found VFIO ids in kargs, adding the below line to removal list"
-              echo "$VFIO_IDS"
-              VFIO_IDS_KARG="--delete-if-present=\"$VFIO_IDS\""
+                echo "Found VFIO ids in kargs, adding the below line to removal list"
+                echo "$VFIO_IDS"
+                VFIO_IDS_KARG="--delete-if-present=\"$VFIO_IDS\""
             fi
             rpm-ostree kargs \
                 --delete-if-present="iommu=pt" \

--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -144,7 +144,7 @@ configure-vfio ACTION="":
         bash -c "cat <<EOF
     ${bold}VFIO and kvmfr Configuration${normal}
     This is only used for GPU passthrough of a secondary dGPU.
-    It will enable vfio and configure kvmfr for use with $(Urllink "https://looking-glass.io" "Looking Glass")
+    It will enable vfio and configure kvmfr for use with $(Urllink "https://looking-glass.io" "Looking Glass").
     If you do not plan to use any of this then press ESC.
     ${bold}NOTE:${normal} Since this is a niche use case, support will be ${b}very limited${n}
     EOF"

--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -190,7 +190,7 @@ configure-vfio ACTION="":
             echo 'rpm-ostree kargs --append-if-missing="vfio-pci.ids=xxxx:yyyy,xxxx:yyzz"'
             echo 'you can find these using "ls-iommu -gr" or "ls-iommu -grr"'
             echo 'for a dedicated gpu there will be at least 1 vga device and 1 audio device.'
-            echo "NOTE: Your second GPU will not be usable by the host after you do this!"
+            echo "NOTE: The GPU you bound to vfio-pci will not be usable by the host after you do this!"
         fi
     elif [[ "${OPTION,,}" =~ (^disable[[:space:]]vfio|vfio-off) ]]; then
         echo ""

--- a/system_files/dx/usr/lib/dracut/dracut.conf.d/80-vfio.conf
+++ b/system_files/dx/usr/lib/dracut/dracut.conf.d/80-vfio.conf
@@ -1,0 +1,1 @@
+force_drivers+=" vfio vfio_iommu_type1 vfio-pci "

--- a/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
+++ b/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
@@ -4,7 +4,7 @@ source /usr/lib/ujust/ujust.sh
 # Required disclaimer and where to report issues first
 echo "$(Urllink "https://looking-glass.io/docs/rc/ivshmem_kvmfr/#libvirt" "This module") along with $(Urllink "https://looking-glass.io" "Looking Glass") is very experimental and not recommended for production use!"
 echo "The ublue team packages the kvmfr module only because it has to be supplied with the system image while using an atomic desktop."
-echo "If you do plan to use Looking Glass, please $(Urllink "https://universal-blue.discourse.group/docs?topic=956" "follow the guide here") on how to compile it for your system."
+echo "If you do plan to use Looking Glass, please $(Urllink "https://docs.bazzite.gg/Advanced/looking-glass/#compiling-looking-glass-client" "follow the guide here") on how to compile it for your system."
 echo "To use the kvmfr module after enabling it, just add and edit the xml for libvirt from the documentation in the first link."
 echo "Since we package the kvmfr module please open kvmfr related issues you have on Bluefin and tag me"
 echo "in the $(Urllink "https://discord.gg/WEu6BdFEtp" "Universal Blue Discord") or the $(Urllink "https://github.com/ublue-os/bluefin/issues" "Bluefin Github issue tracker")."
@@ -15,17 +15,22 @@ if [ "$CONFIRM" == "Cancel" ]; then
     exit 0
 fi
 
-# Add kvmfr to dracut so that it's modprobe file can be used
-echo ""
-echo "Setting up kvmfr module so it loads next boot"
-sudo bash -c 'cat << KVMFR_DRACUT > /etc/dracut.conf.d/kvmfr.conf
-install_items+=" /etc/modprobe.d/kvmfr.conf "
-KVMFR_DRACUT'
-
 # Add kvmfr modprobe file following upstream documentation
-sudo bash -c "cat << KVMFR_MODPROBE > /etc/modprobe.d/kvmfr.conf
-options kvmfr static_size_mb=128
-KVMFR_MODPROBE"
+echo "Setting up kvmfr module so it loads next boot"
+if [ -f "/etc/modprobe.d/kvmfr.conf" ]; then
+    echo "Re-creating dummy kvmfr modprobe file"
+    sudo rm /etc/modprobe.d/kvmfr.conf
+fi
+sudo bash -c 'cat << KVMFR_MODPROBE > /etc/modprobe.d/kvmfr.conf
+# This is a dummy file and changing it does nothing
+# If you want to change the kvmfr static_size_mb
+# Run "rpm-ostree kargs --replace=kvmfr.static_size_mb=oldvalue=newvalue"
+# Default value set by us is 128 which is enough for 4k SDR
+# Find the current value by running "rpm-ostree kargs"
+KVMFR_MODPROBE'
+
+# Add kvmfr static size karg
+rpm-ostree kargs --append-if-missing="kvmfr.static_size_mb=128"
 
 # Add upstream udev rule for kvmfr, adjusted for fedora systems
 echo "Adding udev rule for /dev/kvmfr0"
@@ -64,6 +69,10 @@ fi
 if [ ! -d "$HOME/.config/selinux_te/pp" ]; then
     mkdir -p "$HOME/.config/selinux_te/pp"
 fi
+if [ -f "$HOME/.config/selinux_te/kvmfr.te" ]; then
+    echo "Re-creating kvmfr selinux type enforcement rules"
+    rm $HOME/.config/selinux_te/kvmfr.te
+fi
 bash -c "cat << KVMFR_SELINUX > $HOME/.config/selinux_te/kvmfr.te
 module kvmfr 1.0;
 require {
@@ -73,6 +82,9 @@ require {
 }
 #============= svirt_t ==============
 allow svirt_t device_t:chr_file { open read write map };
+
+#============= virtqemud_t ==============
+allow virtqemud_t device_t:chr_file { read write };
 KVMFR_SELINUX"
 
 # Tell user what type enforcement we made and how it looks like
@@ -100,9 +112,6 @@ echo "If you need to change it to a different value"
 echo "you can do that in /etc/modprobe.d/kvmfr.conf"
 echo "$(Urllink "https://looking-glass.io/docs/rc/ivshmem_kvmfr/#libvirt" "Please read official documentation for kvmfr for how to use it")"
 echo ""
-echo "Press OK to start the process of regenerating your initramfs, this will take a long time"
-echo "and there is no good way to track progress for it, if anything is wrong it will error out."
-echo "${b}NOTE: You can start using kvmfr right now without rebooting, but you will need to regenerate initramfs for it to auto load next boot.${n}"
+echo "${b}NOTE: You can start using kvmfr right now without rebooting.${n}"
 
 CONFIRM=$(Choose OK)
-rpm-ostree initramfs --enable

--- a/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
+++ b/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
@@ -82,9 +82,6 @@ require {
 }
 #============= svirt_t ==============
 allow svirt_t device_t:chr_file { open read write map };
-
-#============= virtqemud_t ==============
-allow virtqemud_t device_t:chr_file { read write };
 KVMFR_SELINUX"
 
 # Tell user what type enforcement we made and how it looks like

--- a/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
+++ b/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
@@ -111,7 +111,7 @@ echo "If you need to change it to a different value"
 echo "you can do that in /etc/modprobe.d/kvmfr.conf"
 echo "$(Urllink "https://looking-glass.io/docs/rc/ivshmem_kvmfr/#libvirt" "Please read official documentation for kvmfr for how to use it")"
 echo ""
-if [ -f "/dev/kvmfr0" ]; then
+if [ -e "/dev/kvmfr0" ]; then
     sudo chown $USER:qemu /dev/kvmfr0
     echo "${b}NOTE: You can start using kvmfr right now without rebooting${n}"
 else

--- a/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
+++ b/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
@@ -89,6 +89,9 @@ echo "This is the type enforcement we wrote for SELinux and you can find it in $
 echo "#======= start of kvmfr.te ======="
 cat "$HOME/.config/selinux_te/kvmfr.te"
 echo "#======== end of kvmfr.te ========"
+CONFIRM=$(Choose OK)
+
+# Convert .te a .pp file for semodule
 checkmodule -M -m -o "$HOME/.config/selinux_te/mod/kvmfr.mod" "$HOME/.config/selinux_te/kvmfr.te"
 semodule_package -o "$HOME/.config/selinux_te/pp/kvmfr.pp" -m "$HOME/.config/selinux_te/mod/kvmfr.mod"
 sudo semodule -i "$HOME/.config/selinux_te/pp/kvmfr.pp"

--- a/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
+++ b/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 source /usr/lib/ujust/ujust.sh
+# Get the image name based on the filename
+IMAGE_NAME=$(basename "$0" | sed -E 's/(-dx|)-kvmfr-setup//')
 
 # Required disclaimer and where to report issues first
 echo "$(Urllink "https://looking-glass.io/docs/rc/ivshmem_kvmfr/#libvirt" "This module") along with $(Urllink "https://looking-glass.io" "Looking Glass") is very experimental and not recommended for production use!"
 echo "The ublue team packages the kvmfr module only because it has to be supplied with the system image while using an atomic desktop."
 echo "If you do plan to use Looking Glass, please $(Urllink "https://docs.bazzite.gg/Advanced/looking-glass/#compiling-looking-glass-client" "follow the guide here") on how to compile it for your system."
 echo "To use the kvmfr module after enabling it, just add and edit the xml for libvirt from the documentation in the first link."
-echo "Since we package the kvmfr module please open kvmfr related issues you have on Bluefin and tag me"
-echo "in the $(Urllink "https://discord.gg/WEu6BdFEtp" "Universal Blue Discord") or the $(Urllink "https://github.com/ublue-os/bluefin/issues" "Bluefin Github issue tracker")."
+echo "Since we package the kvmfr module please open kvmfr related issues you have on ${IMAGE_NAME^} and tag me"
+echo "in the $(Urllink "https://discord.gg/WEu6BdFEtp" "Universal Blue Discord") or the $(Urllink "https://github.com/ublue-os/${IMAGE_NAME,,}/issues" "${IMAGE_NAME^} Github issue tracker")."
 echo "~ @HikariKnight"
 
 CONFIRM=$(Choose Ok Cancel)

--- a/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
+++ b/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
@@ -99,7 +99,6 @@ sudo semodule -i "$HOME/.config/selinux_te/pp/kvmfr.pp"
 # Load kvmfr module into currently booted system
 echo "Loading kvmfr module so you do not have to reboot to use it the first time"
 sudo modprobe kvmfr static_size_mb=128
-sudo chown $USER:qemu /dev/kvmfr0
 
 # Final message and regenerate initramfs so kvmfr loads next boot
 echo ""
@@ -112,6 +111,11 @@ echo "If you need to change it to a different value"
 echo "you can do that in /etc/modprobe.d/kvmfr.conf"
 echo "$(Urllink "https://looking-glass.io/docs/rc/ivshmem_kvmfr/#libvirt" "Please read official documentation for kvmfr for how to use it")"
 echo ""
-echo "${b}NOTE: You can start using kvmfr right now without rebooting.${n}"
+if [ -f "/dev/kvmfr0" ]; then
+    sudo chown $USER:qemu /dev/kvmfr0
+    echo "${b}NOTE: You can start using kvmfr right now without rebooting${n}"
+else
+    echo "Please reboot in order to fully load the kvmfr module."
+fi
 
 CONFIRM=$(Choose OK)

--- a/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
+++ b/system_files/dx/usr/libexec/bluefin-dx-kvmfr-setup
@@ -8,7 +8,7 @@ echo "$(Urllink "https://looking-glass.io/docs/rc/ivshmem_kvmfr/#libvirt" "This 
 echo "The ublue team packages the kvmfr module only because it has to be supplied with the system image while using an atomic desktop."
 echo "If you do plan to use Looking Glass, please $(Urllink "https://docs.bazzite.gg/Advanced/looking-glass/#compiling-looking-glass-client" "follow the guide here") on how to compile it for your system."
 echo "To use the kvmfr module after enabling it, just add and edit the xml for libvirt from the documentation in the first link."
-echo "Since we package the kvmfr module please open kvmfr related issues you have on ${IMAGE_NAME^} and tag me"
+echo "Since we package the kvmfr module please open kvmfr related issues you have on ${IMAGE_NAME^} and tag @HikariKnight"
 echo "in the $(Urllink "https://discord.gg/WEu6BdFEtp" "Universal Blue Discord") or the $(Urllink "https://github.com/ublue-os/${IMAGE_NAME,,}/issues" "${IMAGE_NAME^} Github issue tracker")."
 echo "~ @HikariKnight"
 


### PR DESCRIPTION
This will be kept as a draft in-case more changes are needed, but from what i can tell, dracut is being run as part of the build process so the vfio modules should be included into initramfs with the image with this inclusion.

the just recipes and the script for kvmfr has been updated to reflect this

also minor changes to heredocs in some recipes to make the just highlighting work for me in vscode when writing this.
I will be making a similar PR to Aurora with the same updates later.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
