### PR TITLE
fix: update renovate config for automerge to work

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -37,7 +37,7 @@
     {
       "automerge": true,
       "matchUpdateTypes": ["digest"],
-      "matchDepNames": ["ghcr.io/ublue-os/silverblue-nvidia"],
+      "matchDepNames": ["ghcr.io/ublue-os/silverblue-main"],
     }
   ]
 }


### PR DESCRIPTION
renovate seems to be looking for silverblue-nvidia and as that was changed to silverblue-main yesterday, it won't automerge the image updates
