### PR TITLE
fix: turn off bazaar.service

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -8,7 +8,7 @@ set -eoux pipefail
 sed -i 's|uupd|& --disable-module-distrobox|' /usr/lib/systemd/system/uupd.service
 
 # Setup Systemd
-systemctl --global enable bazaar.service
+# systemctl --global enable bazaar.service
 systemctl --global enable podman-auto-update.timer
 systemctl --global enable ublue-user-setup.service
 systemctl enable brew-setup.service


### PR DESCRIPTION
This has been an ever-growing pain in the past few weeks especially. Users sometimes were hit with random timeouts that no one could ever figure out the cause for. This means that search results for bazaar will only appear in the shell when it has been explicitly started by the user beforehand.

Best to disable it and leave the option to enable it if desired.

We can revisit this later when we have found a better solution to this. Aurora has done this since a couple weeks and hasn't received a single report since then.

Fixes: https://github.com/ublue-os/bluefin/issues/4263
Possibly Related: https://github.com/kolunmi/bazaar/issues/1005

See: get-aurora-dev/common#113

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
