### PR TITLE
revert "feat: Add bbrew to the motd (#2905)"

### DIFF
--- a/system_files/shared/usr/share/ublue-os/motd/template.md
+++ b/system_files/shared/usr/share/ublue-os/motd/template.md
@@ -7,7 +7,7 @@
 | `ujust --choose`  | Show available commands  |
 | `ujust toggle-user-motd` | Toggle this banner on/off | 
 | `ujust bluefin-cli` | Enable terminal bling | 
-| `brew help` or `bbrew` | Manage command line packages | 
+| `brew help` | Manage command line packages | 
 
 Donate to [Bazaar](https://github.com/kolunmi/bazaar), the next generation app store for Flathub!
 


### PR DESCRIPTION
Reverts ublue-os/bluefin#3042

This will only work on new installs so removing it. 