### PR TITLE
feat: add wtype

### DIFF
--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -63,6 +63,7 @@ FEDORA_PACKAGES=(
     virt-manager
     virt-v2v
     virt-viewer
+    wtype
     ydotool
 )
 


### PR DESCRIPTION
Required by the [`goose` CLI](https://block.github.io/goose/docs/guides/goose-cli-commands/), otherwise it complains:

> Warning: Failed to initialize Linux automation: Required dependency 'wtype' not found

<sub>(I know many people wouldn't wanna take the risk of an AI agent like goose wreaking havoc directly on the host / outside a sandbox... 😅)</sub>