### PR TITLE
feat(ci): switch to renovate from cronjobs

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -33,9 +33,3 @@ jobs:
     with:
       stream_name: '["gts"]'
 
-  # build-iso-gts:
-  #   name: Build GTS ISOs
-  #   needs: [build-image-gts]
-  #   if: github.event_name == 'schedule'
-  #   secrets: inherit
-  #   uses: ./.github/workflows/build-iso-gts.yml

--- a/.github/workflows/build-image-latest-hwe.yml
+++ b/.github/workflows/build-image-latest-hwe.yml
@@ -7,7 +7,6 @@ on:
       - testing
     paths-ignore:
       - "**.md"
-  schedule:
   workflow_call:
   workflow_dispatch:
 

--- a/.github/workflows/build-image-latest-hwe.yml
+++ b/.github/workflows/build-image-latest-hwe.yml
@@ -8,8 +8,6 @@ on:
     paths-ignore:
       - "**.md"
   schedule:
-    - cron: "50 4 * * 1,2,3,4,5,6" # 4:50 UTC All But Sunday
-    - cron: "50 4 * * 0" # 4:50 UTC Sunday
   workflow_call:
   workflow_dispatch:
 
@@ -34,10 +32,3 @@ jobs:
     uses: ./.github/workflows/generate-release.yml
     with:
       stream_name: '["latest"]'
-
-  # build-iso-latest:
-  #   name: Build Latest ISOs
-  #   needs: [build-image-latest]
-  #   if: github.event.schedule == '50 4 * * 0'
-  #   secrets: inherit
-  #   uses: ./.github/workflows/build-iso-latest.yml

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -7,9 +7,6 @@ on:
       - testing
     paths-ignore:
       - "**.md"
-  schedule:
-    - cron: "50 4 * * 1,2,3,4,5,6" # 4:50 UTC All But Sunday
-    - cron: "50 4 * * 0" # 4:50 UTC Sunday
   workflow_call:
   workflow_dispatch:
 
@@ -35,9 +32,3 @@ jobs:
     with:
       stream_name: '["latest"]'
 
-  # build-iso-latest:
-  #   name: Build Latest ISOs
-  #   needs: [build-image-latest]
-  #   if: github.event.schedule == '50 4 * * 0'
-  #   secrets: inherit
-  #   uses: ./.github/workflows/build-iso-latest.yml

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -8,7 +8,6 @@ on:
     paths-ignore:
       - "**.md"
   schedule:
-    - cron: "50 5 * * 1,2,3,4,5,6" # 5:50 UTC everyday
     - cron: "50 5 * * 0" # 5:50 UTC sunday
   workflow_call:
   workflow_dispatch:
@@ -35,9 +34,3 @@ jobs:
     with:
       stream_name: '["stable", "stable-daily"]'
 
-  # build-iso-stable:
-  #   name: Build Stable ISOs
-  #   needs: [build-image-stable]
-  #   if: github.event.schedule == '50 5 * * 0'
-  #   secrets: inherit
-  #   uses: ./.github/workflows/build-iso-stable.yml

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -1,5 +1,5 @@
 images:
-  - name: centos-bootc
+  - name: silverblue-nvidia
     image: ghcr.io/ublue-os/silverblue-nvidia
-    tag: c10s
+    tag: latest
     digest: sha256:2d1805dcf6293420423c9fb2a478b4c60e0f003016745e99dd23d8d009a1b394

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -1,0 +1,5 @@
+images:
+  - name: centos-bootc
+    image: ghcr.io/ublue-os/silverblue-nvidia
+    tag: c10s
+    digest: sha256:2d1805dcf6293420423c9fb2a478b4c60e0f003016745e99dd23d8d009a1b394


### PR DESCRIPTION
The intent here is to monitor silverblue-nvidia and then build right after instead of cron timing.

I've left gts and stable as weekly builds because they should just remain that way. LMK if I did this right. 🗡️ 
