### PR TITLE
fix(hwe): switch to skip-unavailable

### DIFF
--- a/build_files/base/09-hwe-additions.sh
+++ b/build_files/base/09-hwe-additions.sh
@@ -28,8 +28,8 @@ ASUS_PACKAGES=(
     asusctl-rog-gui
 )
 
-# iptsd is not available on F42
 SURFACE_PACKAGES=(
+    iptsd
     libcamera
     libcamera-tools
     libcamera-gstreamer
@@ -37,7 +37,7 @@ SURFACE_PACKAGES=(
     pipewire-plugin-libcamera
 )
 
-dnf5 -y install \
+dnf5 -y install --skip-unavailable \
     "${ASUS_PACKAGES[@]}" \
     "${SURFACE_PACKAGES[@]}"
 

--- a/build_files/base/09-hwe-additions.sh
+++ b/build_files/base/09-hwe-additions.sh
@@ -28,8 +28,8 @@ ASUS_PACKAGES=(
     asusctl-rog-gui
 )
 
+# iptsd is not available on F42
 SURFACE_PACKAGES=(
-    iptsd
     libcamera
     libcamera-tools
     libcamera-gstreamer


### PR DESCRIPTION
Iptsd doesn't appear to be available from sueface-linux right now.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
