### PR TITLE
chore: remove beta builds

### DIFF
--- a/.github/workflows/build-image-beta.yml
+++ b/.github/workflows/build-image-beta.yml
@@ -1,15 +1,5 @@
 name: Beta Images
 on:
-  merge_group:
-  pull_request:
-    branches:
-      - main
-      - testing
-    paths-ignore:
-      - "**.md"
-  schedule:
-    - cron: "50 4 * * 1,2,3,4,5,6" # 4:50 UTC All But Sunday
-    - cron: "50 4 * * 0" # 4:50 UTC Sunday
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/build-iso-live.yml
+++ b/.github/workflows/build-iso-live.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         platform: [amd64]
         flavor: ["", "nvidia-open"]
-        image_version: ["gts","stable", "beta"]
+        image_version: ["gts","stable"]
     permissions:
       contents: read
       packages: read


### PR DESCRIPTION
Now that F42 is in the latest image, we don't need beta.  
latest and beta are identical.

Keeps the workflow around for when F43 comes around.
