### PR TITLE
fix: filter excluded packages from include list before installation

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -9,17 +9,22 @@ readarray -t INCLUDED_PACKAGES < <(jq -r "[(.all.include | (select(.all != null)
                     (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".include | (select(.all != null).all)[])] \
                     | sort | unique[]" /tmp/packages.json)
 
+# build list of all packages requested for exclusion
+readarray -t EXCLUDED_PACKAGES < <(jq -r "[(.all.exclude | (select(.all != null).all)[]), \
+                    (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (select(.all != null).all)[])] \
+                    | sort | unique[]" /tmp/packages.json)
+
+# Filter out excluded packages from the include list
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 && "${#INCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    readarray -t INCLUDED_PACKAGES < <(printf '%s\n' "${INCLUDED_PACKAGES[@]}" | grep -vFx -f <(printf '%s\n' "${EXCLUDED_PACKAGES[@]}"))
+fi
+
 # Install Packages
 if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     dnf5 -y install "${INCLUDED_PACKAGES[@]}"
 else
     echo "No packages to install."
 fi
-
-# build list of all packages requested for exclusion
-readarray -t EXCLUDED_PACKAGES < <(jq -r "[(.all.exclude | (select(.all != null).all)[]), \
-                    (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (select(.all != null).all)[])] \
-                    | sort | unique[]" /tmp/packages.json)
 
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     readarray -t EXCLUDED_PACKAGES < <(rpm -qa --queryformat='%{NAME}\n' "${EXCLUDED_PACKAGES[@]}")

--- a/build_files/dx/03-packages-dx.sh
+++ b/build_files/dx/03-packages-dx.sh
@@ -9,17 +9,22 @@ readarray -t INCLUDED_PACKAGES < <(jq -r "[(.all.include | (select(.dx != null).
                     (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".include | (select(.dx != null).dx)[])] \
                     | sort | unique[]" /tmp/packages.json)
 
+# build list of all packages requested for exclusion
+readarray -t EXCLUDED_PACKAGES < <(jq -r "[(.all.exclude | (select(.dx != null).dx)[]), \
+                    (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (select(.dx != null).dx)[])] \
+                    | sort | unique[]" /tmp/packages.json)
+
+# Filter out excluded packages from the include list
+if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 && "${#INCLUDED_PACKAGES[@]}" -gt 0 ]]; then
+    readarray -t INCLUDED_PACKAGES < <(printf '%s\n' "${INCLUDED_PACKAGES[@]}" | grep -vFx -f <(printf '%s\n' "${EXCLUDED_PACKAGES[@]}"))
+fi
+
 # Install Packages
 if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     dnf5 -y install "${INCLUDED_PACKAGES[@]}"
 else
     echo "No packages to install."
 fi
-
-# build list of all packages requested for exclusion
-readarray -t EXCLUDED_PACKAGES < <(jq -r "[(.all.exclude | (select(.dx != null).dx)[]), \
-                    (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (select(.dx != null).dx)[])] \
-                    | sort | unique[]" /tmp/packages.json)
 
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     readarray -t EXCLUDED_PACKAGES < <(rpm -qa --queryformat='%{NAME}\n' "${EXCLUDED_PACKAGES[@]}")


### PR DESCRIPTION
When building package lists, version-specific excludes now properly override global includes. This prevents installation attempts for packages that don't exist in certain Fedora versions.

The scripts now:
1. Build both include and exclude lists upfront
2. Filter excluded packages from the include list
3. Install only the filtered packages
4. Remove any excluded packages still present from base image

Fixes #3400
