### PR TITLE
fix(iso): disable suspend during installation and initial setup

### DIFF
--- a/iso_files/configure_iso_anaconda.sh
+++ b/iso_files/configure_iso_anaconda.sh
@@ -20,6 +20,19 @@ welcome-dialog-last-shown-version='4294967295'
 favorite-apps = ['anaconda.desktop', 'documentation.desktop', 'discourse.desktop', 'org.mozilla.firefox.desktop', 'org.gnome.Nautilus.desktop']
 EOF
 
+# Disable suspend/sleep during live environment and initial setup
+# This prevents the system from suspending during installation or first-boot user creation
+tee /usr/share/glib-2.0/schemas/zz3-bluefin-installer-power.gschema.override <<EOF
+[org.gnome.settings-daemon.plugins.power]
+sleep-inactive-ac-type='nothing'
+sleep-inactive-battery-type='nothing'
+sleep-inactive-ac-timeout=0
+sleep-inactive-battery-timeout=0
+
+[org.gnome.desktop.session]
+idle-delay=uint32 0
+EOF
+
 # don't autostart gnome-software session service
 rm -f /etc/xdg/autostart/org.gnome.Software.desktop
 

--- a/iso_files/configure_lts_iso_anaconda.sh
+++ b/iso_files/configure_lts_iso_anaconda.sh
@@ -20,6 +20,18 @@ welcome-dialog-last-shown-version='4294967295'
 favorite-apps = ['anaconda.desktop', 'documentation.desktop', 'discourse.desktop', 'org.mozilla.firefox.desktop', 'org.gnome.Nautilus.desktop']
 EOF
 
+# Disable suspend/sleep during live environment and initial setup
+# This prevents the system from suspending during installation or first-boot user creation
+tee /usr/share/glib-2.0/schemas/zz3-bluefin-installer-power.gschema.override <<EOF
+[org.gnome.settings-daemon.plugins.power]
+sleep-inactive-ac-type='nothing'
+sleep-inactive-battery-type='nothing'
+sleep-inactive-ac-timeout=0
+sleep-inactive-battery-timeout=0
+
+[org.gnome.desktop.session]
+idle-delay=uint32 0
+EOF
 
 glib-compile-schemas /usr/share/glib-2.0/schemas
 


### PR DESCRIPTION
## Problem

Users reported that during Bluefin installation and initial user account setup (GNOME Initial Setup), the system would suspend if the process took too long. When the system attempted to resume from suspend, it would fail to recover properly, resulting in:
- Empty screen with keyboard input but no display
- No disk activity
- Systemd failures

This was particularly problematic during:
1. The live ISO installation process (Anaconda installer)
2. First boot user account creation (GNOME Initial Setup)

## Solution

This PR disables power management (suspend/sleep) completely during the live environment and initial setup by adding GNOME GSettings schema overrides to the ISO configuration scripts.

### Changes Made

Modified two ISO configuration scripts:
- `iso_files/configure_iso_anaconda.sh` - Standard Bluefin ISO
- `iso_files/configure_lts_iso_anaconda.sh` - Bluefin LTS ISO

### What the Fix Does

Added a new GSettings schema override file (`zz3-bluefin-installer-power.gschema.override`) that configures:

1. **Disable AC suspend**: `sleep-inactive-ac-type='nothing'`
2. **Disable battery suspend**: `sleep-inactive-battery-type='nothing'`
3. **Zero timeout for AC**: `sleep-inactive-ac-timeout=0`
4. **Zero timeout for battery**: `sleep-inactive-battery-timeout=0`
5. **Disable idle screen blank**: `idle-delay=uint32 0`

These settings apply only to the live ISO environment and GNOME Initial Setup. After the user completes initial setup and logs in for the first time, the normal Bluefin power management settings will apply from the installed system image.

## Benefits

- ✅ Prevents installation failures due to suspend issues
- ✅ Improves user experience during setup
- ✅ No manual intervention required
- ✅ Works for both AC and battery power
- ✅ Consistent behavior across standard and LTS versions
- ✅ Minimal, surgical modification (only 13 lines per file)

## Testing Recommendations

1. Build test ISO with these changes
2. Install on a laptop (battery powered)
3. During installation, let the system sit idle for 20+ minutes
4. Verify the system does not suspend
5. Complete installation and user setup
6. After first login, verify normal power management works

Fixes #2590