### PR TITLE
Update logomenu to use gnome-software for Fedora < 42

### DIFF
--- a/build_files/base/07-base-image-changes.sh
+++ b/build_files/base/07-base-image-changes.sh
@@ -30,6 +30,13 @@ if [[ "${FEDORA_MAJOR_VERSION}" -lt "41" ]]; then
     sed -i 's@'", "\''xwayland-native-scaling'\''@@g' /usr/share/glib-2.0/schemas/zz1-bluefin-modifications-mutter-exp-feats.gschema.override
 fi
 
+# Bazaar isn't ready on fedora 41, so for now, set logomenu to still use gnome-software
+# This way the software center option isn't broken for regular users
+# This should be removed as soon as bazaar is ready
+if [[ "${FEDORA_MAJOR_VERSION}" -lt "42" ]]; then
+    sed -i 's/\/usr\/bin\/bazaar window --auto-service/gnome-software/' /etc/dconf/db/distro.d/04-bluefin-logomenu-extension
+fi
+
 # Test bluefin gschema override for errors. If there are no errors, proceed with compiling bluefin gschema, which includes setting overrides.
 mkdir -p /tmp/bluefin-schema-test
 find /usr/share/glib-2.0/schemas/ -type f ! -name "*.gschema.override" -exec cp {} /tmp/bluefin-schema-test/ \;


### PR DESCRIPTION
Adjust the logomenu configuration to utilize gnome-software instead of bazaar for Fedora versions below 42, ensuring functionality for users until bazaar is ready.