### PR TITLE
feat(bazaar): Endorse Main Menu instead of Pins in Curated section

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -55,7 +55,7 @@ sections:
       - bazzite-section
     appids:
       - re.sonny.Eloquent
-      - io.github.fabrialberio.pinapp
+      - page.codeberg.libre_menu_editor.LibreMenuEditor
       - app.fotema.Fotema
       - be.alexandervanhee.gradia
       - app.drey.Damask


### PR DESCRIPTION
I propose endorsing Main Menu instead of Pins in the curated section of Bazaar.

Main Menu allows users to customize their app launchers. While both Pins and Main Menu are under the hood just frontends editing .desktop files, Main Menu removes foot guns by not letting the user just edit keys and values and instead exposing approachable settings.

Check out Main Menu: https://flathub.org/apps/page.codeberg.libre_menu_editor.LibreMenuEditor

I'm not affiliated with Main Menu, I'm just a happy user.
