### PR TITLE
fix: reference digest from retry action correctly

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -228,7 +228,7 @@ jobs:
         if: github.event_name != 'pull_request'
         env:
           IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
           SBOM_OUTPUT: ${{ steps.generate-sbom.outputs.OUTPUT_PATH }}
         run: |


### PR DESCRIPTION
Due to the retry action (which I'd like to remove sometime soon), we need to add some strange hackery to be able to fetch the outputs from the steps. 