### PR TITLE
chore(iso): build nightly

### DIFF
--- a/.github/workflows/build-iso-live.yml
+++ b/.github/workflows/build-iso-live.yml
@@ -9,13 +9,8 @@ on:
         required: false
         default: false
         type: boolean
-  pull_request:
-    branches:
-      - main
-    paths:
-      - '.github/workflows/build-iso-live.yml'
-      - 'iso_files/*'
-      - 'Justfile'
+  schedule:
+    - cron: "0 1 * * *"   
 
 env:
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"


### PR DESCRIPTION
One hour after readymade-nightly, remove PR builds.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
