### PR TITLE
fix(build): resolve podman at /usr/local/bin

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -16,7 +16,7 @@ tags := '(
     [beta]=beta
 )'
 export SUDOIF := if `id -u` == "0" { "" } else { "sudo" }
-export PODMAN := if path_exists("/usr/bin/podman") == "true" { env("PODMAN", "/usr/bin/podman") } else if path_exists("/usr/bin/docker") == "true" { env("PODMAN", "docker") } else { env("PODMAN", "exit 1 ; ") }
+export PODMAN := if path_exists("/usr/bin/podman") == "true" { env("PODMAN", "/usr/bin/podman") } else if path_exists("/usr/local/bin/podman") == "true" { env("PODMAN", "/usr/local/bin/podman") } else if path_exists("/usr/bin/docker") == "true" { env("PODMAN", "docker") } else { env("PODMAN", "exit 1 ; ") }
 export PULL_POLICY := if PODMAN =~ "docker" { "missing" } else { "newer" }
 just := just_executable()
 


### PR DESCRIPTION
## Problem

Every `Latest Images` build has been failing:

```
> [base 1/4] FROM ghcr.io/ublue-os/silverblue-main:44@sha256:da9d42d...
ERROR: failed to build: failed to solve: failed to register layer: max depth exceeded
```

## Root cause

GitHub's `ubuntu-24.04` runner image bumped from `20260720.247.2` to `20260804.265.1`. Per [`install-container-tools.sh`](https://github.com/actions/runner-images/blob/main/images/ubuntu/scripts/build/install-container-tools.sh), podman is no longer installed via apt — it now ships as a **static bundle at `/usr/local/bin/podman`** (4.9.3 → 5.8.4). Only `buildah`, `skopeo` and `uidmap` still come from apt, and none of them pull in podman, so `/usr/bin/podman` no longer exists.

The Justfile probed `/usr/bin/podman` only, so it silently fell through to `docker`.

Docker's overlay2 driver caps stacked lower dirs at **128**. Layer counts:

| Image | Layers |
|---|---|
| `silverblue-main:43` | 99 |
| `silverblue-main:44` | **259** |

F43 squeaked under the cap, so the fallback went unnoticed. F44 does not, and the build dies at the `FROM` line before running a single build script.

Evidence that podman is fine with the identical base — the passing Stable job on the older runner:

```
+ /usr/bin/podman build --build-arg IMAGE_FLAVOR=dx ...
[4/4] STEP 1/16: FROM ghcr.io/ublue-os/silverblue-main:44 AS base
```

vs. the failing Latest job on the new runner:

```
+ docker build --build-arg IMAGE_FLAVOR=dx ...
#0 building with "default" instance using docker driver
```

Same base image, same recipe — only the builder differs.

## Fix

Probe `/usr/local/bin/podman` before falling back to docker. Line 19 of the Justfile is the only place in the repo hardcoding these paths.

## Verification

Exercised every branch against a sandboxed path tree with `just --evaluate`:

| Scenario | Resolves to | `PULL_POLICY` |
|---|---|---|
| podman in `/usr/bin` (old runner) | `/usr/bin/podman` | `newer` |
| podman in `/usr/local/bin` (new runner) | `/usr/local/bin/podman` | `newer` |
| docker only | `docker` | `missing` |
| nothing installed | `exit 1 ; ` | — |
| `PODMAN=/custom/podman` | `/custom/podman` | — |

Only the second row changes behavior; everything else is byte-identical to before. `just check` and `pre-commit` pass.

## Notes

Not adopting [aurora](https://github.com/ublue-os/aurora)'s buildah + BTRFS-loopback pipeline here — that repo is green on the same 257-layer F44 base, but its approach changes storage, caching and build semantics. Bluefin's existing podman build handles the base fine once it's actually found.

Follow-ups worth considering separately (all pre-existing):
- The docker fallback is now a silent downgrade to a builder that **cannot** build these images. It should probably warn or fail loudly rather than degrade into a cryptic `max depth exceeded` an hour later.
- `PULL_POLICY := if PODMAN =~ "docker"` is a substring test; a path like `/opt/docker-tools/podman` would be misclassified.

Assisted-by: Claude Opus 5 via GitHub Copilot CLI