### PR TITLE
fix: ujust changelog shows stable channel even when on GTS

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -132,7 +132,6 @@ install-jetbrains-toolbox:
 incus:
     @ujust install-incus
 
-
 # Install OpenTabletDriver, an open source, cross-platform, user-mode tablet driver
 [group('Apps')]
 install-opentabletdriver:
@@ -164,7 +163,6 @@ install-opentabletdriver:
     else
         echo "Have a good day :)!"
     fi
-
 
 # Install and configure Incus
 [group('Apps')]

--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -54,10 +54,19 @@ alias changelog := changelogs
 # Show the changelog
 changelogs:
     #!/usr/bin/bash
+
+    # Get Image Tag
     TAG=$(jq -r '.["image-tag"]' < /usr/share/ublue-os/image-info.json)
+
+    # If stable or gts, get changelogs from Github Releases
     if [[ "$TAG" =~ gts$|stable$ ]]; then
-        DATE="$(rpm-ostree status --json | jq -r '.deployments.[0].version' | grep -oP ".*\d{2}\.\K\d{8}?\.?\d")"
-        curl -Ls https://api.github.com/repos/ublue-os/bluefin/releases | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body" | glow -p
+        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}(\.\d+|s)" /etc/os-release)"
+        CONTENT=$(curl -Ls https://api.github.com/repos/ublue-os/bluefin/releases | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")
+    fi
+
+    # Display Content with Glow, otherwise fallback to rpm-ostree changelogs (stable-daily/latest/desynced)
+    if [[ -n "${CONTENT:-}" ]]; then
+        echo "$CONTENT" | glow -p
     else
         ujust changelogs-fedora
     fi

--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -49,9 +49,18 @@ toggle-updates ACTION="prompt":
         sudo systemctl disable rpm-ostreed-automatic.timer
     fi
 
-alias changelog := changelogs-fedora
-alias changelogs := changelogs-fedora
+alias changelog := changelogs
 
 # Show the changelog
+changelogs:
+    #!/usr/bin/bash
+    TAG=$(jq -r '.["image-tag"]' < /usr/share/ublue-os/image-info.json)
+    if [[ "$TAG" =~ gts$|stable$ ]]; then
+        DATE="$(rpm-ostree status --json | jq -r '.deployments.[0].version' | grep -oP ".*\d{2}\.\K\d{8}?\.?\d")"
+        curl -Ls https://api.github.com/repos/ublue-os/bluefin/releases | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body" | glow -p
+    else
+        ujust changelogs-fedora
+    fi
+
 changelogs-fedora:
     rpm-ostree db diff --changelogs

--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -49,18 +49,9 @@ toggle-updates ACTION="prompt":
         sudo systemctl disable rpm-ostreed-automatic.timer
     fi
 
-alias changelog := changelogs
+alias changelog := changelogs-fedora
+alias changelogs := changelogs-fedora
 
 # Show the changelog
-
-changelogs:
-    #!/usr/bin/bash
-    . /etc/os-release
-    # Strip Fedora's VERSION_ID from the IMAGE_VERSION
-    VERSION_ID_PREFIX="${VERSION_ID}."
-    IMAGE_VERSION_TAG=${IMAGE_VERSION/#"$VERSION_ID_PREFIX"}
-    CONTENT=$(curl -s "https://api.github.com/repos/ublue-os/bluefin/releases/tags/${RELEASE_TYPE}-${IMAGE_VERSION_TAG}"  | jq -r '.body')
-    echo "$CONTENT" | glow -
-
 changelogs-fedora:
     rpm-ostree db diff --changelogs

--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -60,7 +60,7 @@ changelogs:
 
     # If stable or gts, get changelogs from Github Releases
     if [[ "$TAG" =~ gts$|stable$ ]]; then
-        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}(\.\d+|)" /etc/os-release)"
+        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}[.0-9]*" /etc/os-release)"
         CONTENT=$(curl -Ls https://api.github.com/repos/ublue-os/bluefin/releases | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")
     fi
 

--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -55,7 +55,11 @@ alias changelog := changelogs
 
 changelogs:
     #!/usr/bin/bash
-    CONTENT=$(curl -s https://api.github.com/repos/ublue-os/bluefin/releases/latest | jq -r '.body')
+    . /etc/os-release
+    # Strip Fedora's VERSION_ID from the IMAGE_VERSION
+    VERSION_ID_PREFIX="${VERSION_ID}."
+    IMAGE_VERSION_TAG=${IMAGE_VERSION/#"$VERSION_ID_PREFIX"}
+    CONTENT=$(curl -s "https://api.github.com/repos/ublue-os/bluefin/releases/tags/${RELEASE_TYPE}-${IMAGE_VERSION_TAG}"  | jq -r '.body')
     echo "$CONTENT" | glow -
 
 changelogs-fedora:

--- a/system_files/shared/usr/share/ublue-os/just/10-update.just
+++ b/system_files/shared/usr/share/ublue-os/just/10-update.just
@@ -60,7 +60,7 @@ changelogs:
 
     # If stable or gts, get changelogs from Github Releases
     if [[ "$TAG" =~ gts$|stable$ ]]; then
-        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}(\.\d+|s)" /etc/os-release)"
+        DATE="$(grep -oP "OSTREE_VERSION=.*\d{2}\.\K\d{8}(\.\d+|)" /etc/os-release)"
         CONTENT=$(curl -Ls https://api.github.com/repos/ublue-os/bluefin/releases | jq -r ".[] | select(.tag_name==\"${TAG}-${DATE}\") | .body")
     fi
 


### PR DESCRIPTION
Fixes #2221 by picking the correct channel and by selecting the currently deployed version tag.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
