### PR TITLE
fix(release): pin stable kernel for ZFS

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -31,7 +31,7 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
- #    kernel_pin: 6.17.12-300.fc43.x86_64 ## Pin to 6.17 for ZFS compatibility
+      kernel_pin: 7.0.12-201.fc44.x86_64
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
Pins Stable Images to `7.0.12-201.fc44.x86_64` until akmods catches up. 