### PR TITLE
feat: add renovate rules for GNOME extension submodules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,11 @@
     },
     ],
 
+  // Enable git-submodules manager for GNOME extensions
+  "git-submodules": {
+    "enabled": true
+  },
+
   "packageRules": [
     {
       "automerge": true,
@@ -38,6 +43,41 @@
       "automerge": true,
       "matchUpdateTypes": ["digest"],
       "matchDepNames": ["ghcr.io/ublue-os/silverblue-main"],
+    },
+    // GNOME extensions git-submodules - track stable releases where available
+    {
+      "matchManagers": ["git-submodules"],
+      "matchPackagePatterns": ["ubuntu/gnome-shell-extension-appindicator"],
+      "versioning": "semver",
+      "automerge": false
+    },
+    {
+      "matchManagers": ["git-submodules"],
+      "matchPackagePatterns": ["micheleg/dash-to-dock"],
+      "versioning": "regex:^extensions\\.gnome\\.org-v(?<major>\\d+)$",
+      "automerge": false
+    },
+    {
+      "matchManagers": ["git-submodules"],
+      "matchPackagePatterns": ["GSConnect/gnome-shell-extension-gsconnect"],
+      "versioning": "semver",
+      "automerge": false
+    },
+    {
+      "matchManagers": ["git-submodules"],
+      "matchPackagePatterns": ["eonpatapon/gnome-shell-extension-caffeine"],
+      "versioning": "semver",
+      "automerge": false
+    },
+    // GNOME extensions without releases - track main/master branch
+    {
+      "matchManagers": ["git-submodules"],
+      "matchPackagePatterns": [
+        "xscriptor/blur-my-shell",
+        "ublue-os/Logomenu",
+        "icedman/search-light"
+      ],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
Fixes #3569

This PR adds Renovate configuration to automatically track and update GNOME extension git submodules.

## Changes
- Enable git-submodules manager to track extension updates
- Configure semantic versioning for extensions with releases:
  - appindicatorsupport (semver)
  - dash-to-dock (custom regex for extensions.gnome.org tags)
  - gsconnect (semver)
  - caffeine (semver)
- Track branch updates for extensions without releases:
  - blur-my-shell
  - Logomenu
  - search-light
- Disable automerge for manual review of extension updates
- Use repository default update schedule for consistency

## Testing
The configuration follows Renovate best practices and is compatible with the org-wide renovate config. Renovate will now automatically create PRs when new releases or commits are available for these extensions.