### PR TITLE
feat: remove v4l2loopback and rpmfusion for Fedora 42+

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -49,33 +49,6 @@ else
         /tmp/akmods/kmods/*framework-laptop*.rpm
 fi
 
-# RPMFUSION Dependent AKMODS
-if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
-    dnf5 -y install \
-        https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm || true
-    dnf5 -y install \
-        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm || true
-else
-    dnf5 -y install \
-        https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm \
-        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
-fi
-
-if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
-    dnf5 -y install \
-        v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm || true
-else
-    dnf5 -y install \
-        v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
-fi
-
-if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
-    dnf5 -y remove rpmfusion-free-release || true
-    dnf5 -y remove rpmfusion-nonfree-release || true
-else
-    dnf5 -y remove rpmfusion-free-release rpmfusion-nonfree-release
-fi
-
 # Nvidia AKMODS
 if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
     # Fetch Nvidia RPMs


### PR DESCRIPTION
PipeWire should now provide the features which previously made v4l2loopback necessary. This removes the v4l2loopback install.

Additionally, this removes rpmfusion as it was only still required to provide dependencies for v4l2loopback.


Merge pending testing by @castrojo 
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
