### PR TITLE
fix(packages): remove topgrade

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -76,7 +76,6 @@
 				"stress-ng",
 				"tailscale",
 				"tmux",
-				"topgrade",
 				"ublue-bling",
 				"ublue-brew",
 				"ublue-fastfetch",


### PR DESCRIPTION
Let's ditch this for F42, it's up to date in homebrew anyway. Do not merge until F42

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
