### PR TITLE
feat(flatpaks): replace Clapper with Showtime

### DIFF
--- a/flatpaks/system-flatpaks.list
+++ b/flatpaks/system-flatpaks.list
@@ -1,5 +1,4 @@
 app/com.github.PintaProject.Pinta
-app/com.github.rafostar.Clapper
 app/com.github.tchx84.Flatseal
 app/com.mattjakeman.ExtensionManager
 app/com.ranfdev.DistroShelf
@@ -22,6 +21,7 @@ app/org.gnome.Maps
 app/org.gnome.NautilusPreviewer
 app/org.gnome.Papers
 app/org.gnome.SimpleScan
+app/org.gnome.Showtime
 app/org.gnome.TextEditor
 app/org.gnome.Weather
 app/org.gnome.baobab


### PR DESCRIPTION
Clapper is not well maintained and still pulls in the GNOME 47 flatpak runtime.
See https://github.com/flathub/com.github.rafostar.Clapper/issues/61

Let's switch to GNOME Showtime which is well maintained and the official video player for this DE.

Docs PR: https://github.com/ublue-os/bluefin-docs/pull/459
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
