### PR TITLE
fix(iso-lts): handle fedora version for Centos

### DIFF
--- a/.github/workflows/build-iso-lts.yml
+++ b/.github/workflows/build-iso-lts.yml
@@ -9,4 +9,5 @@ jobs:
     uses: ./.github/workflows/reusable-build-iso.yml
     secrets: inherit
     with:
+      image_flavors: "['main']"
       stream_name: lts

--- a/Justfile
+++ b/Justfile
@@ -498,8 +498,11 @@ build-iso $image="bluefin" $tag="latest" $flavor="main" ghcr="0" pipeline="0":
     fi
 
     # Fedora Version
-    FEDORA_VERSION=$(${PODMAN} inspect ${IMAGE_FULL} | jq -r '.[]["Config"]["Labels"]["ostree.linux"]' | grep -oP 'fc\K[0-9]+')
-    # FEDORA_VERSION=41
+    if [[ "$tag" != lts ]]; then
+        FEDORA_VERSION=$(${PODMAN} inspect ${IMAGE_FULL} | jq -r '.[]["Config"]["Labels"]["ostree.linux"]' | grep -oP 'fc\K[0-9]+')
+    else
+        FEDORA_VERSION=41
+    fi
 
     # Load Image into rootful podman
     if [[ "${UID}" -gt 0 && {{ ghcr }} == "0" && ! "${PODMAN}" =~ docker ]]; then


### PR DESCRIPTION
Only build main.

This is a temporary build process until this moves to bluefin-lts repo.