### PR TITLE
feat: add rechunker-group-fix safety net for legacy rechunk migration

### DIFF
--- a/build_files/base/17-cleanup.sh
+++ b/build_files/base/17-cleanup.sh
@@ -16,6 +16,10 @@ systemctl enable rpm-ostree-countme.service
 systemctl enable tailscaled.service
 systemctl enable ublue-system-setup.service
 
+# see /usr/bin/rechunker-group-fix
+# DO NOT REMOVE THIS
+systemctl enable rechunker-group-fix.service
+
 systemctl enable flatpak-preinstall.service
 
 # Updater

--- a/build_files/base/20-tests.sh
+++ b/build_files/base/20-tests.sh
@@ -79,6 +79,7 @@ if [[ "${IMAGE_NAME}" =~ nvidia ]]; then
 fi
 
 IMPORTANT_UNITS=(
+    rechunker-group-fix.service
     rpm-ostree-countme.timer
     tailscaled.service
     ublue-system-setup.service

--- a/system_files/shared/usr/bin/rechunker-group-fix
+++ b/system_files/shared/usr/bin/rechunker-group-fix
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# To use this script, you'll want to put this in your systemd service:
+# rm /etc/gshadow
+# systemd-sysusers
+# (run this script)
+# systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
+# This will populate /etc/group successfully, and then populate /etc/gshadow
+# with any missing groups that we nuked when we removed /etc/gshadow
+
+GSHADOW_FILE="/etc/gshadow"
+GROUP_FILE="/etc/group"
+
+while IFS= read -r f; do
+   [ -z "$f" ] && continue
+   group_name=$(echo "$f" | cut -f1 -d':')
+   grep -q "^${group_name}:" "$GSHADOW_FILE" || echo "${group_name}:!*::" >> "$GSHADOW_FILE"
+done < "$GROUP_FILE"

--- a/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
+++ b/system_files/shared/usr/lib/systemd/system/rechunker-group-fix.service
@@ -1,0 +1,32 @@
+# We have this script so that people using images with `nss-altfiles` (`/usr/lib/g{roup,shadow}`)
+# do not break their systems when rebasing to an image without that
+# This usually happens when using https://github.com/hhd-dev/rechunk then rebasing to an image without it.
+# Please DO NOT remove this unless this is fully, completely obsolete.
+# This is exactly what is making it break: https://github.com/ublue-os/legacy-rechunk/blob/1d2b0c2e99afbdc2eb06788ae28e157a88b03d70/1_prune.sh#L41-L47
+# Users WILL experience black screens and systems will NOT boot if this script malfunctions. Please test this properly and always make sure this works
+# Relevant issues:
+# - https://github.com/bootc-dev/bootc/issues/1179#issuecomment-2708305926
+# - https://github.com/ublue-os/main/issues/759
+# - https://github.com/ublue-os/bluefin-lts/issues/918
+# - https://github.com/ublue-os/image-template/issues/177
+# - https://github.com/ublue-os/aurora/issues/1468
+# - https://github.com/ublue-os/bluefin/issues/3852
+# This got created on Tue, 16 Dec 2025 00:44:58 -0300
+[Unit]
+Description=Fix groups for Legacy rechunker
+ConditionPathExists=/run/ostree-booted
+ConditionPathExists=!/var/lib/.rechunker-group-fix-done
+Wants=local-fs.target
+After=local-fs.target
+Before=systemd-user-sessions.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/bash -c 'rm -f /etc/gshadow'
+ExecStart=/usr/bin/systemd-sysusers
+ExecStart=/usr/bin/rechunker-group-fix
+ExecStart=/usr/bin/systemd-tmpfiles --create --remove --boot --exclude-prefix=/dev
+ExecStart=/usr/bin/bash -c 'mkdir -p /var/lib && touch /var/lib/.rechunker-group-fix-done'
+
+[Install]
+WantedBy=default.target multi-user.target


### PR DESCRIPTION
Adds a one-shot systemd unit that regenerates `/etc/gshadow` on first boot when migrating from images built with `hhd-dev/legacy-rechunk`'s `nss-altfiles` handling. Without this, users rebasing to images that no longer use the legacy rechunker hit black screens or fail to boot.

The unit is gated by `ConditionPathExists=!/var/lib/.rechunker-group-fix-done` so it runs once per system and never again.

Lands ahead of the rechunker swap so the fix is baked into running systems before they encounter post-swap images.

Split out of #4564 to derisk the change based on feedback by @bsherman.

Refs #4510, #3917
