### PR TITLE
feat(just): add bluefin-specific changelogs

### DIFF
--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -56,7 +56,7 @@ alias changelog := changelogs
 changelogs:
     #!/usr/bin/bash
     CONTENT=$(curl -s https://api.github.com/repos/ublue-os/bluefin/releases/latest | jq -r '.body')
-      echo "$CONTENT" | glow -
+    echo "$CONTENT" | glow -
 
 changelogs-fedora:
     rpm-ostree db diff --changelogs

--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -52,5 +52,11 @@ toggle-updates ACTION="prompt":
 alias changelog := changelogs
 
 # Show the changelog
+
 changelogs:
+    #!/usr/bin/bash
+    CONTENT=$(curl -s https://api.github.com/repos/ublue-os/bluefin/releases/latest | jq -r '.body')
+      echo "$CONTENT" | glow -
+
+changelogs-fedora:
     rpm-ostree db diff --changelogs


### PR DESCRIPTION
`ujust changelogs` now shows the release notes, taken from https://github.com/ublue-os/bazzite/pull/2137

`ujust changelogs-fedora` will pull the package release notes from fedora.
