### PR TITLE
fix: make readymade show up on the dock on newer builds

### DIFF
--- a/iso_files/configure_iso.sh
+++ b/iso_files/configure_iso.sh
@@ -32,6 +32,8 @@ name = "Bluefin"
 module = "Script"
 EOF
 
+rm -f /usr/share/applications/liveinst.desktop
+sed -i '/NoDisplay=.*/d' /usr/share/applications/com.fyralabs.Readymade.desktop
 cp -f /usr/share/applications/com.fyralabs.Readymade.desktop /etc/xdg/autostart
 
 mkdir -p /usr/share/readymade/postinstall.d


### PR DESCRIPTION

This just removes the liveinst symlink so we dont have two readymades and then removes the NoDisplay from the desktop file