### PR TITLE
feat(ci): auto-bump GNOME extension submodule tags

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -21,6 +21,25 @@
       ],
       datasourceTemplate: 'docker',
     },
+    // Track GNOME extension submodules that pin to a release tag via the
+    // `branch =` field in .gitmodules. Renovate's git-submodules manager
+    // alone can't see new tags because tags don't move; this rewrites the
+    // `branch =` line and the git-submodules manager then advances the SHA.
+    // Uses github-tags (not github-releases) because some upstreams ship
+    // git tags without publishing GitHub Releases (e.g. caffeine).
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^\\.gitmodules$/',
+      ],
+      matchStringsStrategy: 'recursive',
+      matchStrings: [
+        '\\[submodule "[^"]+"\\][^\\[]*?url\\s*=\\s*https?://github\\.com/(?<depName>[^/\\s]+/[^/\\s]+?)(?:\\.git)?\\s[^\\[]*?branch\\s*=\\s*(?<currentValue>\\S*v\\d+\\S*)',
+      ],
+      datasourceTemplate: 'github-tags',
+      versioningTemplate: 'loose',
+      depTypeTemplate: 'gnome-extension',
+    },
     ],
 
   "packageRules": [
@@ -49,6 +68,15 @@
       "matchDepNames": [
         "ghcr.io/ublue-os/silverblue-main"
       ]
+    },
+    {
+      "matchDepTypes": ["gnome-extension"],
+      "matchPackageNames": ["micheleg/dash-to-dock"],
+      "versioning": "regex:^extensions\\.gnome\\.org-v(?<major>\\d+)$"
+    },
+    {
+      "matchDepTypes": ["gnome-extension"],
+      "groupName": "GNOME extensions"
     }
   ]
 }


### PR DESCRIPTION
Adds a Renovate `customManager` so the four GNOME extension submodules pinned to release tags via the `branch
=` field in `.gitmodules` get automatic update PRs. Today they're invisible to Renovate's built-in `git-submodules` manager, that manager only tracks branch *tip* movement, and tags don't move, so new upstream releases are never proposed.

This is the structural cause behind #4574 and #4561: GNOME 50 support landed in `appindicator-support v63`, `caffeine v59`, `dash-to-dock extensions.gnome.org-v103`, and `gsconnect v72`, but Bluefin Latest is still pinned to `v61` / `v58` / `v102` / `v71` because nothing told us they were stale.