### PR TITLE
chore(liveiso): install Readymade from nightly

### DIFF
--- a/iso_files/configure_iso.sh
+++ b/iso_files/configure_iso.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-dnf --enablerepo="terra" install -y readymade
+dnf --enablerepo="terra" install -y readymade-nightly
 
 IMAGE_INFO="$(cat /usr/share/ublue-os/image-info.json)"
 IMAGE_TAG="$(jq -c -r '."image-tag"' <<< $IMAGE_INFO)"


### PR DESCRIPTION
Install from the nightly package while there's no release with (working) bootc support