### PR TITLE
chore: pin stable to kernel 6.14.11

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      #     kernel_pin: 6.13.8-200.fc41.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.14.11-300.fc42.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Next CoreOS seems to move to 6.15.4 kernel which is affected by the btrfs bug. We should pin stable until a fixed kernel version is available (looks like 6.15.6 is still affected)
