### PR TITLE
fix: make ujust update use direct calls to rpm-ostree and others

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -5,9 +5,9 @@ alias upgrade := update
 # Update system, flatpaks, and containers all at once
 update:
     #!/usr/bin/bash
-    TOPGRADE_CONFIG="/usr/share/ublue-os/topgrade"
-    /usr/bin/grep "^LockLayering=true" /etc/rpm-ostreed.conf &>/dev/null && TOPGRADE_CONFIG="${TOPGRADE_CONFIG}-bootc"
-    /usr/bin/topgrade --config "${TOPGRADE_CONFIG}.toml" --keep
+    rpm-ostree upgrade
+    flatpak update -y
+    brew update
 
 alias auto-update := toggle-updates
 


### PR DESCRIPTION
Meant to mitigate the current things we are running into with topgrade. This should work just fine - tested it locally and it acts just fine