### PR TITLE
feat: schedule GTS and stable releases every Tuesday at 1 AM UTC

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -9,8 +9,8 @@ on:
       - ".github/workflows/*iso*.yml"
       - ".github/workflows/*validate*.yml"
       - "iso_files/**"
-# schedule:
-#   - cron: "50 5 * * 0" # 5:50 UTC Weekly on Sundays
+  schedule:
+    - cron: "0 1 * * TUE" # Every Tuesday at 1:00 AM UTC (same as bluefin-lts)
   workflow_dispatch:
   workflow_call:
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -10,8 +10,8 @@ on:
       - ".github/workflows/*iso*.yml"
       - ".github/workflows/*validate*.yml"
       - "iso_files/**"
-# schedule:
-#   - cron: "50 5 * * 0" # 5:50 UTC sunday
+  schedule:
+    - cron: "0 1 * * TUE" # Every Tuesday at 1:00 AM UTC (same as bluefin-lts)
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
Align release schedule with bluefin-lts to publish GTS and stable images every Tuesday at 1:00 AM UTC instead of Sundays at 5:50 AM UTC.

This gives us the weekends back. 😄 
