### PR TITLE
fix(ci): grant contents:write to generate-release jobs

### DIFF
--- a/.github/workflows/build-image-beta.yml
+++ b/.github/workflows/build-image-beta.yml
@@ -43,6 +43,8 @@ jobs:
   generate-release:
     name: Generate Release
     needs: [build-image-beta]
+    permissions:
+      contents: write
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -37,6 +37,8 @@ jobs:
   generate-release:
     name: Generate Release
     needs: [build-image-latest]
+    permissions:
+      contents: write
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -38,6 +38,8 @@ jobs:
   generate-release:
     name: Generate Release
     needs: [build-image-stable]
+    permissions:
+      contents: write
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:


### PR DESCRIPTION
We need these perms to allow the workflows to also push to releases. Follows Aurora. 

Fixes: https://github.com/ublue-os/bluefin/actions/runs/23756314212
Fixes: https://github.com/ublue-os/bluefin/actions/runs/23756314268

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
