### PR TITLE
fix: Re-add bcache-tools package required for bcache volumes

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -21,6 +21,7 @@ FEDORA_PACKAGES=(
     adw-gtk3-theme
     adwaita-fonts-all
     bash-color-prompt
+    bcache-tools
     bootc
     borgbackup
     cryfs


### PR DESCRIPTION
Fixes #3557.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
