### PR TITLE
fix: remove ublue-os-luks package (now in common)

### DIFF
--- a/build_files/shared/build.sh
+++ b/build_files/shared/build.sh
@@ -7,8 +7,8 @@ echo "::group:: Copy Files"
 # Copy ISO list for `install-system-flaptaks`
 install -Dm0644 -t /etc/ublue-os/ /ctx/flatpaks/*.list
 
-# We need to remove this package here because lots of files we add from `projectbluefin/common` override the rpm files and they also go away when you do `dnf remove`
-dnf remove -y ublue-os-just ublue-os-signing
+# We need to remove these packages here because lots of files we add from `projectbluefin/common` override the rpm files and they also go away when you do `dnf remove`
+dnf remove -y ublue-os-just ublue-os-signing ublue-os-luks
 
 # Copy Files to Container
 rsync -rvK /ctx/system_files/shared/ /


### PR DESCRIPTION
## Summary

- Add `ublue-os-luks` to `EXCLUDED_PACKAGES` in `04-packages.sh`

The LUKS TPM2 functionality has been moved to projectbluefin/common which provides the new `luks-tpm2-autounlock` script and `ujust toggle-tpm2` command.

Since `ublue-os-luks` is included in the `ublue-os/main` base image, we need to explicitly exclude it. This follows Aurora's approach - using `EXCLUDED_PACKAGES` for packages without file conflicts (unlike `ublue-os-just` which needs early removal in `build.sh`).

## Test plan

- [x] Build completes successfully
- [x] `ublue-os-luks` package is not present in final image (verified via `podman run`)

Closes #3835