### PR TITLE
fix: revert xdg-desktop-portal pin

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -32,7 +32,4 @@ else
     echo "No packages to remove."
 fi
 
-# Add workaround for xdg-desktop-portal
-dnf5 -y upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2025-c358833c5d
-
 echo "::endgroup::"


### PR DESCRIPTION
This is in fedora now

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
