### PR TITLE
preinstall: Add CollectionId to the config

### DIFF
--- a/system_files/shared/usr/share/flatpak/preinstall.d/bazaar.preinstall
+++ b/system_files/shared/usr/share/flatpak/preinstall.d/bazaar.preinstall
@@ -1,3 +1,4 @@
 [Flatpak Preinstall io.github.kolunmi.Bazaar]
 Branch=stable
 IsRuntime=false
+CollectionID=org.flathub.Stable


### PR DESCRIPTION
Add a CollectionID so flatpak will only look for the application on Flathub.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
