### PR TITLE
feat: update bluefin stable kernel pin to 6.12.9

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -6,8 +6,8 @@ on:
       - testing
     paths-ignore:
       - "**.md"
-  schedule:
-    - cron: "50 5 * * 0" # 5:50 UTC Weekly on Sundays
+  # schedule:
+  #   - cron: "50 5 * * 0" # 5:50 UTC Weekly on Sundays
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      kernel_pin: 6.11.8-300.fc41.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.12.9-200.fc41.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 

--- a/Justfile
+++ b/Justfile
@@ -131,8 +131,11 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     # AKMODS Flavor and Kernel Version
     if [[ "${flavor}" =~ hwe ]]; then
         akmods_flavor="bazzite"
-    elif [[ "${tag}" =~ stable|gts ]]; then
+    elif [[ "${tag}" =~ gts ]]; then
         akmods_flavor="coreos-stable"
+    elif [[ "${tag}" =~ stable ]]; then
+        # TODO: revert this to "coreos-stable" once 6.12.9 kernel is released for coreos-stable images
+        akmods_flavor="coreos-testing"
     elif [[ "${tag}" =~ beta ]]; then
         akmods_flavor="coreos-testing"
     else


### PR DESCRIPTION
Note: 6.12.9 is the current coreos-testing kernel and is known to have fixed the AMD suspend bug.

We're switching the "bluefin:stable" builds to use this kernel since it allows us to ship not-broken kernel and not-broken nvidia.

We don't have a pre-existing build for Fedora 40, so we can't ship a fix for "bluefin:gts" at this time.


Partial fix for #2157

This fixes `bluefin:stable`  but  not `bluefin:gts`
