### PR TITLE
fix: revert dnf5 downgrade

### DIFF
--- a/build_files/shared/build-base.sh
+++ b/build_files/shared/build-base.sh
@@ -7,7 +7,6 @@ if [ "${FEDORA_MAJOR_VERSION}" -lt 41 ]; then
     rpm-ostree install --idempotent dnf5 dnf5-plugins
 fi
 
-dnf5 -y downgrade dnf5
 echo "::endgroup::"
 
 echo "::group:: Copy Files"


### PR DESCRIPTION
reverts commit 398bc8607a1de08a40295ae0310c6f4f7357fa75

dnf5 got updated and fixes the gpg errors. Now builds are failing because of the downgrade
