### PR TITLE
fix(just): use system gsettings to configure terminal transparency

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -95,11 +95,11 @@ ptyxis-transparency opacity="0.95":
     if [[ -n "$(echo "{{ opacity }}" | grep -v '^[.0-9]*$')" ]]; then
         printf "Value must be numeric: %s.\n" "{{ opacity }}"
     elif [[ $(echo "0<{{ opacity }} && 1>={{ opacity }}" | bc -q) -eq 1 ]]; then
-        raw="$(gsettings get org.gnome.Ptyxis profile-uuids)"
+        raw="$(/usr/bin/gsettings get org.gnome.Ptyxis profile-uuids)"
         uuids="$(sed -En 's|[^0-9a-z]*||g; s|([0-9a-z]{32})|\1\n|gp' <<<${raw})"
         for i in ${uuids}; do
             location="org.gnome.Ptyxis.Profile:/org/gnome/Ptyxis/Profiles/${i}/"
-            gsettings set "${location}" opacity "{{ opacity }}"; done
+            /usr/bin/gsettings set "${location}" opacity "{{ opacity }}"; done
         printf "Ptyxis opacity is now %s.\n" "{{ opacity }}"
     else
         printf "Value must be greater than 0 and less than or equal to 1: %s.\n" "{{ opacity }}"


### PR DESCRIPTION
This pull request updates the way `gsettings` is called within the `ptyxis-transparency` just recipe. I spent a significant amount of time over the weekend trying to achieve this, encountering some unexpected challenges.

Initially, I attempted to use `gsettings` and `dconf` (as suggested in [this gist](https://gist.github.com/andypiper/f75c25d91548af03fe586a19f35c9742)) to modify the opacity. However, these methods didn't seem to work as expected.

Ultimately, [this Stack Exchange answer](https://askubuntu.com/a/1007851) provided the necessary solution. I have another installation of `gsettings` (not sure what added it) which was being used instead of the system one.

![Screenshot showing the Stack Exchange answer that provided the solution](https://github.com/user-attachments/assets/a7e975c6-8ee5-4acf-8593-6b785b88ecb7)

p.s. Thanks for the hard work put into this project! It's been an amazing experience setting it up and a great way to learn a lot of new things.

