### PR TITLE
chore: remove LXD from group scripts and references - Fixes #283

### DIFF
--- a/build_files/dx/01-install-copr-repos-dx.sh
+++ b/build_files/dx/01-install-copr-repos-dx.sh
@@ -4,7 +4,7 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
-#incus, lxc, lxd
+#incus, lxc
 
 if [[ "${FEDORA_MAJOR_VERSION}" -lt "42" ]]; then
     dnf5 -y copr enable ganto/lxc4

--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -105,7 +105,7 @@ ptyxis-transparency opacity="0.95":
         printf "Value must be greater than 0 and less than or equal to 1: %s.\n" "{{ opacity }}"
     fi
 
-# Configure docker,incus-admin,lxd,libvirt container manager permissions
+# Configure docker,incus-admin,libvirt container manager permissions
 [group('System')]
 dx-group:
     #!/usr/bin/pkexec bash

--- a/system_files/dx/usr/lib/systemd/system/bluefin-dx-groups.service
+++ b/system_files/dx/usr/lib/systemd/system/bluefin-dx-groups.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Add wheel members to docker,incus-admin, and lxd groups
+Description=Add wheel members to docker,and incus-admin groups
 
 [Service]
 Type=oneshot

--- a/system_files/dx/usr/libexec/bluefin-dx-groups
+++ b/system_files/dx/usr/libexec/bluefin-dx-groups
@@ -23,7 +23,6 @@ append_group() {
 # Setup Groups
 append_group docker
 append_group incus-admin
-append_group lxd
 append_group libvirt
 
 wheelarray=($(getent group wheel | cut -d ":" -f 4 | tr  ',' '\n'))
@@ -31,7 +30,6 @@ for user in $wheelarray
 do
   usermod -aG docker $user
   usermod -aG incus-admin $user
-  usermod -aG lxd $user
   usermod -aG libvirt $user
 done
 


### PR DESCRIPTION
This PR removes LXD from the script to add the user to certain "dx" groups. It also removes references to LXD from comments in various files.

