### PR TITLE
fix: clear all versionlocks in clean-stage.sh

### DIFF
--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -5,6 +5,7 @@ echo "::group:: ===$(basename "$0")==="
 set -eoux pipefail
 
 dnf clean all
+dnf versionlock clear
 
 systemctl mask flatpak-add-fedora-repos.service
 rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service


### PR DESCRIPTION
Add `dnf versionlock clear` after `dnf clean all` to ensure kernel versionlocks added during build do not persist into the final image. Mirrors Aurora PR 1817.

Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
