### PR TITLE
Revert "fix: ensure xdg-desktop-portal starts after gnome-keyring-dae…

### DIFF
--- a/system_files/shared/usr/lib/systemd/user/xdg-desktop-portal.service.d/30-after-keyring.conf
+++ b/system_files/shared/usr/lib/systemd/user/xdg-desktop-portal.service.d/30-after-keyring.conf
@@ -1,9 +1,0 @@
-[Unit]
-# Ensure gnome-keyring-daemon is running before the portal starts,
-# so the Secret portal backend (org.freedesktop.portal.Secret) is
-# available when xdg-desktop-portal probes for backends.
-# Without this, the portal may start before the keyring and cache
-# stale backend discovery, causing apps like Pika Backup to fail
-# with "background process inactive" or keyring access errors.
-After=gnome-keyring-daemon.service
-Wants=gnome-keyring-daemon.service


### PR DESCRIPTION
…mon (#4539)"

This reverts commit 60e72be24878ce01b4849cfb4b8efc18932a133e.

See: https://github.com/ublue-os/bluefin/issues/4683#issuecomment-4548807716

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
