### PR TITLE
chore(iso): remove concurrency

### DIFF
--- a/.github/workflows/reusable-build-iso-anaconda.yml
+++ b/.github/workflows/reusable-build-iso-anaconda.yml
@@ -32,10 +32,6 @@ env:
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
   IMAGE_NAME: "bluefin"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
   # Define which variants to build based on input
   determine-matrix:


### PR DESCRIPTION
Remove concurrency so we can generate lts, lts-hwe, etc by firing off the action multiple times.

Otherwise they cancel each other out.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
