### PR TITLE
fix: remove Terra repo configuration for gnome-shell

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -4,18 +4,6 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
-
-# Enable Terra repo (Extras does not exist on F40)
-# shellcheck disable=SC2016
-dnf5 -y swap \
-    --repo="terra, terra-extras" \
-    gnome-shell gnome-shell
-dnf5 versionlock add gnome-shell
-dnf5 -y swap \
-    --repo="terra, terra-extras" \
-    switcheroo-control switcheroo-control
-dnf5 versionlock add switcheroo-control
-
 # Fix for ID in fwupd
 dnf5 -y swap \
     --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \


### PR DESCRIPTION
Removed Terra repo enablement and version locking for gnome-shell and switcheroo-control.

I'd rather drop this feature than deal with this repo, too many outages, and switcheroo is going upstream.