### PR TITLE
fix: pin kernel to 6.17.12 for ZFS compatibility

### DIFF
--- a/.github/workflows/build-image-gts.yml
+++ b/.github/workflows/build-image-gts.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         brand_name: [bluefin]
     with:
-      # kernel_pin: 6.14.11-200.fc41.x86_64    ## This is where kernels get pinned.
+      kernel_pin: 6.17.12-200.fc42.x86_64 ## Pin to 6.17 for ZFS compatibility
       brand_name: ${{ matrix.brand_name }}
       stream_name: gts
 

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      # kernel_pin: 6.14.11-300.fc42.x86_64 ## This is where kernels get pinned.
+      kernel_pin: 6.17.12-200.fc42.x86_64 ## Pin to 6.17 for ZFS compatibility
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
The akmods:coreos-stable-42 container has moved to kernel 6.18.5 but
akmods-zfs:coreos-stable-42 only has ZFS modules for 6.17.12. Without
this pin, builds fail because ZFS modules don't exist for 6.18.

Pins both stable and GTS workflows to 6.17.12-200.fc42.x86_64.

Assisted-by: Claude claude-opus-4.6 via OpenCode