### PR TITLE
chore: clean up a bunch of stuff from the image

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -159,10 +159,10 @@ EXCLUDED_PACKAGES=(
 # Version-specific package exclusions
 case "$FEDORA_MAJOR_VERSION" in
     42)
-        EXCLUDED_PACKAGES+=(gnome-software)
+        EXCLUDED_PACKAGES+=(gnome-software cosign)
         ;;
     43)
-        EXCLUDED_PACKAGES+=(gnome-software)
+        EXCLUDED_PACKAGES+=(gnome-software cosign)
         ;;
 esac
 

--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -4,6 +4,11 @@ echo "::group:: ===$(basename "$0")==="
 
 set -eoux pipefail
 
+# We do not need anything here at all
+rm -rf /usr/src
+rm -rf /usr/share/doc
+
+mkdir -p /usr/share/doc/bluefin
 # Offline Bluefin documentation
 ghcurl "https://github.com/ublue-os/bluefin-docs/releases/download/0.1/bluefin.pdf" --retry 3 -o /tmp/bluefin.pdf
 install -Dm0644 -t /usr/share/doc/bluefin/ /tmp/bluefin.pdf


### PR DESCRIPTION
This is basically an equivalent of [what was done on ublue-os/aurora](https://github.com/ublue-os/aurora/pull/1332) a few days ago, we should save a few hundred megabytes by removing these things from the image

