### PR TITLE
fix: install nvidia-container-toolkit in F43

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -90,7 +90,7 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
     case "$FEDORA_MAJOR_VERSION" in
         43)
             echo "%_pkgverify_level none" > /etc/rpm/macros.verify
-            dnf install -y nvidia-container-toolkit
+            dnf5 install -y nvidia-container-toolkit
             rm /etc/rpm/macros.verify
             ;;
     esac

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -83,6 +83,18 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
         fi
     fi
 
+    # Install nvidia-container-toolkit separately to workaround 
+    # https://github.com/NVIDIA/nvidia-container-toolkit/issues/1307
+    #
+    # Should be reverted when the RPM is created with a modern OS
+    case "$FEDORA_MAJOR_VERSION" in
+        43)
+            echo "%_pkgverify_level none" > /etc/rpm/macros.verify
+            dnf install -y nvidia-container-toolkit
+            rm /etc/rpm/macros.verify
+            ;;
+    esac
+
     # Install Nvidia RPMs
     ghcurl "https://raw.githubusercontent.com/ublue-os/main/main/build_files/nvidia-install.sh" -o /tmp/nvidia-install.sh
     chmod +x /tmp/nvidia-install.sh

--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -71,18 +71,6 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
     tar -xvzf /tmp/akmods-rpms/"$NVIDIA_TARGZ" -C /tmp/
     mv /tmp/rpms/* /tmp/akmods-rpms/
 
-    # Exclude the Golang Nvidia Container Toolkit in Fedora Repo
-    # Exclude for non-beta.... doesn't appear to exist for F42 yet?
-    if [[ "${UBLUE_IMAGE_TAG}" != "beta" ]]; then
-        dnf5 config-manager setopt excludepkgs=golang-github-nvidia-container-toolkit
-    else
-        # Monkey patch right now...
-        if ! grep -q negativo17 <(rpm -qi mesa-dri-drivers); then
-            dnf5 -y swap --repo=updates-testing \
-                mesa-dri-drivers mesa-dri-drivers
-        fi
-    fi
-
     # Install nvidia-container-toolkit separately to workaround 
     # https://github.com/NVIDIA/nvidia-container-toolkit/issues/1307
     #
@@ -94,6 +82,18 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
             rm /etc/rpm/macros.verify
             ;;
     esac
+
+    # Exclude the Golang Nvidia Container Toolkit in Fedora Repo
+    # Exclude for non-beta.... doesn't appear to exist for F42 yet?
+    if [[ "${UBLUE_IMAGE_TAG}" != "beta" ]]; then
+        dnf5 config-manager setopt excludepkgs=golang-github-nvidia-container-toolkit
+    else
+        # Monkey patch right now...
+        if ! grep -q negativo17 <(rpm -qi mesa-dri-drivers); then
+            dnf5 -y swap --repo=updates-testing \
+                mesa-dri-drivers mesa-dri-drivers
+        fi
+    fi
 
     # Install Nvidia RPMs
     ghcurl "https://raw.githubusercontent.com/ublue-os/main/main/build_files/nvidia-install.sh" -o /tmp/nvidia-install.sh

--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -112,18 +112,6 @@ if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     fi
 fi
 
-# Install nvidia-container-toolkit separately to workaround 
-# https://github.com/NVIDIA/nvidia-container-toolkit/issues/1307
-#
-# Should be reverted when the RPM is created with a modern OS
-case "$FEDORA_MAJOR_VERSION" in
-    43)
-        echo "%_pkgverify_level none" > /etc/rpm/macros.verify
-        dnf install -y nvidia-container-toolkit
-        rm /etc/rpm/macros.verify
-        ;;
-esac
-
 systemctl enable docker.socket
 systemctl enable podman.socket
 systemctl enable swtpm-workaround.service

--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -112,6 +112,18 @@ if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     fi
 fi
 
+# Install nvidia-container-toolkit separately to workaround 
+# https://github.com/NVIDIA/nvidia-container-toolkit/issues/1307
+#
+# Should be reverted when the RPM is created with a modern OS
+case "$FEDORA_MAJOR_VERSION" in
+    43)
+        echo "%_pkgverify_level none" > /etc/rpm/macros.verify
+        dnf install -y nvidia-container-toolkit
+        rm /etc/rpm/macros.verify
+        ;;
+esac
+
 systemctl enable docker.socket
 systemctl enable podman.socket
 systemctl enable swtpm-workaround.service


### PR DESCRIPTION
Due to he switch to RPM 6, installing the nvidia-container-toolkit 
fails in F43 and was subsequently removed from the 
ublue-os/akmods repo.  
We can add it here with a little hacking around the verification.  
This is not an ideal solution, and must be reverted when Nvidia
starts building with a modern RPM version.

See https://github.com/NVIDIA/nvidia-container-toolkit/issues/1307