### PR TITLE
fix: change rpmfusion mirror that works on f42

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -50,9 +50,10 @@ else
 fi
 
 # RPMFUSION Dependent AKMODS
+# need to be changed back to mirrors.rpmfusion.org once rpmfusion is fixed
 dnf5 -y install \
-    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm \
-    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
+    https://ftp.fi.muni.cz/pub/linux/rpmfusion/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm \
+    https://ftp.fi.muni.cz/pub/linux/rpmfusion/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
 
 if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
     dnf5 -y install \


### PR DESCRIPTION
temp fix for rpmfusion that works with F42 betas.

Just need to revert/change the url back to mirrors.rpmfusion.org once mirrors are fixed