### PR TITLE
fix(incus): re-enable ganto copr for incus

### DIFF
--- a/build_files/dx/01-install-copr-repos-dx.sh
+++ b/build_files/dx/01-install-copr-repos-dx.sh
@@ -5,10 +5,7 @@ echo "::group:: ===$(basename "$0")==="
 set -eoux pipefail
 
 #incus, lxc, lxd
-
-if [[ "${FEDORA_MAJOR_VERSION}" -lt "42" ]]; then
-    dnf5 -y copr enable ganto/lxc4
-fi
+dnf5 -y copr enable ganto/lxc4
 
 #umoci
 dnf5 -y copr enable ganto/umoci

--- a/build_files/dx/09-cleanup-dx.sh
+++ b/build_files/dx/09-cleanup-dx.sh
@@ -15,9 +15,7 @@ systemctl enable --global bluefin-dx-user-vscode.service
 
 dnf5 -y copr disable ublue-os/staging
 dnf5 -y copr disable ublue-os/packages
-if [[ "${FEDORA_MAJOR_VERSION}" -lt "42" ]]; then
-    dnf5 -y copr disable ganto/lxc4
-fi
+dnf5 -y copr disable ganto/lxc4
 dnf5 -y copr disable ganto/umoci
 dnf5 -y copr disable karmab/kcli
 dnf5 -y copr disable atim/ubuntu-fonts


### PR DESCRIPTION
Incus in F42 is blocked moving past 6.8.

This change re-enables the ganto copr for incus packages.