### PR TITLE
fix(gnome): Add missing library for Blur My Shell

### DIFF
--- a/build_files/base/04-packages.sh
+++ b/build_files/base/04-packages.sh
@@ -126,6 +126,7 @@ copr_install_isolated "che/nerd-fonts" "nerd-fonts"
 
 # From ublue-os/packages
 copr_install_isolated "ublue-os/packages" "uupd"
+copr_install_isolated "ublue-os/packages" "gnome-rounded-blur"
 
 # Version-specific COPR packages
 # case "$FEDORA_MAJOR_VERSION" in


### PR DESCRIPTION
Blur My Shell added blur to the gnome-shell pop-ups (quick settings, calendar...) To Blur around the corners, it currently uses a C library called gnome-rounded-blur

This package is working for Gnome 50 and includes a patch Gnome 51 Beta (Fedora 45)
<!--

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://docs.projectbluefin.io/contributing) before submitting a pull request.

-->
