### PR TITLE
fix: add standard nvidia_icd.json symlink for Vulkan compatibility

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -179,4 +179,11 @@ dnf -y swap \
 #    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2024-dd2e9fb225
 #fi
 
+# -- Vulkan AppImage Compatibility Fix --
+# Create a standard symlink for NVIDIA Vulkan drivers.
+# Fixes an issue where AppImages and standalone games fail to detect the GPU 
+# because they search for "nvidia_icd.json" instead of the upstream "nvidia_icd.x86_64.json".
+mkdir -p /usr/share/vulkan/icd.d/
+ln -sf /usr/share/vulkan/icd.d/nvidia_icd.x86_64.json /usr/share/vulkan/icd.d/nvidia_icd.json
+
 echo "::endgroup::"


### PR DESCRIPTION
### Context & Issue
On Bluefin (and upstream Fedora), the NVIDIA Vulkan ICD file is provided by RPM Fusion with an architecture suffix: `/usr/share/vulkan/icd.d/nvidia_icd.x86_64.json`. This is done intentionally upstream to avoid conflicts in multilib environments (32-bit and 64-bit coexisting).

While the modern Vulkan loader and native system drivers handle this perfectly, many standalone applications, legacy game engines, and AppImages hardcode their Vulkan driver search exclusively to the default Khronos filename: `nvidia_icd.json`. Because this specific file is missing, these applications fail to initialize the discrete NVIDIA GPU. This results in apps either falling back to the integrated graphics or crashing entirely with `VK_ERROR_INITIALIZATION_FAILED`.

### The Fix
This PR adds a simple backward-compatibility symlink at the end of the base package build script (`04-packages.sh`). It links `nvidia_icd.json` to the actual `nvidia_icd.x86_64.json` file.

By doing this directly in the base image build, we ensure that external and standalone applications can automatically detect and bind to the NVIDIA hardware out-of-the-box. Users will no longer need to manually set `VK_ICD_FILENAMES` or create local `/etc` overrides to make AppImages work.

### Safety Note
On systems that do not use NVIDIA (AMD/Intel setups), this command will create a "dangling" symlink (pointing to a non-existent file). The Vulkan loader is designed to safely ignore invalid or dead symlinks, making this a completely zero-risk workaround for non-NVIDIA users while massively improving the gaming/AppImage experience for NVIDIA users.