### PR TITLE
chore(release): unpin stable kernel now that akmods supports 7.1

### DIFF
--- a/.github/workflows/build-image-stable.yml
+++ b/.github/workflows/build-image-stable.yml
@@ -31,7 +31,8 @@ jobs:
       matrix:
         brand_name: ["bluefin"]
     with:
-      kernel_pin: 7.0.12-201.fc44.x86_64
+      # Pin stable to a kernel if needed, like for ZFS compatibility
+      # kernel_pin: 7.0.12-201.fc44.x86_64
       brand_name: ${{ matrix.brand_name }}
       stream_name: stable
 


### PR DESCRIPTION
## Why

#4867 **temporarily pinned** Stable to `7.0.12-201.fc44.x86_64` until akmods catches up. **akmods has now caught up** in ublue-os/akmods#566, and `akmods-zfs:coreos-stable-44` now publishes for 7.1. Aurora dropped its pin in ublue-os/aurora#2706.

Fedora CoreOS stable moved to 7.1 on 2026-07-20, so the pin currently holds Bluefin Stable a minor release behind its own base, kernel CVE fixes included.

## What

One line in `build-image-stable.yml`. With **`kernel_pin` unset**, `just build` resolves the kernel from the `ostree.linux` label on `akmods:coreos-stable-<fedora_version>` -- the path every other stream already takes.

| | pinned | unpinned |
|---|---|---|
| kernel | `7.0.12-201.fc44.x86_64` | `7.1.4-200.fc44.x86_64` |
| `just fedora_version` | 44 | 44 |
| `image-versions.yml` entry | `silverblue-main-44` | `silverblue-main-44` |

The Fedora version is identical either way, so `image-versions.yml` needs no change -- the pin's `fc44` and what `fedora-coreos:stable` resolves to already agree. `akmods`, `akmods-zfs` and `akmods-nvidia-open` all exist and cosign-verify for `7.1.4-200.fc44.x86_64`.

## Local Testing

| | result |
|---|---|
| `just build bluefin stable main` | exit 0 |
| `just build bluefin-dx stable main` | exit 0 |
| `just build bluefin-dx stable nvidia-open` | exit 0 |
| `zfs.ko` vermagic vs shipped kernel | match |
| `just secureboot` on the built image | verifies against both ublue certs |
| VM boot (bootc-image-builder + qemu) | boots, ZFS auto-loads at t=2.78s, no failed units |
| Laptop boot (`bootc switch`, HP 15-fd0xxx) | boots, wifi + bluetooth + ZFS up, no kernel errors |
| Suspend/resume on the same laptop | works |

```
# on the laptop, running bluefin-dx:stable from this branch
uname -r     7.1.4-200.fc44.x86_64
zfs version  zfs-kmod-2.4.3-1
```

**Not covered**: NVIDIA on real hardware (build and vermagic only), external display.

Assisted-by: Claude Opus 5 via Claude Code