### PR TITLE
chore: Remove bcache-tools package required for bcache volumes

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -22,7 +22,6 @@ FEDORA_PACKAGES=(
     adwaita-fonts-all
     autofs
     bash-color-prompt
-    bcache-tools
     bootc
     borgbackup
     containerd


### PR DESCRIPTION
History:
- The `bcache-tools` package was added at my request in:
  - https://github.com/ublue-os/bluefin/issues/1004
- The package was removed on the assumption it was unused in:
  - https://github.com/ublue-os/bluefin/pull/3299
- Package was re-added when the above removal broke my upgrade from F41 to F42 in: 
  - https://github.com/ublue-os/bluefin/issues/3557 and
  - https://github.com/ublue-os/bluefin/pull/3582

That brings us to today.

I finally upgraded my hardware and no longer use `bcache` (again, not to be confused with `bcachefs`). I think over all this time I have been the sole Bluefin user needing this package. I think you can remove it again. :D