### PR TITLE
chore: remove redundant charm repo

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -47,7 +47,6 @@ systemctl disable flatpak-add-fedora-repos.service
 # Disable all COPRs and RPM Fusion Repos
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/tailscale.repo
-sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/charm.repo
 dnf5 -y copr disable ublue-os/staging
 dnf5 -y copr disable ublue-os/packages
 dnf5 -y copr disable che/nerd-fonts

--- a/system_files/shared/etc/yum.repos.d/charm.repo
+++ b/system_files/shared/etc/yum.repos.d/charm.repo
@@ -1,6 +1,0 @@
-[charm]
-name=Charm
-baseurl=https://repo.charm.sh/yum/
-enabled=1
-gpgcheck=1
-gpgkey=https://repo.charm.sh/yum/gpg.key


### PR DESCRIPTION
gum and glow are in fedora repos

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
