### PR TITLE
chore: pin GTS and Stable to kernel 6.13.8

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         brand_name: [bluefin]
     with:
-      #kernel_pin: 6.12.9-100.fc40.x86_64     ## This is where kernels get pinned.
+      kernel_pin: 6.13.8-200.fc41.x86_64     ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: gts
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      #kernel_pin: 6.12.9-200.fc41.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.13.8-200.fc41.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
This is required because Fedora CoreOS stable moved to a rawhide kernel which isn't available in F41.
