### PR TITLE
Adds ROCm Info utility

### DIFF
--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -71,7 +71,8 @@ if [[ ! "${IMAGE_NAME}" =~ nvidia ]]; then
   dnf install -y \
     rocm-hip \
     rocm-opencl \
-    rocm-smi
+    rocm-smi \
+    rocminfo
 fi
 
 dnf config-manager addrepo --from-repofile=https://download.docker.com/linux/fedora/docker-ce.repo


### PR DESCRIPTION
Should fix #4660 

Basically adds a line to include `rocminfo` as part of the _DX Experience_.