### PR TITLE
ci: attach SBOMs to releases

### DIFF
--- a/.github/workflows/build-image-beta.yml
+++ b/.github/workflows/build-image-beta.yml
@@ -45,6 +45,7 @@ jobs:
     needs: [build-image-beta]
     permissions:
       contents: write
+      actions: read
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -39,6 +39,7 @@ jobs:
     needs: [build-image-latest]
     permissions:
       contents: write
+      actions: read
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:

--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -40,6 +40,7 @@ jobs:
     needs: [build-image-stable]
     permissions:
       contents: write
+      actions: read
     secrets: inherit
     uses: ./.github/workflows/generate-release.yml
     with:

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: write
+  actions: read
 
 name: Generate Release
 jobs:
@@ -53,6 +54,14 @@ jobs:
           echo "title=${TITLE}" >> $GITHUB_OUTPUT
           echo "tag=${TAG}" >> $GITHUB_OUTPUT
 
+      - name: Download SBOM release assets
+        if: contains(fromJson('["stable"]'), matrix.version) && (github.event.schedule == '0 1 * * TUE' || contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name))
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: sbom-*
+          path: release-assets
+          merge-multiple: true
+
       - name: Create Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         if: contains(fromJson('["stable"]'), matrix.version) && (github.event.schedule == '0 1 * * TUE' || contains(fromJson('["workflow_dispatch", "workflow_call"]'), github.event_name))
@@ -60,5 +69,6 @@ jobs:
           name: ${{ steps.generate-release-text.outputs.title }}
           tag_name: ${{ steps.generate-release-text.outputs.tag }}
           body_path: ./changelog.md
+          files: release-assets/*.sbom.json
           make_latest: ${{ matrix.version == 'stable' }}
           prerelease: false

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -163,6 +163,25 @@ jobs:
           echo "SBOM=${SBOM}" >> $GITHUB_OUTPUT
           sudo rm -rf ${OCI_DIR}
 
+      - name: Prepare SBOM release asset
+        if: github.event_name != 'pull_request'
+        id: prepare-release-sbom
+        env:
+          IMAGE_NAME: ${{ env.IMAGE_NAME }}
+          SBOM: ${{ steps.generate-sbom.outputs.SBOM }}
+        run: |
+          RELEASE_SBOM="$(mktemp -d)/${IMAGE_NAME}.sbom.json"
+          cp "${SBOM}" "${RELEASE_SBOM}"
+          echo "release_sbom=${RELEASE_SBOM}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload SBOM artifact for release workflow
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sbom-${{ env.IMAGE_NAME }}
+          path: ${{ steps.prepare-release-sbom.outputs.release_sbom }}
+          retention-days: 30
+
       - name: Rechunk Image
         id: rechunk-image
         shell: bash


### PR DESCRIPTION
## Summary
- upload each non-PR build SBOM as a workflow artifact from reusable-build
- download those SBOM artifacts in generate-release and attach them to the GitHub release
- grant release jobs actions: read so the artifact download step can run

## Alignment
- Parallel bluefin-lts PR: ublue-os/bluefin-lts#1360

## Validation
- just check
- pre-commit run --files .github/workflows/reusable-build.yml .github/workflows/generate-release.yml .github/workflows/build-image-stable.yml .github/workflows/build-image-latest-main.yml .github/workflows/build-image-beta.yml
