### PR TITLE
chore: Remove Name key from [Unit] ublue-fix-hostname.service

### DIFF
--- a/system_files/shared/usr/lib/systemd/system/ublue-fix-hostname.service
+++ b/system_files/shared/usr/lib/systemd/system/ublue-fix-hostname.service
@@ -1,5 +1,4 @@
 [Unit]
-Name=Universal Blue Missing /etc/hostname Workaround
 Description=Workaround for the missing /etc/hostname file on Universal Blue systems
 After=network.target
 ConditionPathExists=!/etc/hostname


### PR DESCRIPTION
I was doing a `systemd-analyze` as a part of my integrity checks to my bluefin, and noticed that `ublue-fix-hostname.service` has an unknown key `Name` in the `[Unit]` section. This is a super minuscule thing, but from a correctness standpoint there shouldn't be any keys that just get ignored. `Name` isn't a part of the `[Unit]` as per https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#%5BUnit%5D%20Section%20Options