### PR TITLE
fix: use distroshelf and not boxbuddy

### DIFF
--- a/flatpaks/system-flatpaks.list
+++ b/flatpaks/system-flatpaks.list
@@ -2,7 +2,7 @@ app/com.github.PintaProject.Pinta
 app/com.github.rafostar.Clapper
 app/com.github.tchx84.Flatseal
 app/com.mattjakeman.ExtensionManager
-app/io.github.dvlv.boxbuddyrs
+app/com.ranfdev.DistroShelf
 app/io.github.flattool.Ignition
 app/io.github.flattool.Warehouse
 app/io.gitlab.adhami3310.Impression


### PR DESCRIPTION
For some reason this is boxbuddy instead of the current list, fixing.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
