### PR TITLE
feat(live-iso): add live ISO workflow for LTS too

### DIFF
--- a/.github/workflows/build-iso-live.yml
+++ b/.github/workflows/build-iso-live.yml
@@ -30,6 +30,19 @@ jobs:
         platform: [amd64]
         flavor: ["", "nvidia-open"]
         image_version: ["gts","stable", "stable-daily", "latest"]
+        include:
+          - platform: amd64
+            flavor: ""
+            image_version: lts
+          - platform: arm64
+            flavor: ""
+            image_version: lts
+          - platform: amd64
+            flavor: gdx
+            image_version: lts
+          - platform: arm64
+            flavor: gdx
+            image_version: lts
     permissions:
       contents: read
       packages: read

--- a/iso_files/configure_iso.sh
+++ b/iso_files/configure_iso.sh
@@ -2,8 +2,13 @@
 
 set -x
 
-dnf install -y gparted
-dnf --enablerepo="terra" install -y readymade-nightly
+# no DNF5, most likely c10s
+if [ -x /usr/bin/dnf5 ] ; then
+  sudo dnf install --nogpgcheck --repofrompath 'terra,https://repos.fyralabs.com/terrael10' terra-release 
+else
+  dnf install -y gparted
+  dnf --enablerepo="terra" install -y readymade-nightly
+fi
 
 # FIXME: move to `dnf install` once (https://github.com/terrapkg/packages/pull/4623) is merged
 pushd $(mktemp -d)


### PR DESCRIPTION

Just adds a little workaround for terra and LTS on the workflows