### PR TITLE
chore(live-iso): hide custom partitioning button

### DIFF
--- a/iso_files/configure_iso.sh
+++ b/iso_files/configure_iso.sh
@@ -19,7 +19,7 @@ fi
 
 tee /etc/readymade.toml <<EOF
 [install]
-allowed_installtypes = ["wholedisk", "custom"]
+allowed_installtypes = ["wholedisk"]
 copy_mode = "bootc"
 bootc_imgref = "containers-storage:$OUTPUT_NAME:$IMAGE_TAG"
 bootc_enforce_sigpolicy = true


### PR DESCRIPTION
Can be merged once we get any release with this commit applied https://github.com/FyraLabs/readymade/commit/d5599cd8cf5303d11c19e511239dc4a02066bf76

Fixes: https://github.com/ublue-os/titanoboa/issues/79