### PR TITLE
fix(changelogs): Remove Devpod entry now that it's a flatpak

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -61,7 +61,6 @@ From previous `{target}` version `{prev}` there have been the following changes.
 | --- | --- |
 | **Incus** | {pkgrel:incus} |
 | **Docker** | {pkgrel:docker-ce} |
-| **Devpod** | {pkgrel:devpod} |
 
 {changes}
 


### PR DESCRIPTION
Devpod is now a flatpak this remove the following entry from changelogs since it wasn't populated properly (because it's not a package anymore)