### PR TITLE
fix(gnome): use system-wide dconf override for blur-my-shell

### DIFF
--- a/system_files/shared/etc/dconf/db/distro.d/05-blur-my-shell-extension
+++ b/system_files/shared/etc/dconf/db/distro.d/05-blur-my-shell-extension
@@ -1,0 +1,3 @@
+# Disable Blur my Shell popup blur by default system-wide
+[org/gnome/shell/extensions/blur-my-shell/popup]
+blur=false

--- a/system_files/shared/usr/share/glib-2.0/schemas/zz1-bluefin-extensions.gschema.override
+++ b/system_files/shared/usr/share/glib-2.0/schemas/zz1-bluefin-extensions.gschema.override
@@ -1,2 +1,0 @@
-[org.gnome.shell.extensions.blur-my-shell.popup]
-blur=false

--- a/system_files/shared/usr/share/glib-2.0/schemas/zz1-bluefin-extensions.gschema.override
+++ b/system_files/shared/usr/share/glib-2.0/schemas/zz1-bluefin-extensions.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.shell.extensions.blur-my-shell.popup]
+blur=false

--- a/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
+++ b/system_files/shared/usr/share/ublue-os/user-setup.hooks.d/10-theming.sh
@@ -6,9 +6,6 @@ version-script theming user 1 || exit 0
 
 set -xeuo pipefail
 
-echo 'Disabling Blur my Shell popup blur by default'
-dconf write /org/gnome/shell/extensions/blur-my-shell/popup/blur false
-
 VEN_ID="$(cat /sys/devices/virtual/dmi/id/chassis_vendor)"
 
 if [[ ":Framework:" =~ :$VEN_ID: ]]; then


### PR DESCRIPTION
## Summary
Move the default setting for Blur My Shell popup blur from a GSettings schema override to a system-wide dconf override database.

## Problem
In PR #4819, we introduced a GSettings schema override at `/usr/share/glib-2.0/schemas/zz1-bluefin-extensions.gschema.override`. However, this does not work because `blur-my-shell` is built from source during image creation as a git submodule and its schema is only compiled in-situ inside its individual extension folder. Since the schema is not registered globally under `/usr/share/glib-2.0/schemas/`, the GSettings compiler silently ignores the override.

## Solution
Rather than copying extension schemas globally (which is invasive and prone to conflicts), we use a system-wide dconf override under `/etc/dconf/db/distro.d/`. 

Dconf is a simple key-value store database compiled at boot time via `dconf-update.service` (`dconf update`) and does not validate keys against GSettings schemas during compilation. This is the exact non-invasive pattern already utilized in Bluefin for other extensions like Search Light.

1. Removed the failed override at `system_files/shared/usr/share/glib-2.0/schemas/zz1-bluefin-extensions.gschema.override`.
2. Created a new dconf configuration file under `system_files/shared/etc/dconf/db/distro.d/05-blur-my-shell-extension` with `blur=false`.

Assisted-by: Gemini 3.5 Flash via GitHub Copilot
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>