### PR TITLE
feat: replace Docker Model Runner with llmman

### DIFF
--- a/build_files/dx/00-dx.sh
+++ b/build_files/dx/00-dx.sh
@@ -83,8 +83,7 @@ dnf -y install --enablerepo=docker-ce-stable \
     docker-buildx-plugin \
     docker-ce \
     docker-ce-cli \
-    docker-compose-plugin \
-    docker-model-plugin
+    docker-compose-plugin
 
 tee /etc/yum.repos.d/vscode.repo <<'EOF'
 [code]

--- a/system_files/shared/etc/profile.d/91-bluefin-aliases.sh
+++ b/system_files/shared/etc/profile.d/91-bluefin-aliases.sh
@@ -3,3 +3,7 @@
 if command -v ramalama &>/dev/null; then
     alias rl='ramalama'
 fi
+# llmman shorthand - https://github.com/llmmanorg/llmman
+if command -v llmman &>/dev/null; then
+    alias lm='llmman'
+fi


### PR DESCRIPTION
## What does this change?

- Removes `docker-model-plugin` from the DX Docker package set in `build_files/dx/00-dx.sh`.
- Adds an `lm` alias for [llmman](https://github.com/llmmanorg/llmman) in `91-bluefin-aliases.sh`, alongside the existing `rl` alias for ramalama.

## Why?

llmman covers the same local model runner use case as Docker Model Runner: it pulls models from Hugging Face or any OCI registry (Docker Hub, GHCR, quay), serves them with upstream `llama.cpp`/`vllm`, and launches coding agents (Claude Code, Codex, OpenCode, ...) against local or hosted models. It is installed via Homebrew from the shared `ai-tools.Brewfile` (`ujust bbrew` -> `ai`), so the Docker plugin is no longer needed in the image.

Related PRs:
- projectbluefin/common: adds llmman to `ai-tools.Brewfile`
- ublue-os/aurora, ublue-os/bluefin-lts: same `docker-model-plugin` removal
- ublue-os/aurora-docs: documents llmman