### PR TITLE
fix(iso): manually disable bootloader-update.service to avoid upstream issue

### DIFF
--- a/iso_files/configure_iso.sh
+++ b/iso_files/configure_iso.sh
@@ -117,6 +117,7 @@ glib-compile-schemas /usr/share/glib-2.0/schemas
 
 systemctl disable rpm-ostree-countme.service
 systemctl disable tailscaled.service
+systemctl disable bootloader-update.service
 systemctl disable brew-upgrade.timer
 systemctl disable brew-update.timer
 systemctl disable brew-setup.service


### PR DESCRIPTION

This makes it so we completely avoid this issue on Bluefin's Live ISOs https://discussion.fedoraproject.org/t/merely-booting-fedora-42-live-media-adds-a-fedora-entry-to-the-uefi-boot-menu/148774
