### PR TITLE
feat(cli): Add install-gaming-flatpaks ujust command

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -235,3 +235,21 @@ setup-brew-not-found ACTION="":
         pkexec rm -f "${FILES_TO_BE_REMOVED[@]}"
       echo "Brew command-not-found has been ${b}${red}disabled${n}"
     fi
+
+# Install gaming flatpaks
+# 23.08 runtime versions are needed for Heroic/Lutris
+[group('Apps')]
+install-gaming-flatpaks:
+    #!/usr/bin/env bash
+    flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+    flatpak --system -y install --or-update app/com.valvesoftware.Steam/x86_64/stable \
+                                            app/com.heroicgameslauncher.hgl/x86_64/stable \
+                                            app/net.lutris.Lutris/x86_64/stable \
+                                            app/net.davidotek.pupgui2/x86_64/stable \
+                                            app/com.dec05eba.gpu_screen_recorder/x86_64/stable \
+                                            runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/24.08 \
+                                            runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/23.08 \
+                                            runtime/org.freedesktop.Platform.VulkanLayer.OBSVkCapture/x86_64/24.08 \
+                                            runtime/com.obsproject.Studio.Plugin.OBSVkCapture/x86_64/stable \
+                                            runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08 \
+                                            runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08


### PR DESCRIPTION
I noticed the lack of the `install-gaming-flatpaks` command for `ujust` when moving to Bluefin from Aurora, and wanted to make a PR to add it to Bluefin in hopes that it might be useful to other users like me who wish to install every flatpak needed to play videogames in one go.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
