### PR TITLE
chore(ci): set prerelease to false in release workflow

### DIFF
--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -61,4 +61,4 @@ jobs:
           tag_name: ${{ steps.generate-release-text.outputs.tag }}
           body_path: ./changelog.md
           make_latest: ${{ matrix.version == 'stable' }}
-          prerelease: ${{ matrix.version != 'stable' }}
+          prerelease: false


### PR DESCRIPTION
This should be set to a normal release. That way gts releases show up as normal. Otherwise downstream automation will have out of date info. 