### PR TITLE
fix: update docker extension to container extension

### DIFF
--- a/system_files/dx/usr/share/ublue-os/user-setup.hooks.d/10-vscode.sh
+++ b/system_files/dx/usr/share/ublue-os/user-setup.hooks.d/10-vscode.sh
@@ -14,4 +14,4 @@ fi
 
 code --install-extension ms-vscode-remote.remote-containers
 code --install-extension ms-vscode-remote.remote-ssh
-code --install-extension ms-azuretools.vscode-docker
+code --install-extension ms-azuretools.vscode-containers


### PR DESCRIPTION
This is replaced upstream, existing users get prompted to upgrade within vscode anyway

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
