### PR TITLE
fix: remove yelp

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -31,7 +31,7 @@
 				"gnome-shell-extension-logo-menu",
 				"gnome-shell-extension-search-light",
 				"gnome-shell-extension-tailscale-gnome-qs",
-                "gnome-tweaks",
+                                "gnome-tweaks",
 				"gum",
 				"hplip",
 				"ibus-mozc",
@@ -166,7 +166,8 @@
 				"gnome-shell-extension-background-logo",
 				"gnome-software-rpm-ostree",
 				"gnome-terminal-nautilus",
-				"podman-docker"
+				"podman-docker",
+				"yelp"
 			],
 			"dx": []
 		}


### PR DESCRIPTION
The doc link opens the web browser, though we should just open the ondisk PDF: https://github.com/ublue-os/Logomenu/pull/14

And the Documentation icon in our menu also opens the website. That means we have online and offline help now. We should just purge this entirely, the docs in there are old anyway.

Security issue: https://blogs.gnome.org/mcatanzaro/2025/04/15/dangerous-arbitrary-file-read-vulnerability-in-yelp-cve-2025-3155/

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
