### PR TITLE
chore: remove own flatpak version

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -169,16 +169,6 @@ dnf -y swap \
     --repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
     fwupd fwupd
 
-# TODO: remove me on next flatpak release when preinstall landed in Fedora
-if [[ "$(rpm -E %fedora)" -ge "42" ]]; then
-  dnf -y copr enable ublue-os/flatpak-test
-  dnf -y copr disable ublue-os/flatpak-test
-  dnf -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test swap flatpak flatpak
-  dnf -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test swap flatpak-libs flatpak-libs
-  dnf -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test swap flatpak-session-helper flatpak-session-helper
-  dnf -y --repo=copr:copr.fedorainfracloud.org:ublue-os:flatpak-test install flatpak-debuginfo flatpak-libs-debuginfo flatpak-session-helper-debuginfo
-fi
-
 ## Pins and Overrides
 ## Use this section to pin packages in order to avoid regressions
 # Remember to leave a note with rationale/link to issue for each pin!

--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -16,10 +16,7 @@ systemctl enable rpm-ostree-countme.service
 systemctl enable tailscaled.service
 systemctl enable ublue-system-setup.service
 
-# run flatpak preinstall once at startup
-if [[ "$(rpm -E %fedora)" -ge "42" ]]; then
-  systemctl enable flatpak-preinstall.service
-fi
+systemctl enable flatpak-preinstall.service
 
 # Updater
 systemctl enable uupd.timer

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -28,9 +28,6 @@ test -f /usr/share/ublue-os/homebrew/fonts.Brewfile
 # See: https://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-preinstall
 test -f /usr/share/flatpak/preinstall.d/bazaar.preinstall
 
-# Basic smoke test to check if the flatpak version is from our copr
-flatpak preinstall --help
-
 # Make sure this garbage never makes it to an image
 test -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service && false
 

--- a/build_files/shared/clean-stage.sh
+++ b/build_files/shared/clean-stage.sh
@@ -8,6 +8,8 @@ set -eoux pipefail
 dnf config-manager setopt keepcache=0
 dnf versionlock clear
 
+# This comes last because we can't *ever* afford to ship fedora flatpaks on the image
+systemctl disable flatpak-add-fedora-repos.service
 systemctl mask flatpak-add-fedora-repos.service
 rm -f /usr/lib/systemd/system/flatpak-add-fedora-repos.service
 


### PR DESCRIPTION
This is shipped in Fedora 44 now, there is no need for our own version.

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
