### PR TITLE
fix(mutter): unpin version to most recent one

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -213,13 +213,5 @@ dnf -y install \
 #    Workaround pkcs11-provider regression, see issue #1943
 #    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225
 #fi
-if [[ "${UBLUE_IMAGE_TAG}" != "latest" && "${UBLUE_IMAGE_TAG}" != "beta" && "${FEDORA_MAJOR_VERSION}" == "43" ]] ; then
-    # Downgrade mutter - 20 Nov 2025 - there seems to be a bug with the latest version
-    # where control-alt-<arrow> will leave the arrow key in a weird state,
-    # repeating the keystroke until interrupted
-    # Thank you @adamisrael :salute:
-    # FIXME: please un-pin as soon as this is fixed upstream
-    dnf downgrade -y mutter-49.1-1.fc43
-fi
 
 echo "::endgroup::"


### PR DESCRIPTION
Seems that the regression we ran into is fixed <https://bodhi.fedoraproject.org/updates/FEDORA-2025-98a66bf1df>

Related: https://github.com/ublue-os/bluefin/issues/3696
Related: https://github.com/ublue-os/bluefin/pull/3686