### PR TITLE
fix(ci): push twice so every tag shares the signed digest

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -238,11 +238,10 @@ jobs:
             digest_file="$PWD/.push-digest"
             for tag in ${{ steps.generate-tags.outputs.alias_tags }}; do
               dest=${{ steps.registry_case.outputs.lowercase }}/${{ env.IMAGE_NAME }}:${tag}
-              if [[ "${tag}" == "${{ env.DEFAULT_TAG }}" ]]; then
-                sudo -E podman push --digestfile "${digest_file}" ${{ env.IMAGE_NAME }}:${tag} "${dest}"
-              else
-                sudo -E podman push ${{ env.IMAGE_NAME }}:${tag} "${dest}"
-              fi
+              sudo -E podman push --digestfile "${digest_file}" ${{ env.IMAGE_NAME }}:${tag} "${dest}"
+              # We need to push twice to workaround https://github.com/containers/podman/issues/27796
+              # If we don't do this then the digest changes and we are only signing this specific tag
+              sudo -E podman push --digestfile "${digest_file}" ${{ env.IMAGE_NAME }}:${tag} "${dest}"
             done
 
             digest="$(cat "${digest_file}")"


### PR DESCRIPTION
## The bug

Every tag we publish except the default one is **unsigned and has no SBOM or attestation**.

The `Push to GHCR` step pushed each tag once. Per [containers/podman#27796](https://github.com/containers/podman/issues/27796), podman does not push layer annotations on the first push unless the layers are already present in the registry. Our images are rechunked and carry `ostree.components` layer annotations, so the first push of a given set of layers produces a *different* manifest digest than every push after it.

The result: each tag got its own digest, and only the default tag's digest was captured into `steps.push.outputs.digest`. The cosign signature, the `oras attach` SBOM and the attestation were all applied to that single digest.

Observed on today's images:

| ref | digest | SBOM |
|---|---|---|
| `bluefin:latest` | `ef750caa` | yes |
| `bluefin:latest-20260807` | `ffaf4f31` | **no** |

The dated tags are the ones users pin to with `bootc switch` and the ones our changelog tells people to rebase onto. Those are exactly the tags that were going out unsigned.

It also explains the `No SBOM referrer found` failures in `Generate Release`, since `changelogs.py` resolves the dated tag.

## The fix

Push each tag twice. The second push sees the layers already present, includes the annotations, and yields the stable digest, so all tags converge on the same manifest that gets signed and attested.

This is the same workaround already running in production in `ublue-os/aurora`, including the comment wording:

```bash
${PUSH_CMD} ${image_name}:${tag} ${registry}/${image_name}:${tag}
# We need to push twice to workaround https://github.com/containers/podman/issues/27796
${PUSH_CMD} ${image_name}:${tag} ${registry}/${image_name}:${tag}
```
<sup>[aurora Justfile, `push-image`](https://github.com/ublue-os/aurora/blob/main/Justfile)</sup>

Since every tag now resolves to the same digest, the `DEFAULT_TAG` special case is no longer needed and the branch collapses away. Net change is one line.

## Notes

- Already-published tags stay broken; this fixes images published from here on.
- An earlier revision of this PR pushed once and used `skopeo copy` to retag by digest, and also made `changelogs.py` tolerate missing SBOMs. Both were dropped in favour of matching aurora: the skopeo path relied on `skopeo` being present and on `~/.docker/config.json` being readable by the non-root user while the push runs under `sudo`, neither of which was verified, and aurora's `changelogs.py` is byte-identical to ours, so changing it here would have created divergence for no benefit once the digests are correct.
- Found while investigating why #4832 never merged; its merge_group run failed on exactly these jobs.

Assisted-by: Claude Opus 5 via GitHub Copilot CLI