### PR TITLE
feat: set CMD as /sbin/init

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -45,4 +45,6 @@ RUN --mount=type=cache,dst=/var/cache/libdnf5 \
 # This is for downstream images/stuff like k0s
 RUN rm -rf /opt && ln -s /var/opt /opt
 
+CMD ["/sbin/init"]
+
 RUN bootc container lint


### PR DESCRIPTION
According to bootc docs it is recommended to be set.

See:
https://bootc-dev.github.io/bootc/building/bootc-runtime.html

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
