### PR TITLE
feat: Add Nerd-Font Symbols to VSCode Editor Config #2196

### DIFF
--- a/system_files/dx/etc/skel/.config/Code/User/settings.json
+++ b/system_files/dx/etc/skel/.config/Code/User/settings.json
@@ -1,5 +1,5 @@
 {
     "window.titleBarStyle": "custom",
-    "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace",
+    "editor.fontFamily": "'Cascadia Code', 'Droid Sans Mono', 'monospace', monospace, 'Symbols Nerd Font Mono'",
     "update.mode": "none"
 }


### PR DESCRIPTION
This PR implements the proposal written in https://github.com/ublue-os/bluefin/issues/2196

It fixes the nerd fonts in VS Code, see screenshot with the Bluefin header inside the terminal of VS Code.

![Screenshot From 2025-02-09 17-40-50](https://github.com/user-attachments/assets/64e48b3b-d6dc-422a-ba39-acdbbfd4d40b)

I tried to follow all conventions. Since this is my first (small) contribution, let me know if I overlooked something.