### PR TITLE
fix: leftover file in /boot for real

### DIFF
--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -10,9 +10,9 @@ systemctl mask flatpak-add-fedora-repos.service
 rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service
 
 rm -rf /.gitkeep
-find /boot/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
 find /var/* -maxdepth 0 -type d \! -name cache -exec rm -fr {} \;
 find /var/cache/* -maxdepth 0 -type d \! -name libdnf5 \! -name rpm-ostree -exec rm -fr {} \;
 rm -rf /tmp && mkdir -p /tmp
+rm -rf /boot && mkdir -p /boot
 
 echo "::endgroup::"


### PR DESCRIPTION
This previously didn't cleanup stray files directly in boot

