### PR TITLE
feat: add bluefin offline documentation to `/usr/share/doc`

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -34,6 +34,10 @@ dnf5 -y swap \
     --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
     fwupd fwupd
 
+# Offline Bluefin documentation
+curl --retry 3 -Lo /tmp/bluefin.pdf https://github.com/ublue-os/bluefin-docs/releases/download/0.1/bluefin.pdf
+install -Dm0644 -t /usr/share/doc/bluefin/ /tmp/bluefin.pdf
+
 # Starship Shell Prompt
 curl --retry 3 -Lo /tmp/starship.tar.gz "https://github.com/starship/starship/releases/latest/download/starship-x86_64-unknown-linux-gnu.tar.gz"
 tar -xzf /tmp/starship.tar.gz -C /tmp


### PR DESCRIPTION
This straight up just adds the bluefin docs PDF into `/usr/share/doc/bluefin`