### PR TITLE
fix: add fallback bazaar rpm

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -221,6 +221,7 @@
 	"43": {
 		"include": {
 			"all": [
+				"bazaar",
 				"evolution-ews-core"
 			],
 			"dx": []


### PR DESCRIPTION
We need to have this for now in case something goes wrong with the preinstall stuff, currently there is only the beta that is F43.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
