### PR TITLE
chore: move `ublue-privileged-setup` references to `/usr/bin` instead of `/usr/libexec`

### DIFF
--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/99-privileged.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/99-privileged.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 
 echo "Running all privileged units"
 
-pkexec /usr/libexec/ublue-privileged-setup
+pkexec /usr/bin/ublue-privileged-setup


### PR DESCRIPTION
Required for migration to https://github.com/projectbluefin/common.git -
This is closer to the FHS standard instead of being fedora-specific

Needs to be merged once https://github.com/projectbluefin/common/pull/49 is merged as well
