### PR TITLE
feat: add util-linux-script

### DIFF
--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -59,6 +59,7 @@ FEDORA_PACKAGES=(
     tiptop
     trace-cmd
     udica
+    util-linux-script
     virt-manager
     virt-v2v
     virt-viewer


### PR DESCRIPTION
Starting with F42, the [`script`](https://en.wikipedia.org/wiki/Script_(Unix)) cmd was [moved to its own pkg](https://discussion.fedoraproject.org/t/usr-bin-script-util-linux-in-f42-is-there-a-replacement/154318).

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
