### PR TITLE
chore(ci): enable SBOMs

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -96,25 +96,31 @@ jobs:
 
       - name: Setup Syft
         id: setup-syft
-        if: false
+        if: github.event_name != 'pull_request'
         uses: anchore/sbom-action/download-syft@0b82b0b1a22399a1c542d4d656f70cd903571b5c # v0
         with:
-          syft-version: v1.20.0
+          syft-version: v1.39.0
 
       - name: Generate SBOM
-        if: false
+        if: github.event_name != 'pull_request'
         id: generate-sbom
         env:
           IMAGE: ${{ env.IMAGE_NAME }}
           STREAM_NAME: ${{ matrix.stream_name }}
           SYFT_CMD: ${{ steps.setup-syft.outputs.cmd }}
+          OCI_DIR: "/tmp/image-oci-dir"
         run: |
-          sudo systemctl start podman.socket
+          mkdir -p ${OCI_DIR}/rootfs
+          sudo podman container create --replace --name bluefin-tmp "localhost/${IMAGE}:${STREAM_NAME}"
+          sudo podman export bluefin-tmp | sudo tar -C ${OCI_DIR}/rootfs -xf -
+          sudo podman container rm bluefin-tmp
 
           OUTPUT_PATH="$(mktemp -d)/sbom.json"
           export SYFT_PARALLELISM=$(($(nproc)*2))
-          sudo $SYFT_CMD ${IMAGE}:${STREAM_NAME} -o spdx-json=${OUTPUT_PATH}
+          sudo $SYFT_CMD --source-name "${IMAGE}"-"${STREAM_NAME}" ${OCI_DIR} -o syft-json=${OUTPUT_PATH}
+          du -sh ${OUTPUT_PATH}
           echo "OUTPUT_PATH=${OUTPUT_PATH}" >> $GITHUB_OUTPUT
+          sudo rm -rf ${OCI_DIR}
 
       - name: Rechunk Image
         id: rechunk-image
@@ -226,7 +232,7 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
       - name: Add SBOM Attestation
-        if: false
+        if: github.event_name != 'pull_request'
         env:
           IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
           DIGEST: ${{ steps.push.outputs.outputs && fromJSON(steps.push.outputs.outputs).digest }}


### PR DESCRIPTION
This needs to be extracted this way because we don't have enough memory on the github runners. Likely https://github.com/anchore/syft/issues/3800.

We need this for the changelogs when we want to move off of the hhd/rechunker.

addresses: https://github.com/projectbluefin/common/issues/144

works:
`cosign download attestation ghcr.io/renner0e/bluefin:stable | jq -r '.payload' | base64 -d | jq -r "." > sbom.json`

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
