### PR TITLE
fix: install framework-laptop-kmod-common from akmods common directory

### DIFF
--- a/build_files/base/03-install-kernel-akmods.sh
+++ b/build_files/base/03-install-kernel-akmods.sh
@@ -39,7 +39,7 @@ sed -i 's@enabled=0@enabled=1@g' /etc/yum.repos.d/_copr_ublue-os-akmods.repo
 
 # RPMFUSION Dependent AKMODS
 if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
-    dnf5 -y install /tmp/akmods/kmods/*framework-laptop*.rpm || true
+    dnf5 -y install /tmp/akmods/kmods/*framework-laptop*.rpm /tmp/akmods/common/framework-laptop-kmod-common*.rpm || true
     dnf5 -y install \
         https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm || true
     dnf5 -y install \
@@ -50,7 +50,8 @@ if [[ "${UBLUE_IMAGE_TAG}" == "beta" ]]; then
     dnf5 -y remove rpmfusion-nonfree-release || true
 else
     dnf5 -y install \
-        /tmp/akmods/kmods/*framework-laptop*.rpm
+        /tmp/akmods/kmods/*framework-laptop*.rpm \
+        /tmp/akmods/common/framework-laptop-kmod-common*.rpm
     dnf5 -y install \
         https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-"$(rpm -E %fedora)".noarch.rpm \
         https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-"$(rpm -E %fedora)".noarch.rpm


### PR DESCRIPTION
## Summary

- `kmod-framework-laptop` now declares a dependency on `framework-laptop-kmod-common`, which the akmods bundle places in `/tmp/akmods/common/` (not `kmods/`)
- The existing glob `/tmp/akmods/kmods/*framework-laptop*.rpm` only covers the `kmods/` subdirectory, so the dependency package was never found — causing builds to fail with `nothing provides framework-laptop-kmod-common`
- Fix: explicitly include `/tmp/akmods/common/framework-laptop-kmod-common*.rpm` in both the beta and stable install commands

## Test plan

- [ ] Stable build succeeds without the `conflicting requests` dnf5 error
- [ ] Beta build succeeds (uses `|| true` so previously soft-failed silently)
- [ ] Framework laptop kernel module loads correctly in the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)