### PR TITLE
fix: turn on input remapper service on by default

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -23,6 +23,7 @@ systemctl enable ublue-system-setup.service
 systemctl --global enable ublue-user-setup.service
 systemctl --global enable podman-auto-update.timer
 systemctl enable check-sb-key.service
+systemctl enable input-remapper.service
 
 # Updater
 if systemctl cat -- uupd.timer &> /dev/null; then


### PR DESCRIPTION
Fixes #2504 and #2467

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
