### PR TITLE
fix(packages): remove stress-ng

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -73,7 +73,6 @@
 				"sssd-ad",
 				"sssd-krb5",
 				"sssd-nfs-idmap",
-				"stress-ng",
 				"tailscale",
 				"tmux",
 				"topgrade",


### PR DESCRIPTION
This is in homebrew as `stress`

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
