### PR TITLE
feat(ci): upload OCI archive artifact for PR contributor testing

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -247,6 +247,22 @@ jobs:
 
             echo "digest=${digest}" >> $GITHUB_OUTPUT
 
+      - name: Upload OCI dir as Artifact
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          name: ${{ env.IMAGE_NAME }}.oci
+          path: ${{ env.IMAGE_NAME }}_build
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: PR Testing Instructions
+        if: github.event_name == 'pull_request'
+        run: |
+          echo "Download an image, run unzip bluefin.oci.zip -d bluefin" >> $GITHUB_STEP_SUMMARY
+          echo "Rebase to them: sudo bootc switch --transport oci /absolute/path/to/dir/bluefin" >> $GITHUB_STEP_SUMMARY
+          echo "Go back: sudo bootc switch --enforce-container-sigpolicy ghcr.io/ublue-os/bluefin" >> $GITHUB_STEP_SUMMARY
+
       - name: Install Cosign
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
More Renner Ketchup: 

Add upload-artifact step and PR testing instructions to reusable-build.yml so contributors can download and locally test built images without registry push access. Steps fire only on pull_request events. Retention set to 1 day.


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot
