### PR TITLE
revert: "feat: Fix geolocation (Primarily for timezone detection) now that Mozilla has exited"

### DIFF
--- a/system_files/shared/etc/geoclue/conf.d/99-beacondb.conf
+++ b/system_files/shared/etc/geoclue/conf.d/99-beacondb.conf
@@ -1,3 +1,0 @@
-[wifi]
-enable=true
-url=https://api.beacondb.net/v1/geolocate


### PR DESCRIPTION
Reverts ublue-os/bluefin#2204

This is in the RPM now, no need to have it per-image. 