### PR TITLE
fix: disable automerge for projectbluefin/common container updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,11 +39,15 @@
       "automerge": false
     },
     {
+      "matchUpdateTypes": ["pin", "digest", "pinDigest"],
+      "matchDepNames": ["ghcr.io/projectbluefin/common"],
+      "automerge": false
+    },
+    {
       "automerge": true,
       "matchUpdateTypes": ["digest"],
       "matchDepNames": [
-        "ghcr.io/ublue-os/silverblue-main",
-        "ghcr.io/projectbluefin/common"
+        "ghcr.io/ublue-os/silverblue-main"
       ]
     }
   ]


### PR DESCRIPTION
Merge common by hand for now. 

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
