### PR TITLE
fix(just): remove tailscale just

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -148,63 +148,6 @@ alias rollback-helper := rebase-helper
 rebase-helper:
     @/usr/bin/ublue-rollback-helper
 
-# Toggle tailscale
-[group('System')]
-toggle-tailscale:
-    #!/bin/bash
-    set -euo pipefail
-    source /usr/lib/ujust/ujust.sh
-    source /usr/lib/os-release
-
-    TAILSCALED_STATUS="$(systemctl is-enabled tailscaled || true )"
-
-    if [ "$TAILSCALED_STATUS" == "enabled" ] || [ "$TAILSCALED_STATUS" == "disabled" ]; then
-        TAILSCALED="Installed"
-    else
-        TAILSCALED="Not Found"
-        echo "${b}${red}Unable to enable or disable Tailscale.${n}"
-        echo "The tailscaled service must be present and either enabled or disabled to run this script."
-        echo "tailscaled service status: $TAILSCALED_STATUS"
-    fi
-
-
-    if [ "$TAILSCALED" == "Installed" ]; then
-        echo "Enable or disable Tailscale?"
-        TS_OPTION=$(Choose Enable Disable)
-
-        # gnome-extensions is only available on Bluefin (Gnome)
-        if [ "$VARIANT" == "Silverblue" ]; then
-            TAILSCALE_QS="$(gnome-extensions list | grep -q "tailscale@joaophi.github.com"; echo $?)"
-            if [ "$TAILSCALE_QS" == 0 ]; then
-                TAILSCALE_QS="Installed"
-            else
-                echo "The Tailscale QS extension for Gnome is not installed. Please install it and then run this script again."
-            fi
-
-            if [[ "${TS_OPTION,,}" =~ ^enable ]]; then
-                gnome-extensions enable tailscale@joaophi.github.com
-            elif [[ "${TS_OPTION,,}" =~ ^disable ]]; then
-                gnome-extensions disable tailscale@joaophi.github.com
-            fi
-        fi
-
-        if [ "$TS_OPTION" = "Enable" ]; then
-            systemctl enable --now tailscaled
-            TAILSCALED_STATUS="$(systemctl is-enabled tailscaled || true )"
-            if [ "$TAILSCALED_STATUS" == "enabled" ]; then
-                echo "${b}${green}Tailscale is enabled.${n}"
-                echo "If this is your first time using Tailscale, setup is necessary."
-                echo "Refer to Tailscale's documentation at https://tailscale.com/kb/1346/start."
-            fi
-        elif [ "$TS_OPTION" = "Disable" ]; then
-            systemctl disable --now tailscaled
-            TAILSCALED_STATUS="$(systemctl is-enabled tailscaled || true )"
-            if [ "$TAILSCALED_STATUS" == "disabled" ]; then
-                echo "${b}${red}Tailscale is disabled.${n}"
-            fi
-        fi
-    fi
-
 # Toggle IWD
 [group('System')]
 toggle-iwd:


### PR DESCRIPTION
Removed the toggle-tailscale script from bluefin-system.just. The systray handles all of this stuff and the people who want it off can just turn the service off.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
