### PR TITLE
ci: fix permissions for Build All Images workflow

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -3,9 +3,11 @@ on:
     workflow_dispatch:
 
 permissions:
-    contents: read
+    contents: write
     packages: write
     id-token: write
+    attestations: write
+    artifact-metadata: write
 
 jobs:
     build-image-stable:


### PR DESCRIPTION
The Build All Images workflow was missing permissions needed by its child workflows, causing a [startup failure](https://github.com/ublue-os/bluefin/actions/runs/14693420663) when dispatched.

- contents: read -> contents: write (needed by generate-release.yml)
- Added attestations: write and artifact-metadata: write (needed for image signing)

Parent workflow permissions act as a ceiling for called workflows, so these must be granted here.