### PR TITLE
chore: add guards to ujust update

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -5,9 +5,21 @@ alias upgrade := update
 # Update system, flatpaks, and containers all at once
 update:
     #!/usr/bin/bash
+    # rpm-ostree used due to bootc upgrade not supporting local layered packages
     rpm-ostree upgrade
-    flatpak update -y
-    brew update
+    # Updates system Flatpaks
+    if flatpak remotes | grep -q system; then
+        flatpak update -y
+    fi
+    # Update user Flatpaks
+    if flatpak remotes | grep -q user; then
+        flatpak update --user -y
+    fi
+    # Guard Brew if the user does not own brew/doesn't exist
+    if [[ -O /var/home/linuxbrew/.linuxbrew/bin/brew ]]; then
+        # Upgrade will run brew update if needed
+        /var/home/linuxbrew/.linuxbrew/bin/brew upgrade
+    fi
 
 alias auto-update := toggle-updates
 


### PR DESCRIPTION
This puts guards around flatpak updates (user and system) and brew.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
