### PR TITLE
fix: ublue-fix-hostname unit errors

### DIFF
--- a/system_files/shared/usr/lib/systemd/system/ublue-fix-hostname.service
+++ b/system_files/shared/usr/lib/systemd/system/ublue-fix-hostname.service
@@ -1,7 +1,7 @@
 [Unit]
-name=Universal Blue Missing /etc/hostname Workaround
-description=Workaround for the missing /etc/hostname file on Universal Blue systems
-after=network.target
+Name=Universal Blue Missing /etc/hostname Workaround
+Description=Workaround for the missing /etc/hostname file on Universal Blue systems
+After=network.target
 ConditionPathExists=!/etc/hostname
 
 [Service]


### PR DESCRIPTION
bad casing in unit file, fixed.

```
May 14 21:06:39 beast systemd[1]: /usr/lib/systemd/system/ublue-fix-hostname.service:2: Unknown key 'name' in section [Unit], ignoring.
May 14 21:06:39 beast systemd[1]: /usr/lib/systemd/system/ublue-fix-hostname.service:3: Unknown key 'description' in section [Unit], ignoring.
May 14 21:06:39 beast systemd[1]: /usr/lib/systemd/system/ublue-fix-hostname.service:4: Unknown key 'after' in section [Unit], ignoring.
```