### PR TITLE
fix: cleanup /{boot,tmp}

### DIFF
--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -10,7 +10,9 @@ systemctl mask flatpak-add-fedora-repos.service
 rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service
 
 rm -rf /.gitkeep
+find /boot/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
 find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
 find /var/cache/* -maxdepth 0 -type d \! -name libdnf5 \! -name rpm-ostree -exec rm -fr {} \;
+rm -rf /tmp && mkdir -p /tmp
 
 echo "::endgroup::"


### PR DESCRIPTION
bootc lint complains about /boot/symvers-*.xz which is part of the
kernel-core package.

There are leftovers of 600MiB in /tmp due to temporary build artifacts
like akmods, offline docs.

hhd/rechunk previously cleaned this up, so we never noticed.
This is necessary when we move off of this rechunker implementation.

The complaints about /var are expected due to the way we mount
/var/cache as type=cache.

https://github.com/ublue-os/bluefin/actions/runs/20544945789/job/59014202608#step:10:9934