### PR TITLE
chore(liveiso): add config file

### DIFF
--- a/iso_files/configure_iso.sh
+++ b/iso_files/configure_iso.sh
@@ -4,10 +4,23 @@ set -x
 
 dnf --enablerepo="terra" install -y readymade
 
+# TODO: Figure out exactly what needs to happen in this file
 tee /etc/readymade.toml <<EOF
+[install]
+allowed_installtypes = ["wholedisk"]
 
+[distro]
+name = "Bluefin"
+
+[[postinstall]]
+module = "CleanupBoot"
+
+[[postinstall]]
+module = "InitialSetup"
+
+[[postinstall]]
+module = "Language"
 EOF
-
 
 systemctl disable brew-setup.service
 systemctl --global disable podman-auto-update.timer


### PR DESCRIPTION
This config file is not configured for bootc, but allows us to startup the installer without it crashing.