### PR TITLE
fix(live-iso): allow for offline installation

### DIFF
--- a/iso_files/configure_iso.sh
+++ b/iso_files/configure_iso.sh
@@ -23,6 +23,7 @@ allowed_installtypes = ["wholedisk"]
 copy_mode = "bootc"
 bootc_imgref = "containers-storage:$OUTPUT_NAME:$IMAGE_TAG"
 bootc_enforce_sigpolicy = true
+bootc_args = ["--skip-fetch-check"]
 $KARGS
 
 [distro]


### PR DESCRIPTION
This just adds the argument we were missing for offline installs on the ISO

Fixes: https://github.com/ublue-os/titanoboa/issues/80