### PR TITLE
chore: enable progress on rclone for ISO Cloudflare uploads

### DIFF
--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -157,4 +157,4 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y rclone
-          rclone copy --stats-one-line "${SOURCE_DIR}" R2:bluefin
+          rclone copy "${SOURCE_DIR}" R2:bluefin


### PR DESCRIPTION
Reverts ublue-os/bluefin#2968 


It needs to be --progress