### PR TITLE
feat: Add fedora version to the rebase helper

### DIFF
--- a/system_files/shared/usr/bin/ublue-rollback-helper
+++ b/system_files/shared/usr/bin/ublue-rollback-helper
@@ -22,9 +22,9 @@ function list_tags(){
 
 function rebase_helper(){
     base_image="${IMAGE_REGISTRY}/${IMAGE_NAME}"
-    echo "Which Tag would you like to rebase to?"  
+    echo "Which Tag would you like to rebase to?"
 
-    if [[ "$composefs_enabled" == "true" ]]; then        
+    if [[ "$composefs_enabled" == "true" ]]; then
         CHANNELS=(latest stable stable-daily)
         echo "The default selection is latest, stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers"
         echo "Note: Since you are on Fedora 42+, you will not be able to rollback to the GTS version."
@@ -34,7 +34,14 @@ function rebase_helper(){
         fi
 
     for channel in "${CHANNELS[@]}"; do
-        version=$(skopeo inspect --no-tags docker://ghcr.io/ublue-os/bluefin-dx:$channel | jq -r '.Labels["org.opencontainers.image.version"]' | sed 's/.*-//' | cut -c 1-2)
+        if [[ "$channel" == "gts" ]]; then
+            version=$(( ${VERSIONS_LIST[0]} - 1 ))
+        elif [[ "$channel" == "stable-daily" ]]; then
+            version="${VERSIONS_LIST[1]}"
+        else
+            version=$(skopeo inspect --no-tags docker://ghcr.io/ublue-os/bluefin-dx:$channel | jq -r '.Labels["org.opencontainers.image.version"]' | sed 's/.*-//' | cut -c 1-2)
+        fi
+        VERSIONS_LIST+=("$version")
         CHANNELS_F+=("$channel (F$version)")
     done
 

--- a/system_files/shared/usr/bin/ublue-rollback-helper
+++ b/system_files/shared/usr/bin/ublue-rollback-helper
@@ -33,8 +33,14 @@ function rebase_helper(){
         echo "The default selection is gts, stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers"
         fi
 
-    choose_target=$(Choose date "${CHANNELS[@]}" cancel)
+    for channel in "${CHANNELS[@]}"; do
+        version=$(skopeo inspect --no-tags docker://ghcr.io/ublue-os/bluefin-dx:$channel | jq -r '.Labels["org.opencontainers.image.version"]' | sed 's/.*-//' | cut -c 1-2)
+        CHANNELS_F+=("$channel (F$version)")
+    done
+
+    choose_target=$(Choose date "${CHANNELS_F[@]}" cancel)
     if [[ "$choose_target" != "date" && "$choose_target" != "cancel" ]]; then
+        choose_target=${choose_target%% *}
         rebase_target="${base_image}:${choose_target}"
     elif [[ "$choose_target" == "date" ]]; then
         # shellcheck disable=SC2207


### PR DESCRIPTION
This PR adds fedora versions next to the rebase tag. Those are not hardcoded and use `skopeo` to extract the version.

Then jq is used to extract `org.opencontainers.image.version`, which is usually `gts-41.xx`, `latest-42.xx` or `42.xx` for stable and stable-daily. That's why `sed` is used to match everything before the `-`. `cut` is then used to only retrieve the 41/42 part.

`choose_target=${choose_target%% *}` allows matching everything after the first space and remove it.


Related to #1526 