### PR TITLE
fix(build): actually pin the base image by digest and unblock Renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -8,8 +8,10 @@
     "enabled": true
   },
 
-  // Do not rebase when the default branch is updated
-  "rebaseWhen": "never",
+  // Renovate cannot touch a branch that has been manually edited, which
+  // silently stalls the dependency for months. Keep its own branches current
+  // instead of hand-merging main into them.
+  "rebaseWhen": "behind-base-branch",
     customManagers: [
     {
       customType: 'regex',

--- a/Containerfile
+++ b/Containerfile
@@ -2,6 +2,7 @@ ARG BASE_IMAGE_NAME="silverblue"
 ARG FEDORA_MAJOR_VERSION="42"
 ARG SOURCE_IMAGE="${BASE_IMAGE_NAME}-main"
 ARG BASE_IMAGE="ghcr.io/ublue-os/${SOURCE_IMAGE}"
+ARG BASE_IMAGE_SHA=""
 ARG COMMON_IMAGE="ghcr.io/projectbluefin/common:latest"
 ARG COMMON_IMAGE_SHA=""
 ARG BREW_IMAGE="ghcr.io/ublue-os/brew:latest"
@@ -19,7 +20,7 @@ COPY --from=brew /system_files /system_files/shared
 COPY /system_files /system_files
 
 ## bluefin image section
-FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS base
+FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}@${BASE_IMAGE_SHA} AS base
 
 ARG AKMODS_FLAVOR="coreos-stable"
 ARG BASE_IMAGE_NAME="silverblue"

--- a/Justfile
+++ b/Justfile
@@ -135,8 +135,18 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     fi
     fedora_version=$({{ just }} fedora_version '{{ image }}' '{{ tag }}' '{{ flavor }}' '{{ kernel_pin }}')
 
-    # Verify Base Image with cosign
-    {{ just }} verify-container "${base_image_name}-main:${fedora_version}"
+    # Base image digest pin, keyed by the resolved Fedora version so the pinned
+    # digest can never disagree with the version everything else is built for.
+    base_image_entry="${base_image_name}-main-${fedora_version}"
+    base_image_sha=$(yq -r ".images[] | select(.name == \"${base_image_entry}\") | .digest" image-versions.yml)
+    if [[ -z "${base_image_sha}" || "${base_image_sha}" == "null" ]]; then
+        echo "No digest pinned for ${base_image_entry} in image-versions.yml." >&2
+        echo "Add an entry for Fedora ${fedora_version} before building." >&2
+        exit 1
+    fi
+
+    # Verify Base Image with cosign, pinned by digest
+    {{ just }} verify-container "${base_image_name}-main:${fedora_version}@${base_image_sha}"
 
     # Kernel Release/Pin
     if [[ -z "${kernel_pin:-}" ]]; then
@@ -184,6 +194,7 @@ build $image="bluefin" $tag="latest" $flavor="main" rechunk="0" ghcr="0" pipelin
     fi
     BUILD_ARGS+=("--build-arg" "AKMODS_FLAVOR=${akmods_flavor}")
     BUILD_ARGS+=("--build-arg" "BASE_IMAGE_NAME=${base_image_name}")
+    BUILD_ARGS+=("--build-arg" "BASE_IMAGE_SHA=${base_image_sha}")
     BUILD_ARGS+=("--build-arg" "COMMON_IMAGE={{ common_image }}")
     BUILD_ARGS+=("--build-arg" "COMMON_IMAGE_SHA=${common_image_sha}")
     BUILD_ARGS+=("--build-arg" "BREW_IMAGE={{ brew_image }}")

--- a/image-versions.yml
+++ b/image-versions.yml
@@ -1,8 +1,16 @@
 images:
-  - name: silverblue-main
+  # The base image is pinned per Fedora major version because `just build`
+  # resolves the version dynamically and the stable/latest streams do not always
+  # sit on different releases. The entry name must be
+  # `silverblue-main-${fedora_version}`; add a new one at each Fedora rollover.
+  - name: silverblue-main-43
     image: ghcr.io/ublue-os/silverblue-main
-    tag: latest
-    digest: sha256:30f04a978ca4fae65b178bcd1d1f5ee5c70a26f1a47f7c9fbaa255203b7757ab
+    tag: "43"
+    digest: sha256:5111c949b19454da98cf4f0afb1f241331e0bf0373b590c82653c83d8464e510
+  - name: silverblue-main-44
+    image: ghcr.io/ublue-os/silverblue-main
+    tag: "44"
+    digest: sha256:1f05de28fc4ce8b004e524b1b5e1e0ce5f828b696c07a352bdb6d776b9242903
   - name: common
     image: ghcr.io/projectbluefin/common
     tag: latest
@@ -10,4 +18,4 @@ images:
   - name: brew
     image: ghcr.io/ublue-os/brew
     tag: latest
-    digest: sha256:c6f6775db732b58bf02e27ca89b4390c3b72db27aedcea62d15c09960be7a0cb
+    digest: sha256:8855464e5c150974c5edf4343ffef50ca37b1c4d96a648dce28927033010a372


### PR DESCRIPTION
## Why

`image-versions.yml` had a `silverblue-main` digest that **nothing consumed**:

- `Justfile` only read the `common` and `brew` digests via `yq`.
- `Containerfile` built `FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION}` - a floating tag.

So the base image was never actually pinned, and every Renovate bump of that field for months was a no-op. Bumping the value alone would not have changed a single byte of the built image.

Separately, Renovate had not opened a base image PR in a month. #4832 and #4878 were sitting in **"PR Edited (Blocked)"** on dependency dashboard #2680, because `main` had been hand-merged into their `renovate/*` branches three times. Renovate will not update *or* replace a branch it no longer owns, and the config had `rebaseWhen: "never"`, which makes hand-merging the only way to freshen a stale branch. The PRs looked green and mergeable the whole time.

## What

- Wire `BASE_IMAGE_SHA` through `just build` into the `FROM`, so the pin is real and cosign verifies the exact digest being built.
- Bump the base digest to current `latest`, and bump `brew`.
- `rebaseWhen: "never"` -> `"behind-base-branch"` so Renovate maintains its own branches.

Pins are keyed by **Fedora major version**, not by tag stream. `quay.io/fedora/fedora-coreos:stable` currently reports 44, the same as `latest` - so keying on the stream would have pulled an F43 base into a build whose akmods and kernel resolved for F44. Keying on the version `just build` already resolved makes that mismatch structurally impossible.

At a Fedora rollover the lookup fails loudly with `No digest pinned for silverblue-main-45 ... Add an entry for Fedora 45 before building.` rather than silently falling back.

## Scope

Trimmed after review. Dropped from an earlier revision, as unrelated to the fix: an `AGENTS.md` documentation section, a corrected action version comment, a Renovate rule disabling `ublue-os/remove-unwanted-software`, an explicit `image-versions.yml` custom manager, and the stale `FEDORA_MAJOR_VERSION` ARG defaults.

The custom manager in particular was verified unnecessary: aurora has no such manager yet its dashboard still detects `image-versions.yml`, and Renovate already produced #4832/#4878 from this file. Adding one risked duplicate detection.

Net: **31 insertions, 9 deletions across 4 files.**

## Note for the reviewer

The existing `automerge: true` digest rule for `ghcr.io/ublue-os/silverblue-main` is unchanged, but it is now **load-bearing** rather than cosmetic: base image digest bumps will auto-merge and will now genuinely change the built image. Left as-is deliberately - flagging in case you want that revisited.

## Aurora

Aurora has the identical latent bug: its `kinoite` digest in `image-versions.yml` is dead data, and `Containerfile.in` uses the floating tag. It likely wants the same fix.

## Verification

- `just check`, `renovate-config-validator --strict`, and `pre-commit` on the changed files all pass. (`.devcontainer.json` and `.github/ISSUE_TEMPLATE/config.yml` fail pre-commit on `main` already.)
- Cosign-verified all three digests.
- Simulated the lookup for F43, F44 and F45.

The two red `generate-release` checks are pre-existing repo-wide and are **not** required by the `main` ruleset; unrelated PR #4884 fails on the identical digest. Root cause is fixed separately in #4887.

Assisted-by: Claude Opus 5 via GitHub Copilot CLI