### PR TITLE
feat: add turbowarp to "education" section in bazaar

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -225,6 +225,7 @@ sections:
       - im.bernard.Memorado
       - io.github.josephmawa.Egghead
       - io.github.r_sergii.multiElement
+      - org.turbowarp.TurboWarp
   - title: "AI and Machine Learning"
     subtitle: "Explore the best of open source AI"
     rows: 1


### PR DESCRIPTION
Faster Scratch alternative/fork, also verified on flathub. Big fan of scratch, haven't used it in a while but it was super helpful in learning CS concepts when I was younger.