### PR TITLE
fix(just): change weekly in generate-build-tags

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -770,7 +770,7 @@ generate-build-tags image="bluefin" tag="latest" flavor="main" kernel_pin="" ghc
     set -eou pipefail
 
     TODAY="$(date +%A)"
-    WEEKLY="Sunday"
+    WEEKLY="Tuesday"
     if [[ {{ ghcr }} == "0" ]]; then
         rm -f /tmp/manifest.json
     fi


### PR DESCRIPTION
Change the weekly build day inside the generate-build-tags function. Which was on sunday but changed recently to tuesday

https://github.com/ublue-os/bluefin/discussions/3607