### PR TITLE
fix: remove old motd tips

### DIFF
--- a/system_files/shared/usr/share/ublue-os/motd/tips/10-tips.md
+++ b/system_files/shared/usr/share/ublue-os/motd/tips/10-tips.md
@@ -21,8 +21,5 @@ Switch shells safely: change your shell in Terminal settings instead of system-w
 VS Code comes with devcontainers extension pre-installed - perfect for containerized development
 Container development is OS-agnostic - your devcontainers work on Linux, macOS, and Windows
 Use `docker compose` for multi-container development if devcontainers don't fit your workflow
-`ujust bluefin-k8s` gets you started with Kubernetes development tools like `kind` and `kubectl`
-`ujust bluefin-ai` installs a selection of AI tools
-`ujust bluefin-fonts` installs a well-curated collection of monospace fonts
 Open a folder with Clapgrep (Found in the Bazaar App Store) for super powerful search
 Bluefin separates the OS from your development environment - embrace the cloud-native workflow


### PR DESCRIPTION
## Description

Simply remove three motd tips that do not work anymore. These `just` commands have been replaced by corresponding `ujust bbrew` entries. 

- `ujust bluefin-k8s`
- `ujust bluefin-ai`
- `ujust bluefin-fonts`

Perhaps we should make a tip for `ujust bbrew`. Either way, we should stop telling users to try a command that has been removed. 

## Testing Done

None: this is a trivial, docs-type change. 

## Related Issues

None: I didn't see an issue for this yet and have not created one.
