### PR TITLE
fix(gnome): use gsettings override for blur-my-shell

### DIFF
--- a/system_files/shared/usr/share/glib-2.0/schemas/zz1-bluefin-extensions.gschema.override
+++ b/system_files/shared/usr/share/glib-2.0/schemas/zz1-bluefin-extensions.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.shell.extensions.blur-my-shell.popup]
+blur=false

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
@@ -6,9 +6,6 @@ version-script theming user 1 || exit 0
 
 set -xeuo pipefail
 
-echo 'Disabling Blur my Shell popup blur by default'
-dconf write /org/gnome/shell/extensions/blur-my-shell/popup/blur false
-
 VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
 
 if [[ ":Framework:" =~ :$VEN_ID: ]]; then


### PR DESCRIPTION
## Summary
- Move the Blur my Shell popup default to a system-wide GSettings override
- Remove the per-user dconf write from the theming setup hook

## Testing
- `bash -n system_files/shared/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh`
