### PR TITLE
feat: Add PipeWire config snippet enabling RAOP module (AirPlay)

### DIFF
--- a/system_files/shared/usr/share/pipewire/pipewire.conf.d/raop-audio.conf
+++ b/system_files/shared/usr/share/pipewire/pipewire.conf.d/raop-audio.conf
@@ -1,0 +1,4 @@
+context.modules = [
+    # Use zeroconf to detect and load module-raop-sink
+    { name = libpipewire-module-raop-discover }
+]


### PR DESCRIPTION
Discover RAOP devices on the local network for audio output.

---

Hi, looking for feedback on this :)

I feel like this is a useful feature that's easily enabled on Fedora's pipewire build.
Also planning to drive this into Fedora Desktops properly, but I figured giving it some downstream soak time can't hurt.
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
