### PR TITLE
ci: move image builds to ubuntu-26.04

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -31,7 +31,7 @@ permissions: {}
 jobs:
   build_container:
     name: image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
One line: `runs-on: ubuntu-24.04` → `ubuntu-26.04` in `reusable-build.yml`.

## Why

The `ubuntu-24.04` runner image (`20260804.265`) stopped installing podman from apt and now ships it as a static bundle in `/usr/local/bin`. The Justfile only probes `/usr/bin/podman`, so builds silently fell back to `docker`, whose overlay2 driver caps stacked lower dirs at 128. `silverblue-main:44` has **259** layers, so every Latest build died at the `FROM` line with `max depth exceeded`.

Ubuntu 26.04 installs podman from apt, so it lands back at `/usr/bin/podman`:

```bash
if is_ubuntu26; then
    # apt already provides a current podman on 26.04
    apt-get install podman buildah skopeo
```

## Dependency check

Everything `reusable-build.yml` relies on is present on `ubuntu26/20260804.94`:

| | 24.04 | 26.04 |
|---|---|---|
| Podman | 5.8.4 (`/usr/local/bin`) | **5.7.0 (`/usr/bin`)** |
| Homebrew | 6.0.15, `/home/linuxbrew` | 6.0.15, `/home/linuxbrew` |
| Buildah | 1.33.7 | 1.42.1 |
| Skopeo | 1.13.3 | 1.21.0-dev |
| jq | 1.7.1 | 1.8.1 |
| yq | 4.53.3 | 4.53.3 |

The hardcoded `/home/linuxbrew/.linuxbrew/bin/brew` path used by the `Install Just` step is unchanged on 26.04.

## Note

`ubuntu-26.04` is currently [public preview](https://github.com/actions/runner-images/issues/14226).

Assisted-by: Claude Opus 5 via GitHub Copilot CLI