### PR TITLE
feat: unpin bluefin stable and gts kernel

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         brand_name: [bluefin]
     with:
-      kernel_pin: 6.12.9-100.fc40.x86_64     ## This is where kernels get pinned.
+      #kernel_pin: 6.12.9-100.fc40.x86_64     ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: gts
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      kernel_pin: 6.12.9-200.fc41.x86_64 ## This is where kernels get pinned.
+      #kernel_pin: 6.12.9-200.fc41.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
We had pinned this in #2168 but we can unpin to get to newer kernels again.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
