### PR TITLE
chore: unpin gts and stable kernel

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         brand_name: [bluefin]
     with:
-      kernel_pin: 6.14.11-200.fc41.x86_64    ## This is where kernels get pinned.
+      # kernel_pin: 6.14.11-200.fc41.x86_64    ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: gts
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      kernel_pin: 6.14.11-300.fc42.x86_64 ## This is where kernels get pinned.
+      # kernel_pin: 6.14.11-300.fc42.x86_64 ## This is where kernels get pinned.
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Unpin the kernels in gts and stable.

Needs https://github.com/ublue-os/akmods/pull/401 to be merged