### PR TITLE
feat(ci): add DNF package cache to reusable build workflow

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -70,6 +70,33 @@ jobs:
           echo "Default Tag: ${DEFAULT_TAG}"
           echo "DEFAULT_TAG=${DEFAULT_TAG}" >> $GITHUB_ENV
 
+      - name: DNF Package Cache Setup
+        shell: bash
+        id: setup-cache
+        env:
+          MATRIX_BASE_NAME: ${{ matrix.base_name }}
+          MATRIX_STREAM_NAME: ${{ matrix.stream_name }}
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+        run: |
+          CACHE="$(just setup-cache "${MATRIX_BASE_NAME}" \
+                            "${MATRIX_STREAM_NAME}" \
+                            "1" \
+                            "${GITHUB_EVENT_NAME}")"
+
+          CACHE_NAME="$(echo "${CACHE}" | cut -d' ' -f 1)"
+          ALLOW_CACHE_WRITE="$(echo "${CACHE}" | cut -d' ' -f 2)"
+
+          echo "cache_name=${CACHE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "allow_cache_write=${ALLOW_CACHE_WRITE}" >> "$GITHUB_OUTPUT"
+
+      - name: Restore DNF package cache
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        env:
+          CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
+        with:
+          path: /var/tmp/buildah-cache-*
+          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}
+
       - name: Build Image
         id: build-image
         shell: bash
@@ -81,6 +108,22 @@ jobs:
                                "${{ matrix.stream_name }}" \
                                "${{ matrix.image_flavor }}" \
                                "${{ inputs.kernel_pin }}"
+
+      # https://github.com/actions/cache/issues/1533
+      - name: Hack around permission issue caching
+        shell: bash
+        id: cache-perms
+        run: |
+          sudo chmod 777 --recursive /var/tmp/buildah-cache-0
+
+      - name: Write new DNF package cache
+        if: steps.setup-cache.outputs.allow_cache_write == 'true'
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+        env:
+          CACHE_NAME: ${{ steps.setup-cache.outputs.cache_name }}
+        with:
+          path: /var/tmp/buildah-cache-*
+          key: ${{ runner.os }}-${{ runner.arch }}-buildah-${{ env.CACHE_NAME }}
 
       - name: Setup Syft
         id: setup-syft

--- a/Justfile
+++ b/Justfile
@@ -679,6 +679,29 @@ tag-images image_name="" default_tag="" tags="":
     # Show Images
     ${PODMAN} images
 
+# DNF CI package cache
+[group('Utility')]
+setup-cache $image="bluefin" $tag="latest" $ghcr="0" $github_event="0":
+    #!/usr/bin/bash
+    set -eou pipefail
+
+    image_name=$({{ just }} image_name '{{ image }}')
+    fedora_version=$({{ just }} fedora_version '{{ image }}' '{{ tag }}')
+
+    ALLOW_CACHE_WRITE="false"
+
+    BLESSED_IMAGE=bluefin-dx
+
+    if [[ "${image_name}" == "${BLESSED_IMAGE}" ]] && \
+       [[ "{{ ghcr }}" == "1" ]] && \
+       [[ "${github_event}" == "workflow_dispatch" || "${github_event}" == "schedule" ]]; then
+        ALLOW_CACHE_WRITE="true"
+    fi
+
+    CACHE_NAME="${BLESSED_IMAGE}-${fedora_version}"
+
+    echo "${CACHE_NAME}" "${ALLOW_CACHE_WRITE}"
+
 # Examples:
 #   > just retag-nvidia-on-ghcr stable-daily stable-daily-41.20250126.3 0
 #   > just retag-nvidia-on-ghcr latest latest-41.20250228.1 0


### PR DESCRIPTION
## Summary

Adds a DNF package cache to the reusable build workflow, mirroring what Aurora ships. Caches downloaded RPMs between runs using `actions/cache` to speed up subsequent builds.

## Changes

- `.github/workflows/reusable-build.yml` — 4 new steps:
  - **DNF Package Cache Setup** — runs `just setup-cache` to compute cache name and write permission
  - **Restore DNF package cache** — restores cache before Build Image on all matrix jobs
  - **Hack around permission issue caching** — chmod workaround for actions/cache issue 1533
  - **Write new DNF package cache** — saves cache after Build Image, only on `bluefin-dx` + `schedule`/`workflow_dispatch`
- `Justfile` — new `setup-cache` recipe

## Aurora reference

Mirrors Aurora PR 1761 and Aurora PR 1952. Only adaptation: `aurora-dx` → `bluefin-dx` as the blessed cache-writing image.

## Validation

Tested in castrojo/bluefin with two consecutive `workflow_dispatch` runs:
- Run 1 (cold): cache seeded by both `bluefin-dx` jobs in ~13–14 min
- Run 2 (warm): `Restore DNF package cache` hit on all 4 matrix jobs in <1s

Cache write correctly fires only on `bluefin-dx` + `workflow_dispatch`/`schedule`. All other jobs restore-only. Build time improvement compounds across repeated scheduled builds as the RPM set stabilizes.