### PR TITLE
fix: remove bootc key from topgrade

### DIFF
--- a/system_files/shared/usr/share/ublue-os/topgrade.toml
+++ b/system_files/shared/usr/share/ublue-os/topgrade.toml
@@ -7,5 +7,4 @@ assume_yes = true
 no_retry = false
 
 [linux]
-bootc = false
 rpm_ostree = true


### PR DESCRIPTION
we downgraded to topgrade 15.0.0 which doesn't have support for bootc. This key cannot be handled and throws an error.