### PR TITLE
fix(changelogs): switch to nvidia-open and drop hwe

### DIFF
--- a/.github/changelogs.py
+++ b/.github/changelogs.py
@@ -34,8 +34,7 @@ OTHER_NAMES = {
     "base": "### Base Images\n| | Name | Previous | New |\n| --- | --- | --- | --- |{changes}\n\n",
     "dx": "### [Dev Experience Images](https://docs.projectbluefin.io/bluefin-dx)\n| | Name | Previous | New |\n| --- | --- | --- | --- |{changes}\n\n",
     "gnome": "### [Bluefin Images](https://projectbluefin.io/)\n| | Name | Previous | New |\n| --- | --- | --- | --- |{changes}\n\n",
-    "nvidia": "### Nvidia Images\n| | Name | Previous | New |\n| --- | --- | --- | --- |{changes}\n\n",
-    "hwe": "### HWE Images\n| | Name | Previous | New |\n| --- | --- | --- | --- |{changes}\n\n",
+    "nvidia-open": "### Nvidia Images\n| | Name | Previous | New |\n| --- | --- | --- | --- |{changes}\n\n",
 }
 
 COMMITS_FORMAT = "### Commits\n| Hash | Subject |\n| --- | --- |{commits}\n\n"
@@ -213,9 +212,7 @@ def get_package_groups(target: str, prev: dict[str, Any], manifests: dict[str, A
             if img not in pkg:
                 continue
 
-            if t == "hwe" and "hwe" not in image_flavor:
-                continue
-            if t == "nvidia" and "nvidia" not in image_flavor:
+            if t == "nvidia-open" and "nvidia-open" not in image_flavor:
                 continue
             if t == "gnome" and de != "gnome":
                 continue


### PR DESCRIPTION
This probably fixes the changelog/release notes problems, by removing `hwe` and `nvida`, and adding `nvidia-open` tags. 

hwe dropped here: https://github.com/ublue-os/bluefin/pull/3428
nvidia closed dropped here: https://github.com/ublue-os/bluefin/pull/3448

Before:
```
bluefin ❯ just changelogs 
Getting bluefin:stable manifest (1/4).
Getting bluefin-nvidia:stable manifest (2/4).
Getting bluefin-dx:stable manifest (3/4).
Getting bluefin-dx-nvidia:stable manifest (4/4).
Previous tag: stable-20251021
 Current tag: stable-20251024
Getting bluefin:stable-20251021 manifest (1/4).
Getting bluefin-nvidia:stable-20251021 manifest (2/4).
Getting bluefin-dx:stable-20251021 manifest (3/4).
Getting bluefin-dx-nvidia:stable-20251021 manifest (4/4).
Changelog:
# stable-20251024: Stable (F42.20251024, #cfec4f3)
--snip--
```
After:
```
bluefin ❯ just changelogs 
Getting bluefin:stable manifest (1/4).
Getting bluefin-nvidia-open:stable manifest (2/4).
Getting bluefin-dx:stable manifest (3/4).
Getting bluefin-dx-nvidia-open:stable manifest (4/4).
Previous tag: stable-20251106
 Current tag: stable-20251111
Getting bluefin:stable-20251106 manifest (1/4).
Getting bluefin-nvidia-open:stable-20251106 manifest (2/4).
Getting bluefin-dx:stable-20251106 manifest (3/4).
Getting bluefin-dx-nvidia-open:stable-20251106 manifest (4/4).
Changelog:
# stable-20251111: Stable (F42.20251111, #cfec4f3)
This is an automatically generated changelog for release `stable-20251111`.

From previous `stable` version `stable-20251106` there have been the following changes. **One package per new version shown.**

### Major packages
| Name | Version |
| --- | --- |
| **Kernel** | 6.16.10-200 |
| **Gnome** | 48.6-1 |
| **Mesa** | 25.1.9-1 |
| **Podman** | 5.6.2-1 |
| **Nvidia** | 580.95.05-1 ➡️ 580.105.08-1 |

### Major DX packages
| Name | Version |
| --- | --- |
| **Incus** | 6.15-1 |
| **Docker** | 28.5.2-1 ➡️ 29.0.0-1 |

### Commits
| Hash | Subject |
| --- | --- |
| **[5db80c5](https://github.com/ublue-os/bluefin/commit/5db80c50912fe8f6791cd17105d014176d6931d4)** | fix(just): change weekly in generate-build-tags (#3609) |

### All Images
| | Name | Previous | New |
| --- | --- | --- | --- |
| 🔄 | LCEVCdec | 4.0.2-1 | 4.0.3-1 |
| 🔄 | davs2-libs | 1.7^20220903gitb41cf11-6 | 1.7^20220903gitb41cf11-7 |
| 🔄 | distrobox | 1.8.1.2-1 | 1.8.2.0-1 |
| 🔄 | dymo-cups-drivers | 1.4.0.5-22 | 1.4.0.5-24 |
| 🔄 | ffmpeg | 7.1.2-3 | 7.1.2-5 |
| 🔄 | fxload | 2008_10_13-30 | 2008_10_13-33 |
| 🔄 | ibus-typing-booster | 2.28.1-1 | 2.28.2-1 |
| 🔄 | ipp-usb | 0.9.30-3 | 0.9.30-7 |
| 🔄 | kernel-tools | 6.17.6-200 | 6.17.7-200 |
| 🔄 | libdrm | 2.4.127-3 | 2.4.128-3 |
| 🔄 | libxavs | 0.1.55~20110821svnr55-2 | 0.1.55~20110821svnr55-3 |
| 🔄 | libxcrypt | 4.4.38-7 | 4.5.0-1 |
| 🔄 | python3-boto3 | 1.40.61-1 | 1.40.67-1 |
| 🔄 | python3-keyring | 25.6.0-2 | 25.6.0-13 |
| 🔄 | qadwaitadecorations-qt5 | 0.1.7-1 | 0.1.7-2 |
| 🔄 | qt5-filesystem | 5.15.17-1 | 5.15.18-1 |
| 🔄 | selinux-policy | 42.13-1 | 42.14-1 |
| 🔄 | solaar-udev | 1.1.14-8 | 1.1.16-1 |
| 🔄 | uavs3d-libs | 1.2.0~20230223git1fd0491-5 | 1.2.0~20230223git1fd0491-6 |
| 🔄 | vim-common | 9.1.1818-1 | 9.1.1888-1 |
| 🔄 | vvdec-libs | 3.0.0-1 | 3.0.0-2 |
| 🔄 | x265-libs | 4.1-4 | 4.1-5 |
| 🔄 | xavs2-libs | 1.4-1 | 1.4-2 |
| 🔄 | xeve-libs | 0.5.1-1 | 0.5.1-2 |

### [Dev Experience Images](https://docs.projectbluefin.io/bluefin-dx)
| | Name | Previous | New |
| --- | --- | --- | --- |
| ✨ | bsdunzip | | 3.8.1-1 |
| ✨ | git-lfs | | 3.7.1-1 |
| 🔄 | cockpit-machines | 342-1 | 343-1 |
| 🔄 | cockpit-ostree | 216-1 | 217-1 |
| 🔄 | cockpit-podman | 115-1 | 116-1 |
| 🔄 | containerd.io | 1.7.29-1 | 2.1.5-1 |
| 🔄 | docker-model-plugin | 0.1.44-1 | 1.0.0-1 |
| 🔄 | flatpak-builder | 1.4.4-3 | 1.4.7-1 |
| 🔄 | libnbd | 1.22.4-1 | 1.22.5-1 |
| 🔄 | libpanel | 1.10.2-1 | 1.10.3-1 |
| 🔄 | libvirt | 11.0.0-4 | 11.0.0-5 |
| 🔄 | xen-libs | 4.19.3-4 | 4.19.3-8 |



### How to rebase
For current users, type the following to rebase to this version:
```bash
# Get Image Name
IMAGE_NAME=$(jq -r '.["image-name"]' < /usr/share/ublue-os/image-info.json)

# For this Stream
sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:stable

# For this Specific Image:
sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/$IMAGE_NAME:stable-20251111

### Documentation
Be sure to read the [documentation](https://docs.projectbluefin.io/) for more information
on how to use your cloud native system.


Output:
TITLE="stable-20251111: Stable (F42.20251111, #cfec4f3)"
TAG=stable-20251111
```