### PR TITLE
chore: remove btrfs-action

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -44,18 +44,6 @@ jobs:
         with:
           submodules: recursive
 
-      # We use both actions as stable nvidia-open-dx failed due to /var/tmp being too small
-
-      # mount /mnt as /var/lib/containers
-      - name: Mount BTRFS for podman storage
-        id: container-storage-action
-        uses: ublue-os/container-storage-action@911baca08baf30c8654933e9e9723cb399892140
-        continue-on-error: true
-        with:
-          target-dir: /var/lib/containers
-          mount-opts: compress-force=zstd:2
-          loopback-free: '1'
-
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
 


### PR DESCRIPTION
Github removed /mnt from their runners and /dev/root is now 145G, before it was 72G so the btrfs action was needed. This action is broken now and always used the fallback path and has no purpose anymore.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
