### PR TITLE
chore: pin latest to last 6.12 kernel

### DIFF
--- a/.github/workflows/build-image-latest-hwe.yml
+++ b/.github/workflows/build-image-latest-hwe.yml
@@ -1,4 +1,4 @@
-name: Latest Images
+name: Latest hwe Images
 on:
   merge_group:
   pull_request:

--- a/.github/workflows/build-image-latest-hwe.yml
+++ b/.github/workflows/build-image-latest-hwe.yml
@@ -26,7 +26,7 @@ jobs:
       image_flavors: '["hwe", "hwe-nvidia", "hwe-nvidia-open"]'
       brand_name: ${{ matrix.brand_name }}
       stream_name: latest
-      kernel_pin: bazzite-6.12.12-207.bazzite.fc41.x86_64
+      kernel_pin: 6.12.12-207.bazzite.fc41.x86_64
 
   generate-release:
     name: Generate Release

--- a/.github/workflows/build-image-latest-hwe.yml
+++ b/.github/workflows/build-image-latest-hwe.yml
@@ -1,4 +1,4 @@
-name: Latest hwe Images
+name: Latest Images HWE
 on:
   merge_group:
   pull_request:

--- a/.github/workflows/build-image-latest-hwe.yml
+++ b/.github/workflows/build-image-latest-hwe.yml
@@ -23,10 +23,10 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      image_flavors: '["main", "nvidia", "nvidia-open", "hwe", "hwe-nvidia", "hwe-nvidia-open"]'
+      image_flavors: '["hwe", "hwe-nvidia", "hwe-nvidia-open"]'
       brand_name: ${{ matrix.brand_name }}
       stream_name: latest
-    # This needs splitting, right now a kernel pin will not work due to hwe kernel
+      kernel_pin: bazzite-6.12.12-207.bazzite.fc41.x86_64
 
   generate-release:
     name: Generate Release

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -1,4 +1,4 @@
-name: Latest Images
+name: Latest main Images
 on:
   merge_group:
   pull_request:

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -1,0 +1,44 @@
+name: Latest Images
+on:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+      - testing
+    paths-ignore:
+      - "**.md"
+  schedule:
+    - cron: "50 4 * * 1,2,3,4,5,6" # 4:50 UTC All But Sunday
+    - cron: "50 4 * * 0" # 4:50 UTC Sunday
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  build-image-latest:
+    name: Build Latest Images
+    uses: ./.github/workflows/reusable-build.yml
+    secrets: inherit
+    strategy:
+      fail-fast: false
+      matrix:
+        brand_name: ["bluefin"]
+    with:
+      image_flavors: '["main", "nvidia", "nvidia-open"]'
+      brand_name: ${{ matrix.brand_name }}
+      stream_name: latest
+      kernel_pin: bazzite-6.12.15-200.fc41.x86_64
+
+  generate-release:
+    name: Generate Release
+    needs: [build-image-latest]
+    secrets: inherit
+    uses: ./.github/workflows/generate-release.yml
+    with:
+      stream_name: '["latest"]'
+
+  # build-iso-latest:
+  #   name: Build Latest ISOs
+  #   needs: [build-image-latest]
+  #   if: github.event.schedule == '50 4 * * 0'
+  #   secrets: inherit
+  #   uses: ./.github/workflows/build-iso-latest.yml

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -26,7 +26,7 @@ jobs:
       image_flavors: '["main", "nvidia", "nvidia-open"]'
       brand_name: ${{ matrix.brand_name }}
       stream_name: latest
-      kernel_pin: bazzite-6.12.15-200.fc41.x86_64
+      kernel_pin: 6.12.15-200.fc41.x86_64
 
   generate-release:
     name: Generate Release

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -1,4 +1,4 @@
-name: Latest main Images
+name: Latest Images
 on:
   merge_group:
   pull_request:

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -14,8 +14,11 @@ jobs:
     build-image-stable:
         uses: ./.github/workflows/build-image-stable.yml
         secrets: inherit
-    build-image-latest:
-        uses: ./.github/workflows/build-image-latest.yml
+    build-image-latest-main:
+        uses: ./.github/workflows/build-image-latest-main.yml
+        secrets: inherit
+    build-image-latest-hwe:
+        uses: ./.github/workflows/build-image-latest-hwe.yml
         secrets: inherit
     build-image-beta:
         uses: ./.github/workflows/build-image-beta.yml


### PR DESCRIPTION
This pins bluefin latest kernels to our newest good builds:
- main/nvidia flavors: 6.12.15
- hwe/hwe-nvidia flavors: 6.12.12.bazzite

These are the newest known good kernels for the respective flavors.

The purpose of the pin is avoid shipping kernel 6.13 until the major issues are resolved (eg "bad page state" and fuse issues crashing systems and flatpaks).

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
