### PR TITLE
fix: pin mutter to 49.1 on f43

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -211,7 +211,7 @@ dnf -y install \
 #    Workaround pkcs11-provider regression, see issue #1943
 #    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225
 #fi
-if [[ "${UBLUE_IMAGE_TAG}" != "latest" && "${UBLUE_IMAGE_TAG}" != "beta" ]] ; then
+if [[ "${UBLUE_IMAGE_TAG}" != "latest" && "${UBLUE_IMAGE_TAG}" != "beta" && "${FEDORA_MAJOR_VERSION}" == "43" ]] ; then
     # Downgrade mutter - 20 Nov 2025 - there seems to be a bug with the latest version
     # where control-alt-<arrow> will leave the arrow key in a weird state,
     # repeating the keystroke until interrupted


### PR DESCRIPTION
Seems that there was a regression on mutter recently.

From @adamisrael on discord:

> Has anyone noticed a change recently where when you
control-alt-<arrow>, the arrow key continues to repeat when you switch
workspace? Started happening to me yesterday, and continues today after
an update. It's quite annoying.

Please unpin whenever this is not necessary anymore. Someone should
periodically check this
