### PR TITLE
feat: add audioshare to bazaar bluefin media featured

### DIFF
--- a/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
+++ b/system_files/shared/usr/share/ublue-os/bazaar/config.yaml
@@ -124,6 +124,7 @@ sections:
       - tv.plex.PlexDesktop
       - com.plexamp.Plexamp
       - com.rafaelmardojai.Blanket
+      - de.haeckerfelix.AudioSharing
   - title: "Office & Productivity"
     subtitle: "Work Smarter"
     rows: 4


### PR DESCRIPTION
## Description
This PR add AudioShare to the media section of the Bluefin curated app on Bazaar.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI improvement

## Testing Done
- Local build: No
- Tested on running system: No
- Just recipes tested: No

## Related Issues
Fixes #3372
