### PR TITLE
Revert "feat: remove v4l2loopback and rpmfusion for Fedora 42+ (#2330)"

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -49,8 +49,32 @@ else
         /tmp/akmods/kmods/*framework-laptop*.rpm
 fi
 
-# Install v4l2loopback from terra or gracefully fail
-dnf5 -y install --enable-repo="terra*" /tmp/akmods/kmods/*v4l2loopback*.rpm || true
+# RPMFUSION Dependent AKMODS
+if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
+    dnf5 -y install \
+        https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm || true
+    dnf5 -y install \
+        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm || true
+else
+    dnf5 -y install \
+        https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm \
+        https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm
+fi
+
+if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
+    dnf5 -y install \
+        v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm || true
+else
+    dnf5 -y install \
+        v4l2loopback /tmp/akmods/kmods/*v4l2loopback*.rpm
+fi
+
+if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
+    dnf5 -y remove rpmfusion-free-release || true
+    dnf5 -y remove rpmfusion-nonfree-release || true
+else
+    dnf5 -y remove rpmfusion-free-release rpmfusion-nonfree-release
+fi
 
 # Nvidia AKMODS
 if [[ "${IMAGE_NAME}" =~ nvidia ]]; then


### PR DESCRIPTION
Also partial revert "feat: install v4l2loopback from terra (#2339)"

This reverts commit 3ff7e659d827648c0a7435f5ed7f711226e17929.

Also this removes the terra installed v4l2loopback in a partial revert of commit fa23c87eaef6677dfb44ac816a0c390923e908dc.


The reason for this revert back to rpmfusion for `v4l2loopback` is that the terra package seems to be trying to build the binary kmod in our bluefin build... if we want terra's v4l2loopback, we should first switch to building the binary kmod in akmods repo if we can make that work.
