### PR TITLE
chore: remove beta workarounds

### DIFF
--- a/build_files/dx/02-install-kernel-akmods-dx.sh
+++ b/build_files/dx/02-install-kernel-akmods-dx.sh
@@ -24,10 +24,6 @@ mv /tmp/rpms/* /tmp/akmods/
 # dnf5 versionlock add kernel kernel-devel kernel-devel-matched kernel-core kernel-headers kernel-modules kernel-modules-core kernel-modules-extra
 
 # Install RPMS
-if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
-    dnf5 -y install /tmp/akmods/kmods/*kvmfr*.rpm || true
-else
-    dnf5 -y install /tmp/akmods/kmods/*kvmfr*.rpm
-fi
+dnf5 -y install /tmp/akmods/kmods/*kvmfr*.rpm
 
 echo "::endgroup::"


### PR DESCRIPTION
Mesa is now built for F42 in negativo17. Once merged into main this will work. Slowly removing other beta workarounds. Docker-CE is now building containerd.io but is still missing the rest of the stack.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
