### PR TITLE
fix(just): add current user to dx-groups instead of root

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -121,7 +121,7 @@ dx-group:
 
     for GROUP_ADD in "${GROUPS_ADD[@]}" ; do
         append_group $GROUP_ADD
-        usermod -aG $GROUP_ADD $USER
+        usermod -aG $GROUP_ADD {{ `id -un` }}
     done
 
     echo "Reboot system and log back in to use docker, libvirt and incus."


### PR DESCRIPTION
A recent change introduced a regression, where the whole "ujust dx-group" script is running under pkexec, which means the $USER variable is now expanded "root" and not a current user.

To fix this, use just substitution to inject current user into the script.
