### PR TITLE
fix: prefer Ptyxis in `xdg-terminal-exec`

### DIFF
--- a/system_files/shared/etc/xdg-terminals.list
+++ b/system_files/shared/etc/xdg-terminals.list
@@ -1,0 +1,1 @@
+org.gnome.Ptyxis.desktop


### PR DESCRIPTION
Fixes https://github.com/ublue-os/bluefin/issues/4606.

Relevant excerpt from `xdg-terminal-exec`'s [man page](https://manpages.debian.org/unstable/xdg-terminal-exec/xdg-terminal-exec.1.en.html):

> Preferred terminals are configured by listing them in config files named `${desktop}-xdg-terminals.list` or `xdg-terminals.list` placed in XDG Config hierarchy.
>
> (...)
>
> Default paths for configuration files (in order of decreasing priority):
> 
> In `${XDG_CONFIG_HOME}`:
> - `${HOME}/.config/${desktop}-xdg-terminals.list`
> - `${HOME}/.config/xdg-terminals.list`
> 
> In `${XDG_CONFIG_DIRS}`:
> - `/etc/xdg/${desktop}-xdg-terminals.list`
> - `/etc/xdg/xdg-terminals.list`
> 
> In `${XDG_DATA_DIRS}`:
> - `/usr/share/xdg-terminal-exec/${desktop}-xdg-terminals.list`
> - `/usr/share/xdg-terminal-exec/xdg-terminals.list`