### PR TITLE
fix: unbreak dx builds

### DIFF
--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -123,8 +123,11 @@ sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 # NOTE: we won't use dnf5 copr plugin for ublue-os/akmods until our upstream provides the COPR standard naming
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 
-for i in /etc/yum.repos.d/rpmfusion-*; do
-    sed -i 's@enabled=1@enabled=0@g' "$i"
+# Disable RPM Fusion repos
+for i in /etc/yum.repos.d/rpmfusion-*.repo; do
+    if [[ -f "$i" ]]; then
+        sed -i 's@enabled=1@enabled=0@g' "$i"
+    fi
 done
 
 echo "::endgroup::"


### PR DESCRIPTION
rpmfusion repos for nvidia and steam got removed in main
https://github.com/ublue-os/main/pull/1841

our logic for disabling them is bad on dx. it's now the same as non-dx

<img width="1004" height="575" alt="image" src="https://github.com/user-attachments/assets/de687423-1e21-40e4-ae81-7240d8a11e3b" />

https://github.com/ublue-os/aurora/actions/runs/20289807224/job/58271525954?pr=1475
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
