### PR TITLE
feat(ci): pin container-storage-action to hash

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Maximize build space
-        uses: ublue-os/container-storage-action@main
+        uses: ublue-os/container-storage-action@fb03d44358403015d2a12cc59c5fb658d957adc2
         with:
           target-dir: /var/lib/containers
           mount-opts: compress-force=zstd:2

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -44,6 +44,7 @@ jobs:
 
       - name: Maximize build space
         uses: ublue-os/container-storage-action@fb03d44358403015d2a12cc59c5fb658d957adc2
+        continue-on-error: true
         with:
           target-dir: /var/lib/containers
           mount-opts: compress-force=zstd:2


### PR DESCRIPTION
the new version of the action has our old action built-in as a fallback
so we won't come into these kind of situations:
https://github.com/ublue-os/bluefin/actions/runs/16705420333/job/47283190810?pr=2914
See: https://github.com/ublue-os/container-storage-action/pull/11