### PR TITLE
chore: remove image dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -16,19 +16,3 @@ body:
       value: "I'd like to request the package `vim` because ..."
     validations:
       required: true
-  - type: dropdown
-    id: image
-    attributes:
-      label: Image
-      description: Which specific image do you want?
-      options:
-        - All Images
-        - Bazzite
-        - Kinoite
-        - LXQt
-        - Mate
-        - Silverblue
-        - Ubuntu
-        - Vauxite
-    validations:
-      required: true


### PR DESCRIPTION
This must have come from the old main repo or something.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
