### PR TITLE
fix: exclude gnome-software on all Fedora versions

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -134,6 +134,7 @@ copr_install_isolated "ublue-os/packages" "uupd"
 
 # Packages to exclude - common to all versions
 EXCLUDED_PACKAGES=(
+    cosign
     fedora-bookmarks
     fedora-chromium-config
     fedora-chromium-config-gnome
@@ -147,16 +148,6 @@ EXCLUDED_PACKAGES=(
     podman-docker
     yelp
 )
-
-# Version-specific package exclusions
-case "$FEDORA_MAJOR_VERSION" in
-    42)
-        EXCLUDED_PACKAGES+=(cosign)
-        ;;
-    43)
-        EXCLUDED_PACKAGES+=(cosign)
-        ;;
-esac
 
 # Remove excluded packages if they are installed
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then

--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -141,6 +141,7 @@ EXCLUDED_PACKAGES=(
     firefox-langpacks
     gnome-extensions-app
     gnome-shell-extension-background-logo
+    gnome-software
     gnome-software-rpm-ostree
     gnome-terminal-nautilus
     podman-docker
@@ -150,10 +151,10 @@ EXCLUDED_PACKAGES=(
 # Version-specific package exclusions
 case "$FEDORA_MAJOR_VERSION" in
     42)
-        EXCLUDED_PACKAGES+=(gnome-software cosign)
+        EXCLUDED_PACKAGES+=(cosign)
         ;;
     43)
-        EXCLUDED_PACKAGES+=(gnome-software cosign)
+        EXCLUDED_PACKAGES+=(cosign)
         ;;
 esac
 


### PR DESCRIPTION
Moves gnome-software to the common EXCLUDED_PACKAGES list so it is removed on F44+. F42/43 explicitly exclude the gnome-software package, but F44 doesn't. We're not building F41 anymore, so we can just move to common excludes.