### PR TITLE
fix(nvidia-open): correctly identify nvidia-open on image-info.json + fix live ISO nvidia

### DIFF
--- a/build_files/base/00-image-info.sh
+++ b/build_files/base/00-image-info.sh
@@ -21,6 +21,9 @@ image_flavor="main"
 if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
   image_flavor="nvidia"
 fi
+if [[ "${IMAGE_NAME}" =~ nvidia-open ]]; then
+  image_flavor="nvidia-open"
+fi
 
 cat >$IMAGE_INFO <<EOF
 {

--- a/iso_files/configure_iso.sh
+++ b/iso_files/configure_iso.sh
@@ -10,7 +10,7 @@ IMAGE_FLAVOR="$(jq -c -r '."image-flavor"' <<< $IMAGE_INFO)"
 
 OUTPUT_NAME="ghcr.io/ublue-os/bluefin"
 if [ "$IMAGE_FLAVOR" != "main" ] ; then
-  OUTPUT_NAME="${OUTPUT_NAME}-${FLAVOR}"
+  OUTPUT_NAME="${OUTPUT_NAME}-${IMAGE_FLAVOR}"
 fi
 
 tee /etc/readymade.toml <<EOF


### PR DESCRIPTION

This writes `nvidia-open` instead of `nvidia` for the open kmod images, should work but I havent checked it yet.
Also makes it so the ISOs have the right container name there