### PR TITLE
fix: pin kernel to 6.14.5

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         brand_name: [bluefin]
     with:
-#     kernel_pin: 6.13.8-200.fc41.x86_64     ## This is where kernels get pinned.
+     kernel_pin: 6.14.5-200.fc41.x86_64     ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: gts
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-#     kernel_pin: 6.13.8-200.fc41.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.14.5-200.fc41.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      kernel_pin: 6.14.5-200.fc41.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.14.5-300.fc42.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
We're getting reports that the gated kernel is failing with intel wifi cards, prepping this. 