### PR TITLE
feat(packages): Add gcc-c++ to packages so Homebrew has a c++

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -36,6 +36,7 @@ FEDORA_PACKAGES=(
     foo2zjs
     fuse-encfs
     gcc
+    gcc-c++
     git-credential-libsecret
     glow
     gnome-tweaks


### PR DESCRIPTION
Homebrew assumes that the OS provides a `c++` executable.

This will add it, per @repires comment [1].

See discussions on Bluefin [1] and Homebrew [2] forums.


[1]: https://github.com/ublue-os/bluefin/discussions/4585#discussioncomment-16847724
[2]: https://github.com/orgs/Homebrew/discussions/6832#discussioncomment-16827154

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
