### PR TITLE
Add samsung unified linux driver

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -81,6 +81,7 @@
 				"ublue-brew",
 				"ublue-fastfetch",
 				"ublue-motd",
+				"uld",
 				"usbmuxd",
 				"wireguard-tools",
 				"wl-clipboard",


### PR DESCRIPTION
Add Samsung printer and scanner drivers, this should fix #1550 and #1604

I fixed an issue with files in /opt in the negativo17 repository: https://github.com/negativo17/uld/pull/3
Now the package should not break the build anymore.