### PR TITLE
fix(iso): Use F41 for ISO

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -498,11 +498,11 @@ build-iso $image="bluefin" $tag="latest" $flavor="main" ghcr="0" pipeline="0":
     fi
 
     # Fedora Version
-    if [[ "$tag" != lts ]]; then
-        FEDORA_VERSION=$(${PODMAN} inspect ${IMAGE_FULL} | jq -r '.[]["Config"]["Labels"]["ostree.linux"]' | grep -oP 'fc\K[0-9]+')
-    else
-        FEDORA_VERSION=41
-    fi
+    # if [[ "$tag" != lts ]]; then
+    #     FEDORA_VERSION=$(${PODMAN} inspect ${IMAGE_FULL} | jq -r '.[]["Config"]["Labels"]["ostree.linux"]' | grep -oP 'fc\K[0-9]+')
+    # else
+    FEDORA_VERSION=41
+    # fi
 
     # Load Image into rootful podman
     if [[ "${UID}" -gt 0 && {{ ghcr }} == "0" && ! "${PODMAN}" =~ docker ]]; then


### PR DESCRIPTION
Users are reporting that the F42 ISO is experiencing crashes of the wayland session.

This forces the installer to use F41. This does not affect the target install but will just report that it is F41 in the top right corner.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
