### PR TITLE
fix: remove ramalama from image

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -140,7 +140,6 @@
 				"podman-tui",
 				"podmansh",
 				"powerline-fonts",
-				"python3-ramalama",
 				"qemu",
 				"qemu-char-spice",
 				"qemu-device-display-virtio-gpu",


### PR DESCRIPTION
we're going to the use the brew package. it keeps getting out of date, let's cut out the distro

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
