### PR TITLE
fix: remove wallpaper build rewrite

### DIFF
--- a/build_files/base/05-override-install.sh
+++ b/build_files/base/05-override-install.sh
@@ -20,12 +20,6 @@ ghcurl "https://github.com/starship/starship/releases/latest/download/starship-x
 tar -xzf /tmp/starship.tar.gz -C /tmp
 install -c -m 0755 /tmp/starship /usr/bin
 
-# Automatic wallpaper changing by month
-HARDCODED_RPM_MONTH="12"
-sed -i "/picture-uri/ s/${HARDCODED_RPM_MONTH}/$(date +%m)/" "/usr/share/glib-2.0/schemas/zz0-bluefin-modifications.gschema.override"
-rm /usr/share/glib-2.0/schemas/gschemas.compiled
-glib-compile-schemas /usr/share/glib-2.0/schemas
-
 # Required for bluefin faces to work without conflicting with a ton of packages
 rm -f /usr/share/pixmaps/faces/* || echo "Expected directory deletion to fail"
 mv /usr/share/pixmaps/faces/bluefin/* /usr/share/pixmaps/faces


### PR DESCRIPTION
## Summary

- Remove the build-time wallpaper month rewrite from `05-override-install.sh`.

## Why

Dynamic wallpaper rotation is moving to the shared common layer in projectbluefin/common#349. Keeping this build-time sed block would still mutate the default wallpaper gschema during Bluefin image builds.

This is the Bluefin-side cleanup for the approved dynamic wallpaper work from ublue-os/bluefin#3890.

## Testing

- `bash -n build_files/base/05-override-install.sh`
- `git diff --check HEAD~1..HEAD`

Refs projectbluefin/common#349
Refs ublue-os/bluefin#3890
