### PR TITLE
fix: add temporary workaround service for missing `/etc/hostname` file

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -8,6 +8,7 @@ set -eoux pipefail
 systemctl enable rpm-ostree-countme.service
 systemctl enable tailscaled.service
 systemctl enable dconf-update.service
+systemctl enable ublue-fix-hostname.service
 systemctl --global enable ublue-flatpak-manager.service
 systemctl enable ublue-system-setup.service
 systemctl enable ublue-guest-user.service

--- a/system_files/shared/usr/lib/systemd/system/ublue-fix-hostname.service
+++ b/system_files/shared/usr/lib/systemd/system/ublue-fix-hostname.service
@@ -1,0 +1,11 @@
+[Unit]
+name=Universal Blue Missing /etc/hostname Workaround
+description=Workaround for the missing /etc/hostname file on Universal Blue systems
+after=network.target
+ConditionPathExists=!/etc/hostname
+
+[Service]
+ExecStart=/bin/sh -c 'echo "%H" > /etc/hostname'
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
We've been getting lots of reports of distroboxes breaking due to not having `/etc/hostname`.
This unit that @p5 wrote just puts your hostname into there if that file doesnt exist yet.
