### PR TITLE
revert: "feat: add ews support"

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -16,7 +16,6 @@
 				"cryfs",
 				"davfs2",
 				"ddcutil",
-				"evolution-ews-core",
 				"evtest",
 				"fastfetch",
 				"firewall-config",


### PR DESCRIPTION
Reverts ublue-os/bluefin#3360

Yikes, I messed this up and shouldn't have merged this. Yeah we need to exclude it from gts explicitly. Sorry about that!