### PR TITLE
fix: motd showing no image tag

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -124,7 +124,6 @@ copr_install_isolated "ublue-os/packages" \
     "bluefin-schemas" \
     "ublue-bling" \
     "ublue-fastfetch" \
-    "ublue-motd" \
     "ublue-polkit-rules" \
     "ublue-setup-services" \
     "uupd"


### PR DESCRIPTION
fixes: https://github.com/projectbluefin/common/issues/93
fixes: https://github.com/ublue-os/bluefin/issues/3939

The package is still there and causes /usr/libexec/ublue-motd to be executed instead of the new /usr/bin/ublue-motd

<img width="1920" height="748" alt="image" src="https://github.com/user-attachments/assets/debb349f-60c9-4f99-87ce-04380d6d3045" />