### PR TITLE
fix: remove march wallpaper from GTS (f40)

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -28,24 +28,24 @@ install -c -m 0755 /tmp/starship /usr/bin
 # shellcheck disable=SC2016
 echo 'eval "$(starship init bash)"' >> /etc/bashrc
 
+# Automatic wallpaper changing by month
+HARDCODED_RPM_MONTH="12"
 # Use old bluefin background package for GTS
 # FIXME: remove this once GTS updates to fc41
 if [ "$(rpm --eval "%{dist}")" == ".fc40" ] ; then
     dnf5 install -y "bluefin-backgrounds-0.1.7-1$(rpm -E "%{dist}")"
+    # Pin to february wallpaper instead
+    sed -i "/picture-uri/ s/${HARDCODED_RPM_MONTH}/02/" "/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"
 else
     dnf5 install -y bluefin-backgrounds
-fi 
-
+    sed -i "/picture-uri/ s/${HARDCODED_RPM_MONTH}/$(date +%m)/" "/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"
+fi
+glib-compile-schemas /usr/share/glib-2.0/schemas
 
 # Required for bluefin faces to work without conflicting with a ton of packages
 rm -f /usr/share/pixmaps/faces/* || echo "Expected directory deletion to fail"
 mv /usr/share/pixmaps/faces/bluefin/* /usr/share/pixmaps/faces
 rm -rf /usr/share/pixmaps/faces/bluefin
-
-# Automatic wallpaper changing by month
-HARDCODED_RPM_MONTH="12"
-sed -i "/picture-uri/ s/${HARDCODED_RPM_MONTH}/$(date +%m)/" "/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"
-glib-compile-schemas /usr/share/glib-2.0/schemas
 
 dnf5 -y swap fedora-logos bluefin-logos
 

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -31,7 +31,7 @@ echo 'eval "$(starship init bash)"' >> /etc/bashrc
 # Use old bluefin background package for GTS
 # FIXME: remove this once GTS updates to fc41
 if [ "$(rpm --eval "%{dist}")" == ".fc40" ] ; then
-    dnf5 install -y "bluefin-backgrounds-0.1.6$(rpm -E "%{dist}")"
+    dnf5 install -y "bluefin-backgrounds-0.1.7$(rpm -E "%{dist}")"
 else
     dnf5 install -y bluefin-backgrounds
 fi 

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -31,9 +31,9 @@ echo 'eval "$(starship init bash)"' >> /etc/bashrc
 # Use old bluefin background package for GTS
 # FIXME: remove this once GTS updates to fc41
 if [ "$(rpm --eval "%{dist}")" == ".fc40" ] ; then
-    dnf install -y bluefin-backgrounds-0.1.6
+    dnf5 install -y bluefin-backgrounds-0.1.6
 else
-    dnf install -y bluefin-backgrounds
+    dnf5 install -y bluefin-backgrounds
 fi 
 
 

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -31,7 +31,7 @@ echo 'eval "$(starship init bash)"' >> /etc/bashrc
 # Use old bluefin background package for GTS
 # FIXME: remove this once GTS updates to fc41
 if [ "$(rpm --eval "%{dist}")" == ".fc40" ] ; then
-    dnf5 install -y "bluefin-backgrounds-0.1.7$(rpm -E "%{dist}")"
+    dnf5 install -y "bluefin-backgrounds-0.1.7-1$(rpm -E "%{dist}")"
 else
     dnf5 install -y bluefin-backgrounds
 fi 

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -31,7 +31,7 @@ echo 'eval "$(starship init bash)"' >> /etc/bashrc
 # Use old bluefin background package for GTS
 # FIXME: remove this once GTS updates to fc41
 if [ "$(rpm --eval "%{dist}")" == ".fc40" ] ; then
-    dnf5 install -y bluefin-backgrounds-0.1.6
+    dnf5 install -y "bluefin-backgrounds-0.1.6$(rpm -E "%{dist}")"
 else
     dnf5 install -y bluefin-backgrounds
 fi 

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -28,6 +28,15 @@ install -c -m 0755 /tmp/starship /usr/bin
 # shellcheck disable=SC2016
 echo 'eval "$(starship init bash)"' >> /etc/bashrc
 
+# Use old bluefin background package for GTS
+# FIXME: remove this once GTS updates to fc41
+if [ "$(rpm --eval "%{dist}")" == ".fc40" ] ; then
+    dnf install -y bluefin-backgrounds-0.1.6
+else
+    dnf install -y bluefin-backgrounds
+fi 
+
+
 # Required for bluefin faces to work without conflicting with a ton of packages
 rm -f /usr/share/pixmaps/faces/* || echo "Expected directory deletion to fail"
 mv /usr/share/pixmaps/faces/bluefin/* /usr/share/pixmaps/faces

--- a/packages.json
+++ b/packages.json
@@ -6,7 +6,6 @@
 				"adw-gtk3-theme",
 				"bash-color-prompt",
 				"bcache-tools",
-				"bluefin-backgrounds",
 				"bluefin-schemas",
 				"borgbackup",
 				"bootc",


### PR DESCRIPTION
This should pull in an old version of the bluefin wallpapers package, so we dont get the black screen issue since... we dont get the new wallpaper at all!

Fixes: #2242 