### PR TITLE
fix: only run ublue user services for human users

### DIFF
--- a/system_files/dx/usr/lib/systemd/user/bluefin-dx-user-vscode.service
+++ b/system_files/dx/usr/lib/systemd/user/bluefin-dx-user-vscode.service
@@ -2,6 +2,7 @@
 Description=Run 
 Wants=network-online.target
 After=network-online.target ublue-user-setup.service
+ConditionUser=!@system
 
 [Service]
 Type=oneshot

--- a/system_files/shared/usr/lib/systemd/user/ublue-flatpak-manager.service
+++ b/system_files/shared/usr/lib/systemd/user/ublue-flatpak-manager.service
@@ -3,6 +3,7 @@ Description=Manage flatpaks
 Documentation=https://github.com/ublue-os/endlish-oesque/issues/10
 Wants=network-online.target
 After=network-online.target
+ConditionUser=!@system
 
 [Service]
 Type=oneshot

--- a/system_files/shared/usr/lib/systemd/user/ublue-user-setup.service
+++ b/system_files/shared/usr/lib/systemd/user/ublue-user-setup.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Configure system for current user
+ConditionUser=!@system
 
 [Service]
 Type=simple


### PR DESCRIPTION
Porting changes from https://github.com/ublue-os/aurora/pull/206 to here.

I'm not sure if GDM has the same design as SDDM, which would be an issue for GDM. In any case, we are still running these user services for the root user.