### PR TITLE
feat: add ews support

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -16,6 +16,7 @@
 				"cryfs",
 				"davfs2",
 				"ddcutil",
+				"evolution-ews-core",
 				"evtest",
 				"fastfetch",
 				"firewall-config",


### PR DESCRIPTION
# Add support for EWS

## What

Adds the evolution-ews-core package, this does NOT install the full evolution suite

## Why

- Even if we prefer FOSS solutions, many organisations and individuals use Microsoft 365, having integration with Microsoft calendar and mail is important for many. From my testing it works in the Calendar flatpak and in the top bar calendar dropdown, it does not seem to work with endeavour.
- The option for calendar/mail is there in gnome-online-account, you can activate it, but nothing will happen if you don't have ews installed. This is really confusing behaviour if you don't know how Gnome manages online accounts.


*Thank you JF for teaching me about the existing of the  -core package*