### PR TITLE
chore: remove rpm-ostree cli unwrapping

### DIFF
--- a/build_files/shared/build-base.sh
+++ b/build_files/shared/build-base.sh
@@ -2,21 +2,7 @@
 
 set -eoux pipefail
 
-echo "::group:: ===Remove CLI Wrap==="
-
-# there is no 'rpm-ostree cliwrap uninstall-from-root', but this is close enough. See:
-# https://github.com/coreos/rpm-ostree/blob/6d2548ddb2bfa8f4e9bafe5c6e717cf9531d8001/rust/src/cliwrap.rs#L25-L32
-if [ -d /usr/libexec/rpm-ostree/wrapped ]; then
-    # binaries which could be created if they did not exist thus may not be in wrapped dir
-    rm -f \
-        /usr/bin/yum \
-        /usr/bin/dnf \
-        /usr/bin/kernel-install
-    # binaries which were wrapped
-    mv -f /usr/libexec/rpm-ostree/wrapped/* /usr/bin
-    rm -fr /usr/libexec/rpm-ostree
-fi
-
+echo "::group:: ===Install dnf5==="
 if [ "${FEDORA_MAJOR_VERSION}" -lt 41 ]; then
     rpm-ostree install --idempotent dnf5 dnf5-plugins
 fi


### PR DESCRIPTION
We no longer cliwrap in ublue-os/main, so there shouldn't be any need for this here.
