### PR TITLE
fix: correct check for enabling uupd timer (#3411)

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -32,13 +32,11 @@ if [[ "$(rpm -E %fedora)" -ge "42" ]]; then
 fi
 
 # Updater
-if test -e /usr/lib/systemd/system/uupd.timer; then
-    systemctl enable uupd.timer
-else
-    systemctl enable rpm-ostreed-automatic.timer
-    systemctl enable flatpak-system-update.timer
-    systemctl --global enable flatpak-user-update.timer
-fi
+systemctl enable uupd.timer
+
+# Disable the old update timer
+systemctl disable rpm-ostreed-automatic.timer
+systemctl disable flatpak-system-update.timer
 
 # Hide Desktop Files. Hidden removes mime associations
 for file in fish htop nvtop; do


### PR DESCRIPTION
Replaces the usage of `systemctl cat` in the build process with absolute path references instead, as `systemctl cat` is not functional at build time. This fixes the issue where uupd is always seen as absent in the cleanup script and uupd updates are not enabled.
