### PR TITLE
feat(packaged): switch from fedora media writer to impression

### DIFF
--- a/bluefin_flatpaks/flatpaks
+++ b/bluefin_flatpaks/flatpaks
@@ -1,10 +1,10 @@
 app/io.github.dvlv.boxbuddyrs/x86_64/stable
 app/com.github.rafostar.Clapper/x86_64/stable
-app/org.fedoraproject.MediaWriter/x86_64/stable
 app/com.github.tchx84.Flatseal/x86_64/stable
 app/io.github.flattool.Ignition/x86_64/stable
 app/io.github.flattool.Warehouse/x86_64/stable
 app/io.github.input_leap.input-leap/x86_64/stable
+app/io.gitlab.adhami3310.Impression/x86_64/stable
 app/org.gnome.baobab/x86_64/stable
 app/org.gnome.Calculator/x86_64/stable
 app/org.gnome.Calendar/x86_64/stable


### PR DESCRIPTION
Saves us a runtime on the ISO.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
