### PR TITLE
fix: replace unofficial tailscale gui with official option

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -172,22 +172,6 @@ toggle-tailscale:
         echo "Enable or disable Tailscale?"
         TS_OPTION=$(Choose Enable Disable)
 
-        # gnome-extensions is only available on Bluefin (Gnome)
-        if [ "$VARIANT" == "Silverblue" ]; then
-            TAILSCALE_QS="$(gnome-extensions list | grep -q "tailscale@joaophi.github.com"; echo $?)"
-            if [ "$TAILSCALE_QS" == 0 ]; then
-                TAILSCALE_QS="Installed"
-            else
-                echo "The Tailscale QS extension for Gnome is not installed. Please install it and then run this script again."
-            fi
-
-            if [[ "${TS_OPTION,,}" =~ ^enable ]]; then
-                gnome-extensions enable tailscale@joaophi.github.com
-            elif [[ "${TS_OPTION,,}" =~ ^disable ]]; then
-                gnome-extensions disable tailscale@joaophi.github.com
-            fi
-        fi
-
         if [ "$TS_OPTION" = "Enable" ]; then
             systemctl enable --now tailscaled
             TAILSCALED_STATUS="$(systemctl is-enabled tailscaled || true )"


### PR DESCRIPTION
Removed Tailscale extension checks for Silverblue variant. We're using the new feature in the upstream app itself

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
