### PR TITLE
fix: make gts the default entry on rebase-helper

### DIFF
--- a/system_files/shared/usr/bin/ublue-rollback-helper
+++ b/system_files/shared/usr/bin/ublue-rollback-helper
@@ -35,7 +35,7 @@ function rebase_helper() {
 
   # Step 2: Channel Selection
   declare -a CHANNELS
-  CHANNELS=(latest stable stable-daily gts)
+  CHANNELS=(gts stable stable-daily latest)
   echo "The default selection is gts, stable (weekly builds) and stable-daily (daily builds) are for enthusiasts, and latest is for testers"
 
   # Fetch Fedora version per channel and build display list


### PR DESCRIPTION
So currently the rebase helper sets latest as the default selection but the text says "default is gts".
