### PR TITLE
feat(just): add option to install extra monospace fonts

### DIFF
--- a/just/bluefin-system.just
+++ b/just/bluefin-system.just
@@ -85,6 +85,9 @@ toggle-devmode:
     if gum choose "Do you want to also install the default development flatpaks?" ; then
         ujust install-system-flatpaks 1
     fi
+    if gum choose "Do you want to install extra monospace fonts?" ; then
+        ujust bluefin-fonts
+    fi
 
 # Configure docker,incus-admin,libvirt, container manager, serial permissions
 [group('System')]


### PR DESCRIPTION
Add prompt for installing extra monospace fonts when turn on DX mode.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
