### PR TITLE
chore: pin gts kernel to 6.14.11

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         brand_name: [bluefin]
     with:
-      #     kernel_pin: 6.13.8-200.fc41.x86_64     ## This is where kernels get pinned.
+      kernel_pin: 6.14.11-200.fc41.x86_64    ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: gts
 


### PR DESCRIPTION
Closes https://github.com/ublue-os/bluefin/issues/2778

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
