### PR TITLE
feat(just): add `just validate-scripts` shellcheck for build scripts

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -35,6 +35,13 @@ check:
     echo "Checking syntax: Justfile"
     {{ just }} --unstable --fmt --check -f Justfile
 
+# Validate Shell Scripts with ShellCheck (requires: shellcheck)
+[group('Just')]
+validate-scripts:
+    #!/usr/bin/bash
+    set -eoux pipefail
+    shellcheck build_files/**/*.sh
+
 # Fix Just Syntax
 [group('Just')]
 fix:


### PR DESCRIPTION
## Summary

Adds a `just validate-scripts` recipe that runs ShellCheck against all `.sh` files under `build_files/`, giving contributors instant feedback on shell script quality without waiting 30–90 min for a full container build.

Closes #4719

## Changes

- Added `validate-scripts` recipe to `Justfile` (group `Just`)
- Runs `shellcheck build_files/**/*.sh` and exits non-zero on any finding
- Required tool documented in recipe comment

## Testing

```
just validate-scripts
```

Can be folded into `just lint` (#4712) once that recipe is added.