### PR TITLE
feat: add countme.projectbluefin.io weekly user count reporting

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,3 +5,6 @@
 Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.
 
 -->
+
+## Checklist
+- [ ] Trigger a full e2e run on this PR by commenting `/e2e` (write access required)

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -3,6 +3,7 @@
   "extends": [
     "config:best-practices",
   ],
+  "baseBranches": ["testing"],
 
   "git-submodules": {
     "enabled": true

--- a/.github/workflows/build-image-latest-main.yml
+++ b/.github/workflows/build-image-latest-main.yml
@@ -4,7 +4,14 @@ on:
   pull_request:
     branches:
       - main
-      - testing
+    paths-ignore:
+      - ".github/workflows/*validate*.yml"
+      - "**.md"
+      - "flatpaks/**"
+      - "system_files/shared/etc/bazaar/**"
+  push:
+    branches:
+      - main
     paths-ignore:
       - ".github/workflows/*validate*.yml"
       - "**.md"
@@ -34,12 +41,3 @@ jobs:
       brand_name: ${{ matrix.brand_name }}
       stream_name: latest
 
-  generate-release:
-    name: Generate Release
-    needs: [build-image-latest]
-    permissions:
-      contents: write
-    secrets: inherit
-    uses: ./.github/workflows/generate-release.yml
-    with:
-      stream_name: '["latest"]'

--- a/.github/workflows/build-image-testing.yml
+++ b/.github/workflows/build-image-testing.yml
@@ -1,9 +1,17 @@
-name: Stable Images
+name: Testing Images
 on:
-  merge_group: # Make Stable-Daily run on merge groups
+  merge_group:
+  pull_request:
+    branches:
+      - testing
+    paths-ignore:
+      - ".github/workflows/*validate*.yml"
+      - "**.md"
+      - "flatpaks/**"
+      - "system_files/shared/etc/bazaar/**"
   push:
     branches:
-      - main
+      - testing
     paths-ignore:
       - ".github/workflows/*validate*.yml"
       - "**.md"
@@ -20,8 +28,8 @@ permissions:
   artifact-metadata: write
 
 jobs:
-  build-image-stable:
-    name: Build Stable Images
+  build-image-testing:
+    name: Build Testing Images
     uses: ./.github/workflows/reusable-build.yml
     secrets: inherit
     strategy:
@@ -29,16 +37,6 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
- #    kernel_pin: 6.17.12-300.fc43.x86_64 ## Pin to 6.17 for ZFS compatibility
+      image_flavors: '["main", "nvidia-open"]'
       brand_name: ${{ matrix.brand_name }}
-      stream_name: stable
-
-  generate-release:
-    name: Generate Release
-    needs: [build-image-stable]
-    permissions:
-      contents: write
-    secrets: inherit
-    uses: ./.github/workflows/generate-release.yml
-    with:
-      stream_name: '["stable"]'
+      stream_name: testing

--- a/.github/workflows/e2e-dispatch.yml
+++ b/.github/workflows/e2e-dispatch.yml
@@ -1,0 +1,139 @@
+name: E2E Dispatch
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  actions: write
+  packages: write
+  id-token: write
+
+jobs:
+  dispatch:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/e2e')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    outputs:
+      authorized: ${{ steps.permission.outputs.authorized }}
+      image: ${{ steps.pr.outputs.image }}
+    steps:
+      - name: Check commenter permission
+        id: permission
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PERMISSION=$(gh api /repos/${{ github.repository }}/collaborators/${{ github.event.comment.user.login }}/permission \
+            --jq '.permission' 2>/dev/null || echo "none")
+          if [[ "$PERMISSION" == "admin" || "$PERMISSION" == "write" || "$PERMISSION" == "maintain" ]]; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post starting comment
+        if: steps.permission.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --body "🧪 E2E triggered by @${{ github.event.comment.user.login }}. Building PR image and running suites: smoke, developer, vanilla-gnome." \
+            --repo ${{ github.repository }}
+
+      - name: Post unauthorized comment
+        if: steps.permission.outputs.authorized == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --body "❌ /e2e requires write access to this repository." \
+            --repo ${{ github.repository }}
+
+      - name: Exit if unauthorized
+        if: steps.permission.outputs.authorized == 'false'
+        run: exit 1
+
+      - name: Get PR info
+        if: steps.permission.outputs.authorized == 'true'
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PR_DATA=$(gh pr view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json headRefOid,headRefName \
+            --jq '{sha: .headRefOid, branch: .headRefName}')
+          SHA=$(echo "$PR_DATA" | jq -r '.sha')
+          BRANCH=$(echo "$PR_DATA" | jq -r '.branch')
+          SHORT_SHA="${SHA:0:7}"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+          echo "branch=${BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "image=ghcr.io/${{ github.repository_owner }}/bluefin:pr-${{ github.event.issue.number }}-testing-${SHORT_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger PR build
+        if: steps.permission.outputs.authorized == 'true'
+        id: build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          DISPATCH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run build-image-testing.yml \
+            --ref ${{ steps.pr.outputs.branch }} \
+            -R ${{ github.repository }}
+          sleep 60
+          RUN_ID=""
+          for i in $(seq 1 20); do
+            RUN_ID=$(gh run list \
+              --workflow build-image-testing.yml \
+              --branch ${{ steps.pr.outputs.branch }} \
+              --event workflow_dispatch \
+              --repo ${{ github.repository }} \
+              --limit 10 \
+              --json databaseId,createdAt \
+              --jq ".[] | select(.createdAt >= \"${DISPATCH_TIME}\") | .databaseId" \
+              | head -1)
+            [ -n "$RUN_ID" ] && break
+            echo "Waiting for build run to appear (attempt $i/20)..."
+            sleep 30
+          done
+          if [ -z "$RUN_ID" ]; then
+            echo "ERROR: Could not find build run"
+            exit 1
+          fi
+          gh run watch "$RUN_ID" --exit-status -R ${{ github.repository }}
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    if: needs.dispatch.outputs.authorized == 'true'
+    needs: [dispatch]
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@main
+    secrets: inherit
+    with:
+      image: ${{ needs.dispatch.outputs.image }}
+      suites: smoke,developer,vanilla-gnome
+
+  report:
+    needs: [dispatch, e2e]
+    if: always() && needs.dispatch.outputs.authorized == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RESULT: ${{ needs.e2e.result }}
+        run: |
+          if [[ "$RESULT" == "success" ]]; then
+            MSG="✅ E2E passed on ${{ needs.dispatch.outputs.image }}"
+          else
+            MSG="❌ E2E failed on ${{ needs.dispatch.outputs.image }} — check workflow run for details."
+          fi
+          gh issue comment ${{ github.event.issue.number }} \
+            --body "$MSG" \
+            --repo ${{ github.repository }}

--- a/.github/workflows/generate-release.yml
+++ b/.github/workflows/generate-release.yml
@@ -36,9 +36,7 @@ jobs:
           fetch-depth: 500
 
       - name: Install Just
-        run: |
-          /home/linuxbrew/.linuxbrew/bin/brew install just
-          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+        uses: taiki-e/install-action@873c7452cadb7c034694a1282227095d93fbdf92 # just
 
       - name: Check Just Syntax
         shell: bash

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,42 @@
+name: PR Validation — testsuite
+
+on:
+  pull_request:
+    branches:
+      - testing
+  merge_group:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install just
+        uses: taiki-e/install-action@873c7452cadb7c034694a1282227095d93fbdf92 # just
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Check Just syntax
+        shell: bash
+        run: just check
+
+      - name: Shellcheck build scripts
+        shell: bash
+        run: |
+          shopt -s globstar nullglob
+          shellcheck build_files/**/*.sh
+
+      - name: Run pre-commit
+        shell: bash
+        run: pre-commit run --all-files

--- a/.github/workflows/renovate-automerge.yml
+++ b/.github/workflows/renovate-automerge.yml
@@ -1,0 +1,48 @@
+name: Renovate Auto-merge
+
+on:
+  workflow_run:
+    workflows: ["PR Validation — testsuite"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    name: Auto-merge Renovate PRs
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Find Renovate PR for this commit
+        id: find-pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          PR_NUMBER=$(gh pr list \
+            --repo ${{ github.repository }} \
+            --state open \
+            --json number,headRefOid,author \
+            --jq ".[] | select(.headRefOid == \"$HEAD_SHA\") | select(.author.login == \"renovate[bot]\") | .number" \
+            | head -1)
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open Renovate PR found for SHA $HEAD_SHA — skipping"
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Found Renovate PR #$PR_NUMBER"
+            echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enable auto-merge
+        if: steps.find-pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr merge ${{ steps.find-pr.outputs.pr_number }} \
+            --auto \
+            --merge \
+            --repo ${{ github.repository }}
+          echo "✅ Auto-merge enabled on PR #${{ steps.find-pr.outputs.pr_number }}"

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -235,12 +235,17 @@ jobs:
           command: |
             set -euox pipefail
 
+            digest_file="$PWD/.push-digest"
             for tag in ${{ steps.generate-tags.outputs.alias_tags }}; do
-              sudo -E podman push ${{ env.IMAGE_NAME }}:${tag} ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
+              dest=${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
+              if [[ "${tag}" == "${{ env.DEFAULT_TAG }}" ]]; then
+                sudo -E podman push --digestfile "${digest_file}" ${{ env.IMAGE_NAME }}:${tag} "${dest}"
+              else
+                sudo -E podman push ${{ env.IMAGE_NAME }}:${tag} "${dest}"
+              fi
             done
 
-            digest=$(skopeo inspect docker://${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }} --format '{{.Digest}}')
-
+            digest="$(cat "${digest_file}")"
             echo "digest=${digest}" >> $GITHUB_OUTPUT
 
       - name: Install Cosign
@@ -251,16 +256,6 @@ jobs:
         if: github.event_name != 'pull_request'
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
-        env:
-          TAGS: ${{ steps.push.outputs.digest }}
-          COSIGN_EXPERIMENTAL: false
-          COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
-
-      - name: Sign container image
-        if: github.event_name != 'pull_request' && contains(matrix.image_flavor, 'hwe')
-        shell: bash
-        run: |
-          image_name="${{ env.IMAGE_NAME }}"
         env:
           TAGS: ${{ steps.push.outputs.digest }}
           COSIGN_EXPERIMENTAL: false

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -1,6 +1,10 @@
 name: Reusable Build and Push
 on:
   workflow_call:
+    outputs:
+      digests:
+        description: "JSON map of image_name to digest"
+        value: ${{ jobs.collect-digests.outputs.digests }}
     inputs:
       image_flavors:
         description: "JSON string of flavors to build, '[main, nvidia]'"
@@ -32,6 +36,8 @@ jobs:
   build_container:
     name: image
     runs-on: ubuntu-24.04
+    env:
+      DIGEST_FILE: ${{ github.workspace }}/.push-digest
     permissions:
       contents: read
       packages: write
@@ -56,9 +62,7 @@ jobs:
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6 # v10
 
       - name: Install Just
-        run: |
-          /home/linuxbrew/.linuxbrew/bin/brew install just
-          echo "/home/linuxbrew/.linuxbrew/bin" >> $GITHUB_PATH
+        uses: taiki-e/install-action@873c7452cadb7c034694a1282227095d93fbdf92 # just
 
       - name: Check Just Syntax
         shell: bash
@@ -235,18 +239,36 @@ jobs:
           command: |
             set -euox pipefail
 
-            digest_file="$PWD/.push-digest"
+            rm -f "${{ env.DIGEST_FILE }}"
             for tag in ${{ steps.generate-tags.outputs.alias_tags }}; do
               dest=${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
               if [[ "${tag}" == "${{ env.DEFAULT_TAG }}" ]]; then
-                sudo -E podman push --digestfile "${digest_file}" ${{ env.IMAGE_NAME }}:${tag} "${dest}"
+                sudo -E podman push --digestfile "${{ env.DIGEST_FILE }}" ${{ env.IMAGE_NAME }}:${tag} "${dest}"
               else
                 sudo -E podman push ${{ env.IMAGE_NAME }}:${tag} "${dest}"
               fi
             done
 
-            digest="$(cat "${digest_file}")"
-            echo "digest=${digest}" >> $GITHUB_OUTPUT
+      - name: Export digest
+        id: digest
+        if: github.event_name != 'pull_request'
+        run: |
+          DIGEST=$(cat "${{ env.DIGEST_FILE }}")
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+
+      - name: Write digest to artifact
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ env.IMAGE_NAME }}=${{ steps.digest.outputs.digest }}" >> /tmp/digests/${{ matrix.image_flavor }}-${{ matrix.base_name }}.txt
+
+      - name: Upload digest artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@65c4c4a1e8fd04b4e76d21d66c8c49a394765ef9 # v4
+        with:
+          name: image-digest-${{ inputs.stream_name }}-${{ matrix.base_name }}-${{ matrix.image_flavor }}
+          path: /tmp/digests/
+          retention-days: 1
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
@@ -257,7 +279,7 @@ jobs:
         run: |
           cosign sign -y --key env://COSIGN_PRIVATE_KEY ${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}@${TAGS}
         env:
-          TAGS: ${{ steps.push.outputs.digest }}
+          TAGS: ${{ steps.digest.outputs.digest }}
           COSIGN_EXPERIMENTAL: false
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
 
@@ -275,7 +297,7 @@ jobs:
         id: upload-sbom
         env:
           IMAGE: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          DIGEST: ${{ steps.push.outputs.digest }}
+          DIGEST: ${{ steps.digest.outputs.digest }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: |
           SBOM="sbom_out/${IMAGE_NAME}/sbom.json"
@@ -307,7 +329,7 @@ jobs:
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 #v4.1.0
         with:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          subject-digest: ${{ steps.push.outputs.digest }}
+          subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
 
   check:
@@ -330,3 +352,31 @@ jobs:
               exit 1
             fi
           done
+
+  collect-digests:
+    name: Collect image digests
+    runs-on: ubuntu-latest
+    needs: [check]
+    outputs:
+      digests: ${{ steps.merge.outputs.digests || steps.empty.outputs.digests }}
+    steps:
+      - name: Download all digest artifacts
+        if: github.event_name != 'pull_request'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          pattern: image-digest-${{ inputs.stream_name }}-*
+          merge-multiple: true
+          path: /tmp/digests
+
+      - name: Merge digests
+        if: github.event_name != 'pull_request'
+        id: merge
+        run: |
+          DIGESTS=$(cat /tmp/digests/*.txt | jq -Rs 'split("\n") | map(select(length > 0)) | map(split("=")) | map({(.[0]): .[1]}) | add')
+          echo "digests=${DIGESTS}" >> "$GITHUB_OUTPUT"
+
+      - name: Set empty digests
+        if: github.event_name == 'pull_request'
+        id: empty
+        run: |
+          echo 'digests={}' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/weekly-testing-promotion.yml
+++ b/.github/workflows/weekly-testing-promotion.yml
@@ -1,0 +1,188 @@
+name: Weekly Testing Promotion
+
+on:
+  schedule:
+    - cron: '0 6 * * 2' # Tuesday 06:00 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: weekly-testing-promotion
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+  packages: read
+
+jobs:
+  ensure-testing-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    outputs:
+      run_id: ${{ steps.find-run.outputs.run_id }}
+    steps:
+      - name: Record dispatch time
+        run: |
+          set -euo pipefail
+          echo "DISPATCH_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
+      - name: Trigger testing build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run build-image-testing.yml --ref testing -R ${{ github.repository }}
+
+      - name: Wait for API lag
+        run: |
+          set -euo pipefail
+          sleep 60
+
+      - name: Find dispatched testing build run
+        id: find-run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          RUN_ID=""
+          for i in $(seq 1 20); do
+            RUN_ID=$(gh run list \
+              --workflow build-image-testing.yml \
+              --branch testing \
+              --event workflow_dispatch \
+              --repo ${{ github.repository }} \
+              --limit 10 \
+              --json databaseId,createdAt \
+              --jq ".[] | select(.createdAt >= \"$DISPATCH_TIME\") | .databaseId" \
+              | head -1)
+            [ -n "$RUN_ID" ] && break
+            echo "Waiting for build-image-testing.yml run to appear in API (attempt $i/20)..."
+            sleep 30
+          done
+
+          if [ -z "$RUN_ID" ]; then
+            echo "ERROR: Could not locate build-image-testing.yml run dispatched at $DISPATCH_TIME"
+            exit 1
+          fi
+
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+          echo "Found build-image-testing.yml run $RUN_ID"
+
+      - name: Watch testing build run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh run watch "${{ steps.find-run.outputs.run_id }}" --exit-status --repo ${{ github.repository }}
+
+  e2e:
+    needs: [ensure-testing-build]
+    uses: projectbluefin/testsuite/.github/workflows/e2e.yml@main
+    secrets: inherit
+    with:
+      image: ghcr.io/${{ github.repository_owner }}/bluefin:testing
+      suites: smoke,developer,vanilla-gnome
+
+  promote-to-main:
+    needs: [e2e]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      has_diff: ${{ steps.check-diff.outputs.has_diff }}
+    steps:
+      - name: Checkout testing
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: testing
+
+      - name: Configure git
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Check diff between testing and main
+        id: check-diff
+        run: |
+          set -euo pipefail
+          git fetch origin main testing
+          if git diff --quiet origin/main origin/testing; then
+            echo "No diff between testing and main — nothing to promote"
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or find PR and enable auto-merge
+        id: promote
+        if: steps.check-diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          EXISTING=$(gh pr list \
+            --base main \
+            --head testing \
+            --state open \
+            --repo ${{ github.repository }} \
+            --json number \
+            --jq '.[0].number' 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING" ]; then
+            PR_NUMBER="$EXISTING"
+            echo "Found existing PR #$PR_NUMBER"
+          else
+            PR_URL=$(gh pr create \
+              --base main \
+              --head testing \
+              --title "promote: testing → main (weekly e2e passed)" \
+              --body "Automated promotion after weekly e2e passed. Suites: smoke, developer, vanilla-gnome." \
+              --repo ${{ github.repository }})
+            PR_NUMBER="${PR_URL##*/}"
+            echo "Created PR #$PR_NUMBER"
+          fi
+
+          gh pr merge "$PR_NUMBER" --auto --merge --repo ${{ github.repository }}
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for PR to merge
+        if: steps.check-diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          PR_NUMBER="${{ steps.promote.outputs.pr_number }}"
+          for i in $(seq 1 30); do
+            STATE=$(gh pr view "$PR_NUMBER" --repo ${{ github.repository }} --json state --jq '.state')
+            if [ "$STATE" = "MERGED" ]; then
+              echo "PR #$PR_NUMBER merged successfully"
+              exit 0
+            fi
+            if [ "$STATE" = "CLOSED" ]; then
+              echo "ERROR: PR #$PR_NUMBER was closed without merging"
+              exit 1
+            fi
+            echo "Waiting for PR #$PR_NUMBER to merge (attempt $i/30)..."
+            sleep 30
+          done
+
+          echo "ERROR: PR #$PR_NUMBER did not merge within the expected time"
+          exit 1
+
+  trigger-stable-build:
+    needs: [promote-to-main]
+    if: needs.promote-to-main.outputs.has_diff == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger stable build
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh workflow run build-image-stable.yml --ref main -R ${{ github.repository }}
+          echo "✅ Triggered build-image-stable.yml on main"

--- a/Justfile
+++ b/Justfile
@@ -14,6 +14,7 @@ tags := '(
     [stable]=stable
     [latest]=latest
     [beta]=beta
+    [testing]=testing
 )'
 export SUDOIF := if `id -u` == "0" { "" } else { "sudo" }
 export PODMAN := if path_exists("/usr/bin/podman") == "true" { env("PODMAN", "/usr/bin/podman") } else if path_exists("/usr/bin/docker") == "true" { env("PODMAN", "docker") } else { env("PODMAN", "exit 1 ; ") }
@@ -559,6 +560,8 @@ fedora_version image="bluefin" tag="latest" flavor="main" $kernel_pin="":
         if [[ "{{ tag }}" =~ stable ]]; then
             # CoreOS does not uses cosign
             skopeo inspect --retry-times 3 docker://quay.io/fedora/fedora-coreos:stable > /tmp/manifest.json
+        elif [[ "{{ tag }}" == "testing" ]]; then
+            skopeo inspect --retry-times 3 docker://ghcr.io/ublue-os/base-main:latest > /tmp/manifest.json
         else
             skopeo inspect --retry-times 3 docker://ghcr.io/ublue-os/base-main:"{{ tag }}" > /tmp/manifest.json
         fi
@@ -620,6 +623,9 @@ generate-build-tags image="bluefin" tag="latest" flavor="main" kernel_pin="" ghc
         BUILD_TAGS+=("stable-daily" "${version}" "stable-daily-${version}" "stable-daily-${version:3}")
     else
         BUILD_TAGS+=("{{ tag }}" "{{ tag }}-${version}" "{{ tag }}-${version:3}")
+        if [[ "{{ tag }}" == "latest" ]]; then
+            BUILD_TAGS+=("stable-daily" "stable-daily-${version}" "stable-daily-${version:3}")
+        fi
     fi
 
     # Weekly Stable / Rebuild Stable on workflow_dispatch
@@ -630,7 +636,7 @@ generate-build-tags image="bluefin" tag="latest" flavor="main" kernel_pin="" ghc
         BUILD_TAGS+=("stable" "stable-${version}" "stable-${version:3}" "gts" "gts-${version}" "gts-${version:3}")
     elif [[ "{{ tag }}" =~ "stable" && "{{ ghcr }}" == "0" ]]; then
         BUILD_TAGS+=("stable" "stable-${version}" "stable-${version:3}" "gts" "gts-${version}" "gts-${version:3}")
-    elif [[ ! "{{ tag }}" =~ stable|beta ]]; then
+    elif [[ ! "{{ tag }}" =~ stable|beta && "{{ tag }}" != "testing" ]]; then
         BUILD_TAGS+=("${FEDORA_VERSION}" "${FEDORA_VERSION}-${version}" "${FEDORA_VERSION}-${version:3}")
     fi
 
@@ -653,6 +659,8 @@ generate-default-tag tag="latest" ghcr="0":
         DEFAULT_TAG="stable-daily"
     elif [[ "{{ tag }}" =~ stable && "{{ ghcr }}" == "0" ]]; then
         DEFAULT_TAG="stable"
+    elif [[ "{{ tag }}" == "testing" ]]; then
+        DEFAULT_TAG="testing"
     else
         DEFAULT_TAG="{{ tag }}"
     fi

--- a/system_files/shared/etc/yum.repos.d/bluefin-countme.repo
+++ b/system_files/shared/etc/yum.repos.d/bluefin-countme.repo
@@ -1,0 +1,5 @@
+[bluefin-countme]
+name=Bluefin Count Me
+metalink=https://countme.projectbluefin.io/count?os=bluefin&version=$releasever&arch=$basearch
+enabled=1
+countme=1


### PR DESCRIPTION
## Summary

Ship a single `.repo` file that the **existing** `rpm-ostree-countme.timer` reads automatically — no new services, no new binaries.

The timer appends `&countme=N` (1–4 install-age bucket from the existing cookie at `/var/lib/rpm-ostree-countme/countme`) and sends a weekly GET to `countme.projectbluefin.io`.

Fedora's own repos continue reporting to Fedora unchanged — this is additive only.

### What gets sent (once per week maximum)
```
GET https://countme.projectbluefin.io/count?os=bluefin&version=42&arch=x86_64&countme=3
User-Agent: rpm-ostree (Bluefin 42; bluefin; Linux.x86_64)
```

### Infrastructure
- Worker: https://countme.projectbluefin.io (Cloudflare Workers + D1, free tier)
- Badge: `https://img.shields.io/endpoint?url=https://countme.projectbluefin.io/badge/bluefin.json`
- Source: https://github.com/castrojo/copilot-config/tree/main/countme-worker

### Opt-out
Users can opt out by setting `countme=0` in the repo file or removing it — same mechanism as Fedora countme opt-out.

- [ ] I am using an agent and I take responsibility for this PR