### PR TITLE
feat(bazaar): darken background images and improve padding

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -1,7 +1,7 @@
 css: |
   .bazzite-section {
      margin: 20px;
-     border-radius: 10px;
+     border-radius: 14px;
      background: linear-gradient(to right, alpha(var(--accent-color), 0.2), alpha(var(--accent-bg-color), 0.3));
   }
   .bazzite-section banner {
@@ -9,13 +9,15 @@ css: |
      margin-left: 20px;
      margin-right: 20px;
      border-radius: 10px;
+     filter: brightness(40%);
+     font-size: 3em;
   }
   .bazzite-section banner-text-overlay {
      margin: 30px;
      padding: 20px;
   }
   .bazzite-section banner-text {
-     padding: 50px;
+     padding: 80px;
      color: lighter(var(--accent-color));
   }
   .bazzite-section title {


### PR DESCRIPTION
This darkens the background images for the Bluefin banners used in the Bazaar App Store and makes the text more readable and legible. It also improves padding with the text inside the banners.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
