### PR TITLE
fix: update logic for applying framework laptop 13 fixes

### DIFF
--- a/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
+++ b/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
@@ -40,32 +40,35 @@ fi
 
 SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 
-# FRAMEWORK 13 AMD FIXES
-if [[ "$VEN_ID" == "Framework" && "$SYS_ID" == "Laptop 13 ("* && "$CPU_VENDOR" == "AuthenticAMD" ]]; then
-    echo "Framework Laptop 13 AMD detected"
+# FRAMEWORK 13 FIXES
+if [[ "$VEN_ID" == "Framework" && "$SYS_ID" == "Laptop 13 ("* ]]; then
+    echo "Framework Laptop 13 detected"
 
-    # 3.5mm jack fix
+    # 3.5mm jack fix. Framework 13 laptops need a quirk to disable headset presence detection for the 3.5 mm jack. The kernel auto-enables this quirk for most models but coverage is incomplete (as of kernel 6.16, Framework 13 Ryzen AI 300 is missing) so we enable it here explicitly.
+    # Kernel quirk: https://github.com/torvalds/linux/blame/v6.16/sound/pci/hda/patch_realtek.c#L11445-L11448
     if [[ ! -f /etc/modprobe.d/alsa.conf ]]; then
         echo "Applying 3.5mm audio jack fix"
         tee /etc/modprobe.d/alsa.conf <<<"options snd-hda-intel index=1,0 model=auto,dell-headset-multi"
         echo 0 | tee /sys/module/snd_hda_intel/parameters/power_save
     fi
 
-    # Suspend fix — apply or remove depending on BIOS version
-	# On BIOS versions >= 3.09, the workaround is not needed
-	# (https://knowledgebase.frame.work/framework-laptop-13-bios-and-driver-releases-amd-ryzen-7040-series-r1rXGVL16)
-    if [[ "$(printf '%s\n' 03.09 "$BIOS_VERSION" | sort -V | head -n1)" == "03.09" ]]; then
-        # BIOS is >= 3.09, remove workaround if present
-        if [[ -f /etc/udev/rules.d/20-suspend-fixes.rules ]]; then
-            echo "BIOS $BIOS_VERSION >= 3.09 — removing old suspend workaround"
-            rm -f /etc/udev/rules.d/20-suspend-fixes.rules
-        fi
-    else
+    # Suspend fix for Framework 13 Ryzen 7040
+    # On BIOS versions >= 3.09, the workaround is not needed
+    # (https://knowledgebase.frame.work/framework-laptop-13-bios-and-driver-releases-amd-ryzen-7040-series-r1rXGVL16)
+    if [[ "$SYS_ID" == "Laptop 13 (AMD Ryzen 7040Series)" && "$(printf '%s\n' 03.08 "$BIOS_VERSION" | sort -V | tail -n1)" == "03.08" ]]; then
         # BIOS is older, apply workaround
         if [[ ! -f /etc/udev/rules.d/20-suspend-fixes.rules ]]; then
-            echo "BIOS $BIOS_VERSION < 3.09 — applying suspend workaround"
+            echo "Framework 13 Ryzen 7040 with BIOS $BIOS_VERSION < 3.09 — applying suspend workaround"
             echo 'ACTION=="add", SUBSYSTEM=="serio", DRIVERS=="atkbd", ATTR{power/wakeup}="disabled"' \
                 > /etc/udev/rules.d/20-suspend-fixes.rules
+        fi
+    else
+        # BIOS is >= 3.09, remove workaround if present
+        # Older versions of this script also mistakenly applied then
+        # workaround to Framework 13 Ryzen AI 300. Will get cleaned up here too.
+        if [[ -f /etc/udev/rules.d/20-suspend-fixes.rules ]]; then
+            echo "Removing old suspend workaround"
+            rm -f /etc/udev/rules.d/20-suspend-fixes.rules
         fi
     fi
 fi

--- a/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
+++ b/system_files/shared/usr/share/ublue-os/system-setup.hooks.d/10-framework.sh
@@ -44,12 +44,11 @@ SYS_ID="$(cat /sys/devices/virtual/dmi/id/product_name)"
 if [[ "$VEN_ID" == "Framework" && "$SYS_ID" == "Laptop 13 ("* ]]; then
     echo "Framework Laptop 13 detected"
 
-    # 3.5mm jack fix. Framework 13 laptops need a quirk to disable headset presence detection for the 3.5 mm jack. The kernel auto-enables this quirk for most models but coverage is incomplete (as of kernel 6.16, Framework 13 Ryzen AI 300 is missing) so we enable it here explicitly.
-    # Kernel quirk: https://github.com/torvalds/linux/blame/v6.16/sound/pci/hda/patch_realtek.c#L11445-L11448
+    # Older versions of this script applied a modprobe flag to fix 3.5 mm jack headset detection
+    # which is no longer needed because the kernel applies this automatically.
     if [[ ! -f /etc/modprobe.d/alsa.conf ]]; then
-        echo "Applying 3.5mm audio jack fix"
-        tee /etc/modprobe.d/alsa.conf <<<"options snd-hda-intel index=1,0 model=auto,dell-headset-multi"
-        echo 0 | tee /sys/module/snd_hda_intel/parameters/power_save
+        echo "Removing obsolete 3.5mm audio jack fix"
+        rm -f /etc/modprobe.d/alsa.conf
     fi
 
     # Suspend fix for Framework 13 Ryzen 7040


### PR DESCRIPTION
Two changes:
1. The suspend workaround is specific to Framework 13 Ryzen 7040 but we're also applying it to the recently released Ryzen AI 300 models. These don't need the workaround.
2. The 3.5mm jack workaround is needed for all Framework 13 models. The kernel code applies this workaround automatically for most current Intel/AMD framework models, but it's missing the new Ryzen AI 300. It doesn't seem to hurt to apply this workaround explicitly even when the kernel does it (we've been doing so for the Ryzen 7040 for some time now) so I loosened the condition to apply it to all models.

I've tested this on a Framework 13 Ryzen AI 300. If anyone could test on other Framework 13 models (especially the Ryzen 7040) that would be appreciated!