### PR TITLE
add VK_hdr_layer

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -84,6 +84,7 @@ FEDORA_PACKAGES=(
     tmux
     usbip
     usbmuxd
+    VK_hdr_layer
     waypipe
     wireguard-tools
     wl-clipboard


### PR DESCRIPTION
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

--> 

## Description
Adds Vk_HDR_Layer, required for Nvidia users and to transmit HDR metadata. Gnome supports HDR, required for video content, browsers, and even games. The layer is only activated by manually setting the environment variable ENABLE_HDR_WSI=1. https://packages.fedoraproject.org/pkgs/VK_hdr_layer/VK_hdr_layer/


## Type of Change
- [ ] Bug fix
- [x ] New feature
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI improvement

## Testing Done
- Local build: No
- Tested on running system: Yes
- Just recipes tested: No
