### PR TITLE
chore: install Docker CE from stable repos

### DIFF
--- a/build_files/dx/04-override-install-dx.sh
+++ b/build_files/dx/04-override-install-dx.sh
@@ -28,10 +28,4 @@ tar --no-same-owner --no-same-permissions --no-overwrite-dir -xvzf /tmp/ls-iommu
 mv /tmp/ls-iommu/ls-iommu /usr/bin/
 rm -rf /tmp/ls-iommu*
 
-# Install Docker Release Candidate - remove this when F42 packages are pushed to the stable repos
-# https://download.docker.com/linux/fedora/42/x86_64/stable/Packages/
-if [[ $FEDORA_MAJOR_VERSION -eq 42 ]]; then
-    dnf install -y --enablerepo=docker-ce-testing docker-buildx-plugin docker-ce docker-ce-cli docker-compose-plugin
-fi
-
 echo "::endgroup::"

--- a/packages.json
+++ b/packages.json
@@ -103,6 +103,10 @@
 				"code",
 				"containerd.io",
 				"dbus-x11",
+				"docker-buildx-plugin",
+				"docker-ce",
+				"docker-ce-cli",
+				"docker-compose-plugin",
 				"edk2-ovmf",
 				"flatpak-builder",
 				"genisoimage",
@@ -194,12 +198,7 @@
 				"epson-inkjet-printer-escpr2",
 				"google-noto-fonts-all"
 			],
-			"dx": [
-				"docker-buildx-plugin",
-				"docker-ce",
-				"docker-ce-cli",
-				"docker-compose-plugin"
-			]
+			"dx": []
 		},
 		"exclude": {
 			"all": [],


### PR DESCRIPTION
Docker have now updated the stable repos to contain F42 packages, so we can switch to that.