### PR TITLE
fix(beta): add mozilla-fira-mono-fonts to dx exclude list

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -223,14 +223,13 @@
 			"all": [
 				"evolution-ews-core"
 			],
-			"dx": [
-				"mozilla-fira-mono-fonts"
-			]
+			"dx": []
 		},
 		"exclude": {
 			"all": [
 				"fwupd",
-				"gnome-software"
+				"gnome-software",
+				"mozilla-fira-mono-fonts"
 			],
 			"dx": []
 		}


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
