### PR TITLE
fix(dx): remove devpod from the image

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -102,7 +102,6 @@
 				"cockpit-system",
 				"code",
 				"dbus-x11",
-				"devpod",
 				"edk2-ovmf",
 				"flatpak-builder",
 				"genisoimage",


### PR DESCRIPTION
This is coming via a flatpak

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
