### PR TITLE
docs: consolidate AI agent instructions into AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,3 +332,17 @@ This repository is complex but well-structured. Following these instructions wil
 - Always be surgical with the least amount of code, the project strives to be easy to maintain.
 - Documentation for this project exists in ublue-os/bluefin-docs
 - Bluefin LTS exists in ublue-os/bluefin-lts
+
+## Attribution Requirements
+
+AI agents must disclose what tool and model they are using in the "Assisted-by" commit footer:
+
+```text
+Assisted-by: [Model Name] via [Tool Name]
+```
+
+Example:
+
+```text
+Assisted-by: Claude 3.5 Sonnet via GitHub Copilot
+```


### PR DESCRIPTION
This PR consolidates AI agent instructions into a single AGENTS.md file in the repository root.

## Changes
- Rename `.github/copilot-instructions.md` to `AGENTS.md` in root
- Add attribution requirements for AI agents

## Attribution Requirements
AI agents must now disclose what tool and model they are using in the "Assisted-by" commit footer:

```
Assisted-by: [Model Name] via [Tool Name]
```

Example:
```
Assisted-by: Claude 3.5 Sonnet via GitHub Copilot
```

This standardizes AI agent identification across all ublue-os repositories.