### PR TITLE
chore: remove references to brew timer

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -12,8 +12,6 @@ systemctl --global enable bazaar.service
 systemctl --global enable podman-auto-update.timer
 systemctl --global enable ublue-user-setup.service
 systemctl enable brew-setup.service
-systemctl enable brew-update.timer
-systemctl enable brew-upgrade.timer
 systemctl enable dconf-update.service
 systemctl enable flatpak-nuke-fedora.service
 systemctl enable input-remapper.service

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -82,8 +82,6 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
 fi
 
 IMPORTANT_UNITS=(
-    brew-update.timer
-    brew-upgrade.timer
     rpm-ostree-countme.timer
     tailscaled.service
     ublue-system-setup.service


### PR DESCRIPTION
There already is a systemd preset to set this to enabled and uupd handles this for us

Related: https://github.com/projectbluefin/common/issues/121
