### PR TITLE
fix(pin): linux-firmware to 20250410

### DIFF
--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -14,10 +14,11 @@ set -eoux pipefail
 #    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225
 #fi
 
-if [ "$FEDORA_MAJOR_VERSION" -eq "42" ]; then
-# Workaround atheros-firmware regression, see https://bugzilla.redhat.com/show_bug.cgi?id=2365882
-    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2025-0b94571b06
-fi
+# Use dnf list --showduplicates package
+
+# Workaround atheros-firmware regression
+# see https://bugzilla.redhat.com/show_bug.cgi?id=2365882
+dnf -y swap atheros-firmware atheros-firmware-20250311-1$(rpm -E %{dist})
 
 # Current bluefin systems have the bling.sh and bling.fish in their default locations
 mkdir -p /usr/share/ublue-os/bluefin-cli

--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -14,6 +14,11 @@ set -eoux pipefail
 #    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225
 #fi
 
+if [ "$FEDORA_MAJOR_VERSION" -eq "42" ]; then
+# Workaround atheros-firmware regression, see https://bugzilla.redhat.com/show_bug.cgi?id=2365882
+    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2025-0b94571b06
+fi
+
 # Current bluefin systems have the bling.sh and bling.fish in their default locations
 mkdir -p /usr/share/ublue-os/bluefin-cli
 cp /usr/share/ublue-os/bling/* /usr/share/ublue-os/bluefin-cli


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
This PR fixes a major regression with Atheros firmware, where the current firmware prevents the kernel from loading the module.

https://bugzilla.kernel.org/show_bug.cgi?id=220108
https://bugzilla.redhat.com/show_bug.cgi?id=2365882
https://www.reddit.com/r/archlinux/comments/1kja6f9/ath12k_regression_on_latest_linuxfirmware_upgrade/