### PR TITLE
chore: show a prompt for installing stress-ng via brew if its not installed

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -14,6 +14,17 @@
 [group('System')]
 benchmark:
     #!/usr/bin/env bash
+    source /usr/lib/ujust/ujust.sh
+    if ! type -P "stress-ng" &>/dev/null ; then
+        if gum confirm "Stress does not seem to be on your path, do you wish to install it?" ; then
+            set -eu
+            brew install stress-ng
+            set +eu
+        else
+            exit 0
+        fi
+    fi
+
     echo 'Running a 1 minute benchmark ...'
     trap popd EXIT
     pushd $(mktemp -d)


### PR DESCRIPTION

Fixes: https://github.com/ublue-os/bluefin/issues/2403