### PR TITLE
feat(cli): replace ProtonUp-Qt with ProtonPlus

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -245,11 +245,12 @@ install-gaming-flatpaks:
     flatpak --system -y install --or-update app/com.valvesoftware.Steam/x86_64/stable \
                                             app/com.heroicgameslauncher.hgl/x86_64/stable \
                                             app/net.lutris.Lutris/x86_64/stable \
-                                            app/net.davidotek.pupgui2/x86_64/stable \
+                                            app/com.vysp3r.ProtonPlus/x86_64/stable \
                                             app/com.dec05eba.gpu_screen_recorder/x86_64/stable \
                                             runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/24.08 \
                                             runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/23.08 \
                                             runtime/org.freedesktop.Platform.VulkanLayer.OBSVkCapture/x86_64/24.08 \
                                             runtime/com.obsproject.Studio.Plugin.OBSVkCapture/x86_64/stable \
                                             runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/24.08 \
-                                            runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08
+                                            runtime/org.freedesktop.Platform.VulkanLayer.MangoHud/x86_64/23.08 \
+                                            runtime/com.valvesoftware.Steam.Utility.steamtinkerlaunch/x86_64/stable

--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -247,6 +247,7 @@ install-gaming-flatpaks:
                                             app/net.lutris.Lutris/x86_64/stable \
                                             app/com.vysp3r.ProtonPlus/x86_64/stable \
                                             app/com.dec05eba.gpu_screen_recorder/x86_64/stable \
+                                            app/com.github.Matoking.protontricks/x86_64/stable \
                                             runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/24.08 \
                                             runtime/org.freedesktop.Platform.VulkanLayer.gamescope/x86_64/23.08 \
                                             runtime/org.freedesktop.Platform.VulkanLayer.OBSVkCapture/x86_64/24.08 \


### PR DESCRIPTION
Replace ProtonUp-Qt with ProtonPlus is more suitable for Gnome DE(Bazzite use it on GNOME ver) add steamtinkerlaunch for more advanced users and gamers

EDIT: Adding also Protontricks.

I think these two tools are quite essential to have if we already providing mangohud and gamescope  + Swap for libadwaita based ProtonPlus.
