### PR TITLE
feat: add containerd

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -24,6 +24,7 @@ FEDORA_PACKAGES=(
     bcache-tools
     bootc
     borgbackup
+    containerd
     cryfs
     davfs2
     ddcutil


### PR DESCRIPTION
This adds containerd to the base image so that users can use docker from brew. This is the first step in removing the need for dedicated DX images.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
