### PR TITLE
chore: Remove Docker from Fedora 42 DX builds temporarily

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -113,10 +113,6 @@
 				"containerd.io",
 				"dbus-x11",
 				"devpod",
-				"docker-ce",
-				"docker-ce-cli",
-				"docker-buildx-plugin",
-				"docker-compose-plugin",
 				"edk2-ovmf",
 				"flatpak-builder",
 				"genisoimage",
@@ -190,7 +186,11 @@
 			"silverblue": [],
 			"dx": [
 				"lxd-agent",
-				"lxd"
+				"lxd",
+				"docker-ce",
+				"docker-ce-cli",
+				"docker-buildx-plugin",
+				"docker-compose-plugin"
 			]
 		},
 		"exclude": {
@@ -204,7 +204,25 @@
 			"all": [
 				"google-noto-fonts-all"
 			],
-			"silverblue": []
+			"silverblue": [],
+			"dx": [
+				"docker-ce",
+				"docker-ce-cli",
+				"docker-buildx-plugin",
+				"docker-compose-plugin"
+			]
+		},
+		"exclude": {
+			"all": [],
+			"silverblue": [],
+			"dx": []
+		}
+	},
+	"42": {
+		"include": {
+			"all": [],
+			"silverblue": [],
+			"dx": []
 		},
 		"exclude": {
 			"all": [],


### PR DESCRIPTION
While Docker isn't pushing the packages.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
