### PR TITLE
fix: readd gnome-tweaks

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -31,6 +31,7 @@
 				"gnome-shell-extension-logo-menu",
 				"gnome-shell-extension-search-light",
 				"gnome-shell-extension-tailscale-gnome-qs",
+    "gnome-tweaks",
 				"gum",
 				"hplip",
 				"ibus-mozc",

--- a/packages.json
+++ b/packages.json
@@ -31,7 +31,7 @@
 				"gnome-shell-extension-logo-menu",
 				"gnome-shell-extension-search-light",
 				"gnome-shell-extension-tailscale-gnome-qs",
-    "gnome-tweaks",
+                "gnome-tweaks",
 				"gum",
 				"hplip",
 				"ibus-mozc",


### PR DESCRIPTION
need it for keyboard layouts. let's just bury it in the utilities folder