### PR TITLE
fix: remove Distrobox from automatic updates

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -4,6 +4,9 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
+# Prevent Distrobox containers from being updated via the background service
+sed -i 's|uupd|& --disable-module-distrobox|' /usr/lib/systemd/system/uupd.service
+
 # Setup Systemd
 systemctl enable rpm-ostree-countme.service
 systemctl enable tailscaled.service


### PR DESCRIPTION
This PR removes Distrobox container updates from the automatic background update service.

This PR addresses issue [https://github.com/ublue-os/bluefin/issues/2436](https://github.com/ublue-os/bluefin/issues/2436).
