### PR TITLE
fix(ci): use --digestfile to avoid signing race condition

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -235,12 +235,17 @@ jobs:
           command: |
             set -euox pipefail
 
+            digest_file="$PWD/.push-digest"
             for tag in ${{ steps.generate-tags.outputs.alias_tags }}; do
-              sudo -E podman push ${{ env.IMAGE_NAME }}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
+              dest=${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
+              if [[ "${tag}" == "${{ env.DEFAULT_TAG }}" ]]; then
+                sudo -E podman push --digestfile "${digest_file}" ${{ env.IMAGE_NAME }}:${tag} "${dest}"
+              else
+                sudo -E podman push ${{ env.IMAGE_NAME }}:${tag} "${dest}"
+              fi
             done
 
-            digest=$(skopeo inspect docker://${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }} --format '{{.Digest}}')
-
+            digest="$(cat "${digest_file}")"
             echo "digest=${digest}" >> $GITHUB_OUTPUT
 
       - name: Install Cosign
@@ -251,16 +256,6 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
-        env:
-          TAGS: ${{ steps.push.outputs.digest }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-
-      - name: Sign container image
-        if: github.event_name != 'pull_request' && contains(matrix.image_flavor, 'hwe')
-        shell: bash
-        run: |
-          image_name="${{ env.IMAGE_NAME }}"
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false


### PR DESCRIPTION
When concurrent builds run (e.g. workflow_dispatch + merge_group), both push to stable-daily. The previous code captured the digest by doing a skopeo inspect on stable-daily AFTER all pushes, which could read a different run's digest — leaving stable signed against a digest it doesn't point to, causing bootc upgrade to fail with 'signature required but no signature exists'.

Fix: capture the digest via podman push --digestfile during the DEFAULT_TAG push itself. This is atomic and immune to concurrent runs overwriting the same tag in the registry.

Also removes the dead second 'Sign container image' step (HWE condition) which only set a variable and never signed anything.

Fixes: https://github.com/ublue-os/bluefin/issues/4690


Assisted-by: Claude Sonnet 4.6 via GitHub Copilot

<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
