### PR TITLE
fix: ensure xdg-desktop-portal starts after gnome-keyring-daemon

### DIFF
--- a/system_files/shared/usr/lib/systemd/user/xdg-desktop-portal.service.d/30-after-keyring.conf
+++ b/system_files/shared/usr/lib/systemd/user/xdg-desktop-portal.service.d/30-after-keyring.conf
@@ -1,0 +1,9 @@
+[Unit]
+# Ensure gnome-keyring-daemon is running before the portal starts,
+# so the Secret portal backend (org.freedesktop.portal.Secret) is
+# available when xdg-desktop-portal probes for backends.
+# Without this, the portal may start before the keyring and cache
+# stale backend discovery, causing apps like Pika Backup to fail
+# with "background process inactive" or keyring access errors.
+After=gnome-keyring-daemon.service
+Wants=gnome-keyring-daemon.service


### PR DESCRIPTION
Pika Backup cannot connect to the secret service to retrieve or save passwords after each upgrade.

## Reason

xdg-desktop-portal may start before gnome-keyring-daemon registers org.freedesktop.portal.Secret, leaving the Secret portal interface unavailable. This causes Pika Backup and other apps relying on the Secret portal to fail with "background process inactive" or keyring access errors.

## Solution

Add a systemd user drop-in that orders xdg-desktop-portal after gnome-keyring-daemon, ensuring the Secret backend is always discovered during portal startup.