### PR TITLE
fix: remove kernel pin, unleash Fedora 42

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         brand_name: [bluefin]
     with:
-      kernel_pin: 6.13.8-200.fc41.x86_64     ## This is where kernels get pinned.
+#     kernel_pin: 6.13.8-200.fc41.x86_64     ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: gts
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      kernel_pin: 6.13.8-200.fc41.x86_64 ## This is where kernels get pinned.
+#     kernel_pin: 6.13.8-200.fc41.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Please do not merge until we confirm that akmods as slurped in the new CoreOS kernel. 

Ideally renovate will refresh akmods, main, and bluefin before we merge this, wouldn't that be something. 😄 