### PR TITLE
fix: motd unnecessary slash in url (#3090)

### DIFF
--- a/system_files/shared/usr/share/ublue-os/motd/template.md
+++ b/system_files/shared/usr/share/ublue-os/motd/template.md
@@ -12,8 +12,8 @@
 Donate to [Bazaar](https://github.com/kolunmi/bazaar), the next generation app store for Flathub!
 
 - **󰊤** [Issues](https://issues.projectbluefin.io)
-- **󰈙** [Documentation](http://docs.projectbluefin.io/)
-- **󰊌** [Discuss](https://community.projectbluefin.io/)
+- **󰈙** [Documentation](http://docs.projectbluefin.io)
+- **󰊌** [Discuss](https://community.projectbluefin.io)
 - **󰊌** [Leave Feedback](https://feedback.projectbluefin.io)
 
 %KEY_WARN%


### PR DESCRIPTION
Makes the slashes in motd urls consistent, see https://github.com/ublue-os/bluefin/issues/3090
