### PR TITLE
fix: Small typo in shell

### DIFF
--- a/just/bluefin-apps.just
+++ b/just/bluefin-apps.just
@@ -172,7 +172,7 @@ install-incus:
     CURRENT_IMAGE=$(rpm-ostree status -b --json | jq -r '.deployments[0]."container-image-reference"')
     if ! grep -e "-dx" <<< $CURRENT_IMAGE ; then
         echo "Developer mode is currently ${b}${red}Disabled${n}."
-        echo "Run \"just devmode\" to turn on Developer mode."
+        echo "Run \"ujust devmode\" to turn on Developer mode."
         exit
     fi
     echo 'Installing and configuring Incus.'


### PR DESCRIPTION
fix: 

stdio says that I should be using devmode to try out incus containers. Well, `ujust devmode` is the current prerequisite to enable that.

Err msg:
```
$ ujust incus
Developer mode is currently Disabled.
Run "just devmode" to turn on Developer mode.
$ just devmode
error: Justfile does not contain recipe `devmode`
```
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
