### PR TITLE
fix: remove google-noto-fonts-all

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -99,14 +99,12 @@ case "$FEDORA_MAJOR_VERSION" in
         FEDORA_PACKAGES+=(
             epson-inkjet-printer-escpr
             epson-inkjet-printer-escpr2
-            google-noto-fonts-all
             uld
         )
         ;;
     42)
         FEDORA_PACKAGES+=(
             evolution-ews-core
-            google-noto-fonts-all
             uld
         )
         ;;


### PR DESCRIPTION
Removed 'google-noto-fonts-all' from Fedora package lists.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
