### PR TITLE
fix(uupd): apply disable-module-distrobox on all versions

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -5,10 +5,7 @@ echo "::group:: ===$(basename "$0")==="
 set -eoux pipefail
 
 # Prevent Distrobox containers from being updated via the background service
-if [[ "$(rpm -E %fedora)" -eq "42" ]]; then
-    sed -i 's|uupd|& --disable-module-distrobox|' /usr/lib/systemd/system/uupd.service
-fi
-
+sed -i 's|uupd|& --disable-module-distrobox|' /usr/lib/systemd/system/uupd.service
 
 # Setup Systemd
 systemctl enable rpm-ostree-countme.service


### PR DESCRIPTION
Currently distrobox updates are only disabled on F42. This was introduced in https://github.com/ublue-os/bluefin/pull/2458 and gated because of the availabilty of uupd. 

From now on all images have uupd, so the gate could be removed.