### PR TITLE
fix: /etc/hostname fixup

### DIFF
--- a/system_files/shared/usr/lib/systemd/system/ublue-fix-hostname.service
+++ b/system_files/shared/usr/lib/systemd/system/ublue-fix-hostname.service
@@ -5,7 +5,7 @@ after=network.target
 ConditionPathExists=!/etc/hostname
 
 [Service]
-ExecStart=/bin/sh -c 'echo "%H" > /etc/hostname'
+ExecStart=/usr/bin/touch /etc/hostname
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
The previously solution could overwrite the user's configured hostname. This creates an empty file if it does not exist.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
