### PR TITLE
fix: pin mutter to .48.1-1 in F42

### DIFF
--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -14,6 +14,13 @@ set -eoux pipefail
 #    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225
 #fi
 
+# Workaround mutter regression, remove in early June
+# https://bugzilla.redhat.com/show_wbug.cgi?id=2369147
+if [[ "${FEDORA_MAJOR_VERSION}" -eq "42" ]]; then
+    dnf5 -y swap mutter mutter-0:48.1-1.fc42 && \
+    dnf5 versionlock add mutter
+fi
+
 # Use dnf list --showduplicates package
 
 # Workaround atheros-firmware regression

--- a/build_files/base/18-workarounds.sh
+++ b/build_files/base/18-workarounds.sh
@@ -15,7 +15,7 @@ set -eoux pipefail
 #fi
 
 # Workaround mutter regression, remove in early June
-# https://bugzilla.redhat.com/show_wbug.cgi?id=2369147
+# https://bugzilla.redhat.com/show_bug.cgi?id=2369147
 if [[ "${FEDORA_MAJOR_VERSION}" -eq "42" ]]; then
     dnf5 -y swap mutter mutter-0:48.1-1.fc42 && \
     dnf5 versionlock add mutter


### PR DESCRIPTION
Avoids https://bugzilla.redhat.com/show_bug.cgi?id=2369147

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
